### PR TITLE
chore: dynamically import AI SDKs in API routes

### DIFF
--- a/pages/api/ai/test-drive.ts
+++ b/pages/api/ai/test-drive.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 
 type Ok = { ok: true; answer: string };
 type Err = { ok: false; error: string };
@@ -40,6 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const key = process.env.GEMINI_API_KEY;
     if (!key) return res.status(500).json({ ok: false, error: 'Gemini key missing on server.' });
 
+    const { GoogleGenerativeAI } = await import('@google/generative-ai');
     const genAI = new GoogleGenerativeAI(key);
     const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 

--- a/pages/api/speaking/partner/summary.ts
+++ b/pages/api/speaking/partner/summary.ts
@@ -1,7 +1,6 @@
 // pages/api/speaking/partner/summary.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
-import Groq from 'groq-sdk';
 
 export const config = { api: { bodyParser: true, sizeLimit: '1mb' } };
 
@@ -75,6 +74,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const wc = transcript.split(/\s+/).filter(Boolean).length;
 
     // Call Groq (OpenAI-compatible)
+    const Groq = (await import('groq-sdk')).default;
     const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
     const model = process.env.GROQ_MODEL || 'llama-3.1-8b-instant';
 

--- a/pages/api/speaking/score-audio-groq.ts
+++ b/pages/api/speaking/score-audio-groq.ts
@@ -1,6 +1,5 @@
 // pages/api/speaking/score-audio-groq.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import Groq from 'groq-sdk';
 import { z } from 'zod';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -10,7 +9,6 @@ export const config = {
   api: { bodyParser: { sizeLimit: '25mb' } }, // plenty for short speaking parts
 };
 
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
 
 const ScoreSchema = z.object({
   fluency: z.number().min(0).max(9),
@@ -37,6 +35,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!parsed.success) return res.status(400).json({ error: 'Bad request', issues: parsed.error.issues });
 
     const { audioBase64, mime, part, promptHint } = parsed.data;
+
+    const Groq = (await import('groq-sdk')).default;
+    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
 
     // 1) write temp file (Groq SDK accepts file streams)
     const buf = Buffer.from(audioBase64, 'base64');

--- a/pages/api/speaking/score-groq.ts
+++ b/pages/api/speaking/score-groq.ts
@@ -1,9 +1,6 @@
 // pages/api/speaking/score-groq.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import Groq from 'groq-sdk';
 import { z } from 'zod';
-
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
 
 const OutputSchema = z.object({
   fluency: z.number().min(0).max(9),
@@ -50,6 +47,8 @@ Rules
 `;
 
   try {
+    const Groq = (await import('groq-sdk')).default;
+    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
     const completion = await groq.chat.completions.create({
       // Good free-tier model; you can switch to 8B if you hit limits
       model: 'llama-3.1-70b-versatile',

--- a/pages/api/speaking/score.ts
+++ b/pages/api/speaking/score.ts
@@ -2,7 +2,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
-import OpenAI from 'openai';
 
 type Breakdown = { fluency: number; lexical: number; grammar: number; pronunciation: number };
 
@@ -52,6 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // ---- 2. Transcribe all audio with Whisper ----
+    const OpenAI = (await import('openai')).default;
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
     let fullTranscript = '';
 

--- a/pages/api/writing/reevaluate.ts
+++ b/pages/api/writing/reevaluate.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 import { z } from 'zod';
 
 const BodySchema = z.object({
@@ -78,6 +77,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // 4) Call Gemini
   try {
+    const { GoogleGenerativeAI } = await import('@google/generative-ai');
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY as string);
     const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro' }); // or 'gemini-1.5-flash' for cheaper/faster
 


### PR DESCRIPTION
## Summary
- lazy load GoogleGenerativeAI in writing and AI test-drive endpoints
- load OpenAI client at runtime in speaking score API
- lazy load Groq SDK in speaking summary and scoring endpoints to keep bundles slim

## Testing
- `npx vercel build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*
- `TSC_COMPILE_ON_ERROR=true npm run build` *(fails: Type error in components/writing/ReevalHistory.tsx)*
- `npm run lint` *(no output, Next.js suggests adding ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a6835ce4e483218a96fc4177610d16