### PR TITLE
feat: add subscriptions and stripe integration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/env.ts
+++ b/env.ts
@@ -9,6 +9,8 @@ const envSchema = z.object({
   GEMINI_API_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   PREMIUM_MASTER_PIN: z.string().optional(),
+  STRIPE_SECRET_KEY: z.string().optional(),
+  STRIPE_WEBHOOK_SECRET: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
   ADMIN_EMAILS: z.string().optional(),
   SPEAKING_DAILY_LIMIT: z.coerce.number().optional(),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -12,6 +12,8 @@ const envSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   GEMINI_API_KEY: z.string().optional(),
   PREMIUM_MASTER_PIN: z.string().optional(),
+  STRIPE_SECRET_KEY: z.string().optional(),
+  STRIPE_WEBHOOK_SECRET: z.string().optional(),
   SPEAKING_DAILY_LIMIT: z.coerce.number().optional(),
   SPEAKING_BUCKET: z.string().optional(),
   NEXT_PUBLIC_DEBUG: z.string().optional(),

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,35 @@
+'use server';
+import Stripe from 'stripe';
+import { env } from '@/lib/env';
+
+const secret = env.STRIPE_SECRET_KEY;
+if (!secret) throw new Error('Missing STRIPE_SECRET_KEY');
+
+export const stripe = new Stripe(secret, {
+  apiVersion: '2024-06-20',
+});
+
+export async function createCheckoutSession(opts: {
+  customer: string;
+  priceId: string;
+  successUrl: string;
+  cancelUrl: string;
+}) {
+  const { customer, priceId, successUrl, cancelUrl } = opts;
+  return stripe.checkout.sessions.create({
+    customer,
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+  });
+}
+
+export async function getActiveSubscription(customerId: string) {
+  const subs = await stripe.subscriptions.list({
+    customer: customerId,
+    status: 'active',
+    limit: 1,
+  });
+  return subs.data[0] ?? null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,26 +1,43 @@
 // middleware.ts
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
 
-export function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
   // Only protect /premium/*
   if (!pathname.startsWith('/premium')) return NextResponse.next();
 
-  // Allow the PIN page and verification API to be reachable without the cookie
-  if (pathname === '/premium/pin' || pathname.startsWith('/api/premium/verify-pin')) {
-    return NextResponse.next();
+  const res = NextResponse.next();
+  const supabase = createMiddlewareClient({ req, res });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
+    return NextResponse.redirect(url);
   }
 
-  const ok = req.cookies.get('pr_pin_ok')?.value === '1';
-  if (ok) return NextResponse.next();
+  const { data: sub } = await supabase
+    .from('subscriptions')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+    .maybeSingle();
 
-  // Not unlocked yet → bounce to PIN page with ?next=
-  const url = req.nextUrl.clone();
-  url.pathname = '/premium/pin';
-  url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
-  return NextResponse.redirect(url);
+  if (!sub) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/pricing';
+    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
+    return NextResponse.redirect(url);
+  }
+
+  return res;
 }
 
 export const config = { matcher: ['/premium/:path*'] };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.1.1",
     "formidable": "^3.5.4",
     "groq-sdk": "^0.30.0",
+    "stripe": "^14.0.0",
     "multiparty": "^4.2.3",
     "next": "14.2.31",
     "next-themes": "^0.3.0",

--- a/supabase/migrations/20250811_subscriptions_payments.sql
+++ b/supabase/migrations/20250811_subscriptions_payments.sql
@@ -1,0 +1,45 @@
+-- subscriptions and payments tables
+
+-- Subscriptions
+create table if not exists public.subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  stripe_subscription_id text not null,
+  status text not null check (status in ('active','canceled','incomplete','past_due','unpaid','trialing')),
+  current_period_end timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+drop trigger if exists trg_subscriptions_updated on public.subscriptions;
+create trigger trg_subscriptions_updated
+before update on public.subscriptions
+for each row execute procedure public.set_updated_at();
+
+alter table public.subscriptions enable row level security;
+
+create policy "users can view own subscriptions"
+  on public.subscriptions for select
+  using (auth.uid() = user_id);
+
+create index if not exists subscriptions_user_id_idx on public.subscriptions (user_id);
+
+-- Payments
+create table if not exists public.payments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  subscription_id uuid references public.subscriptions(id) on delete cascade,
+  stripe_payment_intent_id text,
+  amount integer,
+  currency text,
+  status text,
+  created_at timestamptz default now()
+);
+
+alter table public.payments enable row level security;
+
+create policy "users can view own payments"
+  on public.payments for select
+  using (auth.uid() = user_id);
+
+create index if not exists payments_user_id_idx on public.payments (user_id);


### PR DESCRIPTION
## Summary
- add Stripe payments helper
- track subscriptions and payments in Supabase
- require active subscription for premium routes
- configure ESLint and refine subscription migration

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: multiple lint errors and parse issues)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68abb08ad418832186155180fb316211