### PR TITLE
feat: add timer and scoring to listening module

### DIFF
--- a/lib/listening/score.test.ts
+++ b/lib/listening/score.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'assert';
+import { scoreOne, scoreAll } from './score';
+
+// scoreOne tests
+assert.equal(scoreOne({ qno:1, type:'mcq', answer_key:{ value:'A' } }, 'A'), true);
+assert.equal(scoreOne({ qno:2, type:'gap', answer_key:{ text:'Apple Pie' } }, 'apple pie'), true);
+assert.equal(scoreOne({ qno:3, type:'match', answer_key:{ pairs:[[1,2],[3,4]] } }, [[1,2],[3,4]]), true);
+assert.equal(scoreOne({ qno:4, type:'mcq', answer_key:{ value:'B' } }, 'A'), false);
+
+// scoreAll test
+const qs = [
+  { qno:1, type:'mcq', answer_key:{ value:'A' } },
+  { qno:2, type:'gap', answer_key:{ text:'blue car' } },
+];
+const ans = [
+  { qno:1, answer:'A' },
+  { qno:2, answer:'Blue   Car' },
+];
+const { total } = scoreAll(qs as any, ans as any);
+assert.equal(total, 2);
+
+console.log('listening score tests passed');


### PR DESCRIPTION
## Summary
- add 30‑minute countdown timer with auto-submit for listening test
- record attempts via Supabase RPC and compute band score
- show per-question answer review using shared listening scorer

## Testing
- `npx ts-node --esm lib/listening/score.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68abae21340c8321bdeecb53046bc902