### PR TITLE
feat: centralize environment variables

### DIFF
--- a/components/design-system/AvatarUploader.tsx
+++ b/components/design-system/AvatarUploader.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useEffect, useRef, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import { Alert } from './Alert';
@@ -13,8 +14,8 @@ type Props = {
 };
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
 export const AvatarUploader: React.FC<Props> = ({

--- a/components/listening/ReviewScreen.tsx
+++ b/components/listening/ReviewScreen.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useEffect, useMemo, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import { Card } from '@/components/design-system/Card';
@@ -10,8 +11,8 @@ import { isCorrect } from '@/lib/answers';
 
 // Browser client (auth comes from the user's session)
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+  env.NEXT_PUBLIC_SUPABASE_URL as string,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
 );
 
 type Row = {

--- a/components/sections/Learning/CourseCatalog.tsx
+++ b/components/sections/Learning/CourseCatalog.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { createClient } from '@supabase/supabase-js';
@@ -8,8 +9,8 @@ import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
 type Course = {

--- a/doc/env.md
+++ b/doc/env.md
@@ -1,0 +1,23 @@
+# Environment Variables
+
+The application relies on the following environment variables. Provide these values in your `.env` files or in your Vercel project settings.
+
+| Key | Description |
+| --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | URL of the Supabase instance. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key for Supabase. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for server-side tasks. |
+| `NEXT_PUBLIC_BASE_URL` | Base URL for building absolute links. |
+| `ADMIN_EMAILS` | Comma separated list of admin emails. |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Google Generative AI API key. |
+| `GROQ_API_KEY` | Groq API key. |
+| `GROQ_MODEL` | Groq model identifier. |
+| `OPENAI_API_KEY` | OpenAI API key. |
+| `GEMINI_API_KEY` | Gemini API key. |
+| `PREMIUM_MASTER_PIN` | Master PIN for premium feature access. |
+| `SPEAKING_DAILY_LIMIT` | Daily limit for speaking attempts. |
+| `SPEAKING_BUCKET` | Storage bucket name for speaking uploads. |
+| `NEXT_PUBLIC_DEBUG` | Enables debug features when set. |
+
+These variables are validated at runtime in [`lib/env.ts`](../lib/env.ts).
+

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,6 +1,7 @@
+import { env } from "@/lib/env";
 // lib/admin.ts
 export function getAdminEmails(): string[] {
-  const raw = process.env.ADMIN_EMAILS || '';
+  const raw = env.ADMIN_EMAILS || '';
   return raw
     .split(/[,\s]+/)
     .map((e) => e.trim().toLowerCase())

--- a/lib/ai/evaluate.ts
+++ b/lib/ai/evaluate.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { BandFeedback } from "./schema";
 // MOCK evaluator (works offline). Replace with real calls later.
 export async function evaluateSpeakingMock(transcript: string): Promise<BandFeedback> {
@@ -13,6 +14,6 @@ export async function evaluateSpeakingMock(transcript: string): Promise<BandFeed
   return { band, criteria, summary: "Good overall performance. Improve collocations and consistency in tense usage for a higher band." };
 }
 // Provider placeholders (wire later)
-export async function evaluateWithOpenAI(prompt: string): Promise<BandFeedback> { if (!process.env.OPENAI_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }
-export async function evaluateWithGemini(prompt: string): Promise<BandFeedback> { if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }
-export async function evaluateWithGrok(prompt: string): Promise<BandFeedback> { if (!process.env.GROQ_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }
+export async function evaluateWithOpenAI(prompt: string): Promise<BandFeedback> { if (!env.OPENAI_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }
+export async function evaluateWithGemini(prompt: string): Promise<BandFeedback> { if (!env.GOOGLE_GENERATIVE_AI_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }
+export async function evaluateWithGrok(prompt: string): Promise<BandFeedback> { if (!env.GROQ_API_KEY) return evaluateSpeakingMock(prompt); return evaluateSpeakingMock(prompt); }

--- a/lib/ai/evaluateSpeaking.ts
+++ b/lib/ai/evaluateSpeaking.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // /lib/ai/evaluateSpeaking.ts
 import Groq from 'groq-sdk';
 
@@ -34,7 +35,7 @@ ${SYSTEM_JSON_SPEC}
 }
 
 // ---------- Gemini path ----------
-export async function evaluateWithGemini(input: EvalInputs, apiKey = process.env.GEMINI_API_KEY): Promise<Feedback | null> {
+export async function evaluateWithGemini(input: EvalInputs, apiKey = env.GEMINI_API_KEY): Promise<Feedback | null> {
   if (!apiKey) return null;
   // lightweight fetch to avoid adding SDK if you prefer
   const prompt = buildPrompt(input);
@@ -56,7 +57,7 @@ export async function evaluateWithGemini(input: EvalInputs, apiKey = process.env
 }
 
 // ---------- Groq LLM path (e.g., Llama 3.1 70B) ----------
-export async function evaluateWithGroq(input: EvalInputs, apiKey = process.env.GROQ_API_KEY): Promise<Feedback | null> {
+export async function evaluateWithGroq(input: EvalInputs, apiKey = env.GROQ_API_KEY): Promise<Feedback | null> {
   if (!apiKey) return null;
   const groq = new Groq({ apiKey });
   const prompt = buildPrompt(input);
@@ -81,7 +82,7 @@ export async function evaluateWithGroq(input: EvalInputs, apiKey = process.env.G
 }
 
 // ---------- Groq Whisper transcription ----------
-export async function transcribeWithGroq(audioBytes: Buffer, filename = 'audio.webm', apiKey = process.env.GROQ_API_KEY): Promise<string | null> {
+export async function transcribeWithGroq(audioBytes: Buffer, filename = 'audio.webm', apiKey = env.GROQ_API_KEY): Promise<string | null> {
   if (!apiKey) return null;
   const groq = new Groq({ apiKey });
   // The Groq SDK expects a File (Web API). In Node 18+, File exists globally.

--- a/lib/apiAuth.ts
+++ b/lib/apiAuth.ts
@@ -1,9 +1,10 @@
+import { env } from "@/lib/env";
 // lib/apiAuth.ts
 import type { NextApiRequest } from 'next';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 export function supabaseFromRequest(req: NextApiRequest): SupabaseClient {
   const auth = typeof req.headers.authorization === 'string' ? req.headers.authorization : '';

--- a/lib/authServer.ts
+++ b/lib/authServer.ts
@@ -1,10 +1,11 @@
+import { env } from "@/lib/env";
 // lib/authServer.ts
 import type { NextApiRequest } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SERVICE = env.SUPABASE_SERVICE_ROLE_KEY || '';
 
 function b64urlToJson(b64: string) {
   const pad = (s:string) => s + '=' * ((4 - (s.length % 4)) % 4);

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
+  ADMIN_EMAILS: z.string().optional(),
+  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
+  GROQ_API_KEY: z.string().optional(),
+  GROQ_MODEL: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  GEMINI_API_KEY: z.string().optional(),
+  PREMIUM_MASTER_PIN: z.string().optional(),
+  SPEAKING_DAILY_LIMIT: z.coerce.number().optional(),
+  SPEAKING_BUCKET: z.string().optional(),
+  NEXT_PUBLIC_DEBUG: z.string().optional(),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+});
+
+export const env = envSchema.parse(process.env);
+

--- a/lib/reading/supabaseAdapters.ts
+++ b/lib/reading/supabaseAdapters.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 /**
  * Supabase adapters for Reading.
  * No schema changes required. Adjust table/column names in the mappers to match your existing DB.
@@ -10,8 +11,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 // Prefer service role for secure SSR inserts; fall back to anon for public reads.
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey  = env.SUPABASE_SERVICE_ROLE_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 export const supabaseServer = createClient(supabaseUrl, serviceKey);
 
 /** Shapes used by the Reading runner */

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,9 +1,10 @@
+import { env } from "@/lib/env";
 // lib/supabaseAdmin.ts
 import { createClient } from '@supabase/supabase-js';
 // import type { Database } from '@/types/supabase'; // optional generated types
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!url) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
 if (!serviceRoleKey) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY');
@@ -14,7 +15,7 @@ export const supabaseAdmin =
     auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
   });
 
-if (process.env.NODE_ENV !== 'production') {
+if (env.NODE_ENV !== 'production') {
   // @ts-ignore
   globalThis.__supabaseAdmin = supabaseAdmin;
 }

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,9 +1,10 @@
+import { env } from "@/lib/env";
 // lib/supabaseBrowser.ts
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 
-const url  = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const url  = env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 // Browser-side client (persists session)
 export const supabaseBrowser = createClient<Database>(url, anon, {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,8 +1,9 @@
+import { env } from "@/lib/env";
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 // Singleton client (safe for SSR/ISR selects on public tables)
 export const supabase = createClient<Database>(url, anon, {

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,8 +1,9 @@
+import { env } from "@/lib/env";
 import { createClient } from '@supabase/supabase-js';
 
 export function supabaseAdmin() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  if (!env.NEXT_PUBLIC_SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error('Supabase env is missing');
   }
-  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 }

--- a/lib/supabaseService.ts
+++ b/lib/supabaseService.ts
@@ -1,15 +1,16 @@
+import { env } from "@/lib/env";
 // lib/supabaseService.ts
 import { createClient } from '@supabase/supabase-js';
 
 export const supabaseService = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.SUPABASE_SERVICE_ROLE_KEY as string
+  env.NEXT_PUBLIC_SUPABASE_URL as string,
+  env.SUPABASE_SERVICE_ROLE_KEY as string
 );
 
 // Comma-separated admin emails
 export function isAdminEmail(email?: string | null) {
   if (!email) return false;
-  const raw = process.env.ADMIN_EMAILS || '';
+  const raw = env.ADMIN_EMAILS || '';
   const list = raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
   return list.includes(email.toLowerCase());
 }

--- a/pages/api/admin/premium/clear-pin.ts
+++ b/pages/api/admin/premium/clear-pin.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/admin/premium/clear-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -16,8 +17,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   if (!token) return res.status(401).json({ error: 'Unauthorized' });
 
   const supabaseCaller = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
     { global: { headers: { Authorization: `Bearer ${token}` } } }
   );
   const { data: userData } = await supabaseCaller.auth.getUser();

--- a/pages/api/admin/premium/set-pin.ts
+++ b/pages/api/admin/premium/set-pin.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/admin/premium/set-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -19,8 +20,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     // Get caller’s email from anon client (only to identify who is calling)
     const supabaseCaller = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+      env.NEXT_PUBLIC_SUPABASE_URL as string,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
       { global: { headers: { Authorization: `Bearer ${token}` } } }
     );
     const { data: userData, error: userErr } = await supabaseCaller.auth.getUser();

--- a/pages/api/admin/set-pin.ts
+++ b/pages/api/admin/set-pin.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/admin/set-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -11,8 +12,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   // 1) Verify requester is logged-in admin (from cookies)
   const supabaseSSR = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
     { cookies: { get: (k) => req.cookies[k], set: () => {}, remove: () => {} } }
   );
 
@@ -31,8 +32,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   // 3) Call admin RPC with service_role (server only)
   const svc = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.SUPABASE_SERVICE_ROLE_KEY as string
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.SUPABASE_SERVICE_ROLE_KEY as string
   );
 
   const { data, error } = await svc.rpc('admin_set_premium_pin', { user_email: email, new_pin: String(newPin) });

--- a/pages/api/ai/profile-suggest.ts
+++ b/pages/api/ai/profile-suggest.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/ai/profile-suggest.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -62,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'english_level is required' });
   }
 
-  const key = process.env.OPENAI_API_KEY;
+  const key = env.OPENAI_API_KEY;
   if (!key) {
     return res.status(200).json(localHeuristic(payload));
   }

--- a/pages/api/ai/test-drive.ts
+++ b/pages/api/ai/test-drive.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
@@ -37,7 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   if (question.length > 200) return res.status(400).json({ ok: false, error: 'Keep it under 200 characters.' });
 
   try {
-    const key = process.env.GEMINI_API_KEY;
+    const key = env.GEMINI_API_KEY;
     if (!key) return res.status(500).json({ ok: false, error: 'Gemini key missing on server.' });
 
     const genAI = new GoogleGenerativeAI(key);

--- a/pages/api/placement/score.ts
+++ b/pages/api/placement/score.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/placement/score.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -97,10 +98,10 @@ function localHeuristic(payload: ClientPayload): ScoreResult {
 
 // ---------- GROQ scorer (preferred if key exists) ----------
 async function callGroq(payload: ClientPayload): Promise<ScoreResult | null> {
-  const key = process.env.GROQ_API_KEY;
+  const key = env.GROQ_API_KEY;
   if (!key) return null;
 
-  const model = process.env.GROQ_MODEL || 'llama-3.1-70b-versatile';
+  const model = env.GROQ_MODEL || 'llama-3.1-70b-versatile';
   const userData = JSON.stringify(
     payload.answers.map(a => ({
       id: a.id,
@@ -173,7 +174,7 @@ Respond ONLY as compact JSON with this exact shape:
 
 // ---------- Gemini scorer (fallback if GROQ not present) ----------
 async function callGemini(payload: ClientPayload): Promise<ScoreResult | null> {
-  const key = process.env.GEMINI_API_KEY;
+  const key = env.GEMINI_API_KEY;
   if (!key) return null;
 
   const model = 'models/gemini-1.5-flash-latest:generateContent';

--- a/pages/api/premium/pin-status.ts
+++ b/pages/api/premium/pin-status.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/premium/pin-status.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -12,8 +13,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   if (!token) return res.status(401).json({ error: 'Unauthorized' });
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
     { global: { headers: { Authorization: `Bearer ${token}` } } }
   );
 

--- a/pages/api/premium/set-pin.ts
+++ b/pages/api/premium/set-pin.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/premium/set-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -20,8 +21,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   if (!/^\d{4,6}$/.test(String(newPin))) return res.status(400).json({ ok: false, reason: 'INVALID_NEW' });
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
     { global: { headers: { Authorization: `Bearer ${token}` } } }
   );
 

--- a/pages/api/premium/verify-pin.ts
+++ b/pages/api/premium/verify-pin.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/premium/verify-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -28,8 +29,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     }
 
     const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+      env.NEXT_PUBLIC_SUPABASE_URL as string,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
       { global: { headers: { Authorization: `Bearer ${token}` } } }
     );
 

--- a/pages/api/premium/verify.ts
+++ b/pages/api/premium/verify.ts
@@ -1,10 +1,11 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from "next";
 import bcrypt from "bcryptjs";
 import { createServerSupabaseClient } from "@supabase/auth-helpers-nextjs";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 
 // Optional master override via env, e.g. PREMIUM_MASTER_PIN=123456
-const MASTER_PIN = process.env.PREMIUM_MASTER_PIN || "";
+const MASTER_PIN = env.PREMIUM_MASTER_PIN || "";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });

--- a/pages/api/reading/explain.ts
+++ b/pages/api/reading/explain.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAttempt } from './reading/submit';
 
@@ -35,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       `Explain briefly (2–4 lines) why the correct answer is right. Focus on evidence from the passage; avoid revealing extra info not supported by it.`
     ].filter(Boolean).join('\n\n');
 
-    const apiKey = process.env.GEMINI_API_KEY;
+    const apiKey = env.GEMINI_API_KEY;
     if (!apiKey) return res.status(500).json({ error: 'GEMINI_API_KEY missing in env' });
 
     const r = await fetch(`${GEMINI_ENDPOINT}?key=${apiKey}`, {

--- a/pages/api/reading/submit.ts
+++ b/pages/api/reading/submit.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { scoreReading } from '@/lib/reading/scoring';
 import { v4 as uuid } from 'uuid';
@@ -11,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { slug, answers } = req.body as { slug: string; answers: Record<string, any> };
     if (!slug || !answers) return res.status(400).json({ error: 'Missing payload' });
 
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${req.headers.host}`;
+    const baseUrl = env.NEXT_PUBLIC_BASE_URL || `http://${req.headers.host}`;
     const paperRes = await fetch(`${baseUrl}/api/reading/test/${slug}`);
     const paper = await paperRes.json();
 

--- a/pages/api/speaking/evaluate.ts
+++ b/pages/api/speaking/evaluate.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getUserServer } from '@/lib/authServer';
 import { supabaseServer } from '@/lib/supabaseServer';
@@ -16,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     let feedback: string | null = null;
     try {
       // Gemini
-      const gemResp = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' + process.env.GEMINI_API_KEY, {
+      const gemResp = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' + env.GEMINI_API_KEY, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -35,7 +36,7 @@ Return band estimate and 2–3 lines of constructive feedback.` }] }]
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.GROQ_API_KEY}`
+          Authorization: `Bearer ${env.GROQ_API_KEY}`
         },
         body: JSON.stringify({
           model: 'llama3-8b-8192',

--- a/pages/api/speaking/file.ts
+++ b/pages/api/speaking/file.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/file.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -9,8 +10,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const filePath = req.query.path as string;
   if (!filePath) return res.status(400).json({ error: 'Missing path' });
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const supabase = createClient(url, anon, {
     global: { headers: { Cookie: req.headers.cookie || '' } },
   });

--- a/pages/api/speaking/limits/today.ts
+++ b/pages/api/speaking/limits/today.ts
@@ -1,6 +1,7 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getUserServer } from '@/lib/authServer';
-const DAILY_LIMIT = parseInt(process.env.SPEAKING_DAILY_LIMIT || '5', 10);
+const DAILY_LIMIT = parseInt(env.SPEAKING_DAILY_LIMIT || '5', 10);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { user, supabase } = await getUserServer(req, res);

--- a/pages/api/speaking/partner-summary.ts
+++ b/pages/api/speaking/partner-summary.ts
@@ -1,6 +1,7 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-const GROQ = process.env.GROQ_API_KEY;
+const GROQ = env.GROQ_API_KEY;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/speaking/partner.ts
+++ b/pages/api/speaking/partner.ts
@@ -1,9 +1,10 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/partner.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 type HistoryMsg = { role: 'bot' | 'assistant' | 'user'; text: string };
 
-const GROQ = process.env.GROQ_API_KEY;
+const GROQ = env.GROQ_API_KEY;
 
 // Utility: keep errors short (no HTML blobs)
 function nice(e: any) {

--- a/pages/api/speaking/partner/review/[attemptId].ts
+++ b/pages/api/speaking/partner/review/[attemptId].ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/partner/review/[attemptId].ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -14,9 +15,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'Invalid attemptId (must be UUID)' });
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
   const key =
-    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+    env.SUPABASE_SERVICE_ROLE_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const supabase = createClient(url, key, { auth: { persistSession: false } });
 
   // Fetch latest feedback and transcript for this attempt

--- a/pages/api/speaking/partner/summary.ts
+++ b/pages/api/speaking/partner/summary.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/partner/summary.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
@@ -75,8 +76,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const wc = transcript.split(/\s+/).filter(Boolean).length;
 
     // Call Groq (OpenAI-compatible)
-    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
-    const model = process.env.GROQ_MODEL || 'llama-3.1-8b-instant';
+    const groq = new Groq({ apiKey: env.GROQ_API_KEY });
+    const model = env.GROQ_MODEL || 'llama-3.1-8b-instant';
 
     const sys =
       'You are an IELTS Speaking examiner. Evaluate the USER transcript ONLY. ' +

--- a/pages/api/speaking/score-audio-groq.ts
+++ b/pages/api/speaking/score-audio-groq.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/score-audio-groq.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Groq from 'groq-sdk';
@@ -10,7 +11,7 @@ export const config = {
   api: { bodyParser: { sizeLimit: '25mb' } }, // plenty for short speaking parts
 };
 
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
+const groq = new Groq({ apiKey: env.GROQ_API_KEY });
 
 const ScoreSchema = z.object({
   fluency: z.number().min(0).max(9),
@@ -30,7 +31,7 @@ const ReqSchema = z.object({
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
-  if (!process.env.GROQ_API_KEY) return res.status(500).json({ error: 'GROQ_API_KEY missing' });
+  if (!env.GROQ_API_KEY) return res.status(500).json({ error: 'GROQ_API_KEY missing' });
 
   try {
     const parsed = ReqSchema.safeParse(req.body);

--- a/pages/api/speaking/score-groq.ts
+++ b/pages/api/speaking/score-groq.ts
@@ -1,9 +1,10 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/score-groq.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Groq from 'groq-sdk';
 import { z } from 'zod';
 
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
+const groq = new Groq({ apiKey: env.GROQ_API_KEY });
 
 const OutputSchema = z.object({
   fluency: z.number().min(0).max(9),

--- a/pages/api/speaking/score.ts
+++ b/pages/api/speaking/score.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/score.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
@@ -18,8 +19,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { attemptId } = req.body as { attemptId: string };
   if (!attemptId) return res.status(400).json({ error: 'Missing attemptId' });
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const supabase = createClient(url, anon, {
     global: { headers: { Cookie: req.headers.cookie || '' } },
   });
@@ -52,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // ---- 2. Transcribe all audio with Whisper ----
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+    const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
     let fullTranscript = '';
 
     for (const audioUrl of signedUrls) {

--- a/pages/api/speaking/signed-url.ts
+++ b/pages/api/speaking/signed-url.ts
@@ -1,10 +1,11 @@
+import { env } from "@/lib/env";
 // pages/api/speaking/signed-url.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!; // <-- add to env (server only)
+const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SERVICE = env.SUPABASE_SERVICE_ROLE_KEY; // <-- add to env (server only)
 
 // Server client for storage signing + DB auth checks
 const svc = createClient(URL, SERVICE, { auth: { persistSession: false } });

--- a/pages/api/speaking/upload.ts
+++ b/pages/api/speaking/upload.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import formidable, { File } from 'formidable';
 import fs from 'node:fs/promises';
@@ -17,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
   const supabase = supabaseFromRequest(req);
-  const bucket = process.env.SPEAKING_BUCKET || 'speaking';
+  const bucket = env.SPEAKING_BUCKET || 'speaking';
 
   try {
     const { fields, files } = await parseForm(req);

--- a/pages/api/strategies/toggle-save.ts
+++ b/pages/api/strategies/toggle-save.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
@@ -5,8 +6,8 @@ type Json =
   | { ok: true; saved: boolean }
   | { ok: false; error: string };
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const SUPABASE_URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 function getAccessToken(req: NextApiRequest) {
   const h = req.headers.authorization || '';

--- a/pages/api/strategies/vote.ts
+++ b/pages/api/strategies/vote.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
@@ -5,8 +6,8 @@ type Json =
   | { ok: true; helpful: boolean }
   | { ok: false; error: string };
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const SUPABASE_URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 function getAccessToken(req: NextApiRequest) {
   const h = req.headers.authorization || '';

--- a/pages/api/waitlist.ts
+++ b/pages/api/waitlist.ts
@@ -1,8 +1,9 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!; // keep secret
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY; // keep secret
 
 const supabase = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
 

--- a/pages/api/writing/reeval-history.ts
+++ b/pages/api/writing/reeval-history.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
@@ -6,8 +7,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!attemptId) return res.status(400).json({ error: 'attemptId required' });
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY ?? env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 
   const { data, error } = await supabase

--- a/pages/api/writing/reevaluate.ts
+++ b/pages/api/writing/reevaluate.ts
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { GoogleGenerativeAI } from '@google/generative-ai';
@@ -78,7 +79,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // 4) Call Gemini
   try {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY as string);
+    const genAI = new GoogleGenerativeAI(env.GEMINI_API_KEY as string);
     const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro' }); // or 'gemini-1.5-flash' for cheaper/faster
 
     const prompt = promptForGemini({

--- a/pages/learning/[slug].tsx
+++ b/pages/learning/[slug].tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/learning/[slug].tsx
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
@@ -11,8 +12,8 @@ import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
 type Course = {

--- a/pages/learning/skills/[skill].tsx
+++ b/pages/learning/skills/[skill].tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
@@ -10,8 +11,8 @@ import { Alert } from '@/components/design-system/Alert';
 import { StreakIndicator } from '@/components/design-system/StreakIndicator';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
 type CoachAI = {

--- a/pages/learning/strategies/[tipSlug].tsx
+++ b/pages/learning/strategies/[tipSlug].tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/learning/strategies/[tipSlug].tsx
 import Head from 'next/head';
 import type { GetServerSideProps } from 'next';
@@ -58,8 +59,8 @@ function normalizeDrill(payload: any): DrillResult {
 
 function getClient(): SupabaseClient {
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 }
 
@@ -72,7 +73,7 @@ export default function TipDetail({
 }) {
   const router = useRouter();
   const DEBUG =
-    process.env.NEXT_PUBLIC_DEBUG === '1' || (router.query.debug as string) === '1';
+    env.NEXT_PUBLIC_DEBUG === '1' || (router.query.debug as string) === '1';
 
   const [userId, setUserId] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -360,8 +361,8 @@ export default function TipDetail({
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 
   const slug = String(ctx.params?.tipSlug || '');

--- a/pages/learning/strategies/index.tsx
+++ b/pages/learning/strategies/index.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/learning/strategies/index.tsx
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
@@ -55,8 +56,8 @@ function normalizeDrill(payload: any): DrillResult {
 }
 
 function getSupabase(): SupabaseClient {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   return createClient(url, key);
 }
 

--- a/pages/profile-setup.tsx
+++ b/pages/profile-setup.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { createClient } from '@supabase/supabase-js';
@@ -11,8 +12,8 @@ import { Select } from '@/components/design-system/Select';
 
 /** Supabase browser client */
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
 const COUNTRIES = ['Pakistan','India','Bangladesh','United Arab Emirates','Saudi Arabia','United Kingdom','United States','Canada','Australia','New Zealand'];

--- a/pages/reading/passage/[slug].tsx
+++ b/pages/reading/passage/[slug].tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/reading/passage/[slug].tsx
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import type { GetServerSideProps } from 'next';
@@ -33,8 +34,8 @@ type Props = {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const slug = String(ctx.params?.slug ?? '');
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const supabase = createClient(url, anon, { auth: { persistSession: false } });
 
   const [{ data: passage }, { data: qRows }] = await Promise.all([

--- a/pages/reading/review/index.tsx
+++ b/pages/reading/review/index.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/reading/review/index.tsx
 import React, { useEffect, useMemo, useState } from 'react';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -78,8 +79,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
     return { props: { passage: null, questions: [], error: 'Missing slug', notFound: false } };
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !anon) {
     return {
       props: { passage: null, questions: [], error: 'Supabase env missing', notFound: false },
@@ -152,8 +153,8 @@ const ReviewPage: NextPage<Props> = ({ passage, questions, notFound, error }) =>
       try {
         // Attempt: fetch from DB if we have attemptId + token
         if (attemptId) {
-          const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-          const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+          const url = env.NEXT_PUBLIC_SUPABASE_URL;
+          const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
           const { createClient } = await import('@supabase/supabase-js');
           const supabase = createClient(url, anon);
           const { data: { session } } = await supabase.auth.getSession();

--- a/pages/speaking/index.tsx
+++ b/pages/speaking/index.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/speaking/index.tsx
 import React from 'react';
 import { GetServerSideProps } from 'next';
@@ -154,7 +155,7 @@ export default function SpeakingHub({
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   const { user, supabase } = await getUserServer(req as any, res as any);
 
-  const limit = parseInt(process.env.SPEAKING_DAILY_LIMIT || '5', 10);
+  const limit = parseInt(env.SPEAKING_DAILY_LIMIT || '5', 10);
   if (!user) {
     return { props: { attempts: [], attemptsToday: 0, limit, signedIn: false } };
   }

--- a/pages/speaking/partner/history.tsx
+++ b/pages/speaking/partner/history.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 // pages/speaking/partner/history.tsx
 import React, { useMemo, useState } from 'react';
 import type { GetServerSideProps } from 'next';
@@ -34,8 +35,8 @@ type Props = {
 
 export const getServerSideProps: GetServerSideProps<Props> = async () => {
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 
   // Recent attempts for the (RLS-scoped) current user

--- a/pages/speaking/review/[id].tsx
+++ b/pages/speaking/review/[id].tsx
@@ -1,3 +1,4 @@
+import { env } from "@/lib/env";
 import React, { useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
@@ -23,8 +24,8 @@ type Props = { attempt: Attempt | null };
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { attemptId } = ctx.query as { attemptId: string };
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const supabase = createClient(url, anon, {
     global: { headers: { Cookie: ctx.req.headers.cookie || '' } },
   });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "env": {
+    "NEXT_PUBLIC_SUPABASE_URL": "@next_public_supabase_url",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@next_public_supabase_anon_key",
+    "SUPABASE_SERVICE_ROLE_KEY": "@supabase_service_role_key",
+    "NEXT_PUBLIC_BASE_URL": "@next_public_base_url",
+    "ADMIN_EMAILS": "@admin_emails",
+    "GOOGLE_GENERATIVE_AI_API_KEY": "@google_generative_ai_api_key",
+    "GROQ_API_KEY": "@groq_api_key",
+    "GROQ_MODEL": "@groq_model",
+    "OPENAI_API_KEY": "@openai_api_key",
+    "GEMINI_API_KEY": "@gemini_api_key",
+    "PREMIUM_MASTER_PIN": "@premium_master_pin",
+    "SPEAKING_DAILY_LIMIT": "@speaking_daily_limit",
+    "SPEAKING_BUCKET": "@speaking_bucket",
+    "NEXT_PUBLIC_DEBUG": "@next_public_debug"
+  }
+}
+


### PR DESCRIPTION
## Summary
- add env schema with zod and export validated values
- use env imports instead of `process.env` everywhere
- document required env keys and configure vercel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service NEXT_PUBLIC_BASE_URL=https://example.com ADMIN_EMAILS=a@example.com GOOGLE_GENERATIVE_AI_API_KEY=1 GROQ_API_KEY=1 GROQ_MODEL=model OPENAI_API_KEY=1 GEMINI_API_KEY=1 PREMIUM_MASTER_PIN=1 SPEAKING_DAILY_LIMIT=5 SPEAKING_BUCKET=bucket NEXT_PUBLIC_DEBUG=1 npm run build` *(fails: Type error in components/writing/ReevalHistory.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a6824bb3888321bbdbabc1e38e3a98