### PR TITLE
fix: guard browser APIs for SSR

### DIFF
--- a/components/speaking/Recorder.tsx
+++ b/components/speaking/Recorder.tsx
@@ -25,6 +25,7 @@ export const Recorder: React.FC<Props> = ({
   const [isRecording, setIsRecording] = useState(false);
 
   const start = async () => {
+    if (typeof window === 'undefined') return;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
@@ -67,22 +68,24 @@ export const Recorder: React.FC<Props> = ({
       setIsRecording(true);
 
       stopAtRef.current = Date.now() + maxMs;
-      if (timerRef.current) window.clearInterval(timerRef.current);
-      timerRef.current = window.setInterval(() => {
-        setSeconds((s) => {
-          const next = s + 1;
-          if (Date.now() >= (stopAtRef.current ?? 0)) {
-            if (mediaRec.current && mediaRec.current.state !== 'inactive') {
-              mediaRec.current.stop();
+      if (typeof window !== 'undefined') {
+        if (timerRef.current) window.clearInterval(timerRef.current);
+        timerRef.current = window.setInterval(() => {
+          setSeconds((s) => {
+            const next = s + 1;
+            if (Date.now() >= (stopAtRef.current ?? 0)) {
+              if (mediaRec.current && mediaRec.current.state !== 'inactive') {
+                mediaRec.current.stop();
+              }
+              if (timerRef.current) {
+                window.clearInterval(timerRef.current);
+                timerRef.current = null;
+              }
             }
-            if (timerRef.current) {
-              window.clearInterval(timerRef.current);
-              timerRef.current = null;
-            }
-          }
-          return next;
-        });
-      }, 1000);
+            return next;
+          });
+        }, 1000);
+      }
     } catch (e: any) {
       onError?.(e);
     }
@@ -93,7 +96,7 @@ export const Recorder: React.FC<Props> = ({
       if (mediaRec.current && mediaRec.current.state !== 'inactive') {
         mediaRec.current.stop();
       }
-      if (timerRef.current) {
+      if (typeof window !== 'undefined' && timerRef.current) {
         window.clearInterval(timerRef.current);
         timerRef.current = null;
       }

--- a/components/speaking/useSpeech.ts
+++ b/components/speaking/useSpeech.ts
@@ -8,9 +8,17 @@ export function useSpeech() {
   const timerRef = useRef<number | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
 
-  useEffect(() => () => { if (timerRef.current) window.clearInterval(timerRef.current); }, []);
+  useEffect(
+    () => () => {
+      if (typeof window !== 'undefined' && timerRef.current) {
+        window.clearInterval(timerRef.current);
+      }
+    },
+    []
+  );
 
   async function start() {
+    if (typeof window === 'undefined') return;
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     const rec = new MediaRecorder(stream, { mimeType: 'audio/webm' });
     chunksRef.current = [];
@@ -20,7 +28,9 @@ export function useSpeech() {
     setSeconds(0);
     setRecording(true);
     rec.start();
-    timerRef.current = window.setInterval(() => setSeconds(s => s + 1), 1000);
+    if (typeof window !== 'undefined') {
+      timerRef.current = window.setInterval(() => setSeconds(s => s + 1), 1000);
+    }
   }
 
   async function stop(): Promise<Blob> {
@@ -30,7 +40,9 @@ export function useSpeech() {
       rec.onstop = () => {
         const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
         setRecording(false);
-        if (timerRef.current) window.clearInterval(timerRef.current);
+        if (typeof window !== 'undefined' && timerRef.current) {
+          window.clearInterval(timerRef.current);
+        }
         resolve(blob);
       };
       rec.stop();

--- a/hooks/useCountdown.ts
+++ b/hooks/useCountdown.ts
@@ -1,12 +1,39 @@
 import { useEffect, useRef, useState } from "react";
+
 export function useCountdown(totalSeconds: number, autoStart = false) {
   const [seconds, setSeconds] = useState(totalSeconds);
   const [running, setRunning] = useState(autoStart);
   const timerRef = useRef<number | null>(null);
-  useEffect(() => { if (!running) return; timerRef.current = window.setInterval(() => { setSeconds((s) => (s > 0 ? s - 1 : 0)); }, 1000); return () => { if (timerRef.current) clearInterval(timerRef.current); }; }, [running]);
-  useEffect(() => { if (seconds === 0 && running) setRunning(false); }, [seconds, running]);
-  const start = () => { setSeconds(totalSeconds); setRunning(true); };
-  const stop = () => { setRunning(false); };
-  const reset = () => { setSeconds(totalSeconds); setRunning(false); };
+
+  useEffect(() => {
+    if (!running || typeof window === "undefined") return;
+    timerRef.current = window.setInterval(() => {
+      setSeconds((s) => (s > 0 ? s - 1 : 0));
+    }, 1000);
+    return () => {
+      if (timerRef.current) {
+        window.clearInterval(timerRef.current);
+      }
+    };
+  }, [running]);
+
+  useEffect(() => {
+    if (seconds === 0 && running) setRunning(false);
+  }, [seconds, running]);
+
+  const start = () => {
+    setSeconds(totalSeconds);
+    setRunning(true);
+  };
+
+  const stop = () => {
+    setRunning(false);
+  };
+
+  const reset = () => {
+    setSeconds(totalSeconds);
+    setRunning(false);
+  };
+
   return { seconds, running, start, stop, reset };
 }

--- a/hooks/usePremiumTheme.ts
+++ b/hooks/usePremiumTheme.ts
@@ -4,22 +4,30 @@ const LS_KEY = "premium:theme";
 
 export function usePremiumTheme(defaultTheme: "light" | "dark" | "aurora" | "gold" = "light") {
   useEffect(() => {
+    if (typeof document === "undefined") return;
     const root = (document.getElementById("premium-root") ||
       document.querySelector(".premium-root")) as HTMLElement | null;
 
-    const stored = (typeof window !== "undefined" &&
-      (localStorage.getItem(LS_KEY) as "light" | "dark" | "aurora" | "gold" | null)) || null;
+    const stored =
+      (typeof window !== "undefined" &&
+        (localStorage.getItem(LS_KEY) as "light" | "dark" | "aurora" | "gold" | null)) ||
+      null;
 
     const initial = stored || defaultTheme;
     if (root) root.setAttribute("data-pr-theme", initial);
   }, [defaultTheme]);
 
   const setTheme = (t: "light" | "dark" | "aurora" | "gold") => {
+    if (typeof document === "undefined") return;
     const root = (document.getElementById("premium-root") ||
       document.querySelector(".premium-root")) as HTMLElement | null;
     if (root) {
       root.setAttribute("data-pr-theme", t);
-      try { localStorage.setItem(LS_KEY, t); } catch {}
+      if (typeof window !== "undefined") {
+        try {
+          localStorage.setItem(LS_KEY, t);
+        } catch {}
+      }
     }
   };
 

--- a/hooks/useRecorder.ts
+++ b/hooks/useRecorder.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+
 export function useRecorder() {
   const [isRecording, setIsRecording] = useState(false);
   const [level, setLevel] = useState(0);
@@ -9,18 +10,66 @@ export function useRecorder() {
   const analyserRef = useRef<AnalyserNode | null>(null);
   const dataArrayRef = useRef<Uint8Array | null>(null);
   const rafRef = useRef<number | null>(null);
-  useEffect(() => { return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); audioCtxRef.current?.close(); mediaStreamRef.current?.getTracks().forEach(t => t.stop()); }; }, []);
+
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined" && rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      audioCtxRef.current?.close();
+      mediaStreamRef.current?.getTracks().forEach(t => t.stop());
+    };
+  }, []);
+
   const start = async () => {
+    if (typeof window === "undefined") return;
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    mediaStreamRef.current = stream; const mediaRecorder = new MediaRecorder(stream); const chunks: BlobPart[] = [];
-    mediaRecorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
-    mediaRecorder.onstop = () => { const b = new Blob(chunks, { type: "audio/webm" }); setBlob(b); };
-    mediaRecRef.current = mediaRecorder; mediaRecorder.start(); setIsRecording(true);
-    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)(); audioCtxRef.current = ctx;
-    const src = ctx.createMediaStreamSource(stream); const analyser = ctx.createAnalyser(); analyser.fftSize = 256; analyserRef.current = analyser; dataArrayRef.current = new Uint8Array(analyser.frequencyBinCount); src.connect(analyser);
-    const tick = () => { if (!analyserRef.current || !dataArrayRef.current) return; analyserRef.current.getByteTimeDomainData(dataArrayRef.current); let sum = 0; for (let i=0;i<dataArrayRef.current.length;i++) { const v = (dataArrayRef.current[i] - 128) / 128; sum += Math.abs(v); } setLevel(Math.min(1, sum / dataArrayRef.current.length * 4)); rafRef.current = requestAnimationFrame(tick); };
+    mediaStreamRef.current = stream;
+    const mediaRecorder = new MediaRecorder(stream);
+    const chunks: BlobPart[] = [];
+    mediaRecorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunks.push(e.data);
+    };
+    mediaRecorder.onstop = () => {
+      const b = new Blob(chunks, { type: "audio/webm" });
+      setBlob(b);
+    };
+    mediaRecRef.current = mediaRecorder;
+    mediaRecorder.start();
+    setIsRecording(true);
+
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    audioCtxRef.current = ctx;
+    const src = ctx.createMediaStreamSource(stream);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 256;
+    analyserRef.current = analyser;
+    dataArrayRef.current = new Uint8Array(analyser.frequencyBinCount);
+    src.connect(analyser);
+
+    const tick = () => {
+      if (!analyserRef.current || !dataArrayRef.current) return;
+      analyserRef.current.getByteTimeDomainData(dataArrayRef.current);
+      let sum = 0;
+      for (let i = 0; i < dataArrayRef.current.length; i++) {
+        const v = (dataArrayRef.current[i] - 128) / 128;
+        sum += Math.abs(v);
+      }
+      setLevel(Math.min(1, (sum / dataArrayRef.current.length) * 4));
+      rafRef.current = requestAnimationFrame(tick);
+    };
     tick();
   };
-  const stop = () => { mediaRecRef.current?.stop(); audioCtxRef.current?.close(); mediaStreamRef.current?.getTracks().forEach(t => t.stop()); setIsRecording(false); if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+
+  const stop = () => {
+    mediaRecRef.current?.stop();
+    audioCtxRef.current?.close();
+    mediaStreamRef.current?.getTracks().forEach(t => t.stop());
+    setIsRecording(false);
+    if (typeof window !== "undefined" && rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+  };
+
   return { isRecording, level, blob, start, stop };
 }

--- a/hooks/useTTS.ts
+++ b/hooks/useTTS.ts
@@ -1,13 +1,40 @@
 import { useRef, useState } from "react";
+
 export function useTTS() {
   const [speaking, setSpeaking] = useState(false);
   const utterRef = useRef<SpeechSynthesisUtterance | null>(null);
+
   const speak = (text: string, onend?: () => void) => {
-    if (!("speechSynthesis" in window)) { console.warn("SpeechSynthesis not supported"); onend?.(); return; }
-    if (utterRef.current) { window.speechSynthesis.cancel(); }
-    const utter = new SpeechSynthesisUtterance(text); utter.rate = 1; utter.pitch = 1; utter.onend = () => { setSpeaking(false); onend?.(); }; utter.onerror = () => { setSpeaking(false); onend?.(); };
-    utterRef.current = utter; setSpeaking(true); window.speechSynthesis.speak(utter);
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+      console.warn("SpeechSynthesis not supported");
+      onend?.();
+      return;
+    }
+    if (utterRef.current) {
+      window.speechSynthesis.cancel();
+    }
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.rate = 1;
+    utter.pitch = 1;
+    utter.onend = () => {
+      setSpeaking(false);
+      onend?.();
+    };
+    utter.onerror = () => {
+      setSpeaking(false);
+      onend?.();
+    };
+    utterRef.current = utter;
+    setSpeaking(true);
+    window.speechSynthesis.speak(utter);
   };
-  const cancel = () => { if (utterRef.current) { window.speechSynthesis.cancel(); setSpeaking(false); } };
+
+  const cancel = () => {
+    if (typeof window !== "undefined" && utterRef.current) {
+      window.speechSynthesis.cancel();
+      setSpeaking(false);
+    }
+  };
+
   return { speak, cancel, speaking };
 }


### PR DESCRIPTION
## Summary
- guard window usage in speaking Recorder and related hooks
- ensure premium theme and countdown hooks safe on server
- add server-side checks to TTS hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a67fe6414c832181e7794cfba2ba7c