### PR TITLE
Add FocusGuard to track exam focus

### DIFF
--- a/components/exam/FocusGuard.tsx
+++ b/components/exam/FocusGuard.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Alert } from '@/components/design-system/Alert';
+import { recordFocusViolation } from '@/lib/examSecurity';
+
+interface Props {
+  exam: string;
+  slug?: string;
+}
+
+export default function FocusGuard({ exam, slug }: Props) {
+  const [warn, setWarn] = useState(false);
+
+  useEffect(() => {
+    const el = document.documentElement as HTMLElement & { requestFullscreen?: () => Promise<void> };
+    el.requestFullscreen?.().catch(() => {});
+
+    let wasHidden = false;
+    let timer: number | undefined;
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        wasHidden = true;
+        recordFocusViolation({ exam, testSlug: slug, type: 'visibilitychange' });
+      } else if (wasHidden) {
+        wasHidden = false;
+        setWarn(true);
+        timer = window.setTimeout(() => setWarn(false), 5000);
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [exam, slug]);
+
+  return warn ? (
+    <div className="fixed top-4 left-1/2 z-50 w-full max-w-md -translate-x-1/2">
+      <Alert variant="warning" title="Stay focused">
+        Switching tabs is recorded and may invalidate your attempt.
+      </Alert>
+    </div>
+  ) : null;
+}
+

--- a/lib/examSecurity.ts
+++ b/lib/examSecurity.ts
@@ -1,0 +1,24 @@
+import { supabase } from '@/lib/supabaseClient';
+
+interface Params {
+  exam: string;
+  testSlug?: string;
+  type?: string;
+}
+
+export async function recordFocusViolation(params: Params) {
+  try {
+    const { data } = await supabase.auth.getUser();
+    const userId = data.user?.id ?? null;
+    await supabase.from('exam_focus_violations').insert({
+      user_id: userId,
+      exam: params.exam,
+      test_slug: params.testSlug ?? null,
+      type: params.type ?? null,
+      created_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error('recordFocusViolation failed', err);
+  }
+}
+

--- a/pages/listening/[slug].tsx
+++ b/pages/listening/[slug].tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { Input } from '@/components/design-system/Input';
+import FocusGuard from '@/components/exam/FocusGuard';
 
 type MCQ = {
   id: string;
@@ -311,8 +312,10 @@ export default function ListeningTestPage() {
   const sliceSecs = currentSection ? Math.max(0, Math.round((currentSection.endMs - currentSection.startMs) / 1000)) : 0;
 
   return (
-    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-      <Container>
+    <>
+      <FocusGuard exam="listening" slug={slug} />
+      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+        <Container>
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
@@ -515,6 +518,7 @@ export default function ListeningTestPage() {
           )}
         </div>
       </Container>
-    </section>
+      </section>
+    </>
   );
 }

--- a/pages/reading/[slug].tsx
+++ b/pages/reading/[slug].tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { QuestionBlock } from '@/components/reading/QuestionBlock';
 import { QuestionNav } from '@/components/reading/QuestionNav';
+import FocusGuard from '@/components/exam/FocusGuard';
 
 type BaseQ = { id: string; qNo: number; type: 'mcq'|'tfng'|'ynng'|'gap'|'match'; prompt: string };
 type MCQ = BaseQ & { type: 'mcq'; options: string[]; answer?: string };
@@ -199,8 +200,10 @@ export default function ReadingRunnerPage() {
   const ss = Math.max(0, (secondsLeft ?? 0) % 60).toString().padStart(2, '0');
 
   return (
-    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-      <Container>
+    <>
+      <FocusGuard exam="reading" slug={slug} />
+      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+        <Container>
         {!test ? (
           err ? <Alert variant="error" title="Error">{err}</Alert> : (
             <Card className="p-6"><div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" /></Card>
@@ -284,8 +287,9 @@ export default function ReadingRunnerPage() {
             </div>
           </>
         )}
-      </Container>
-    </section>
+        </Container>
+      </section>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add FocusGuard client component that requests fullscreen, detects tab changes, and logs to Supabase
- integrate FocusGuard on reading and listening exam pages
- provide helper to record focus violations in Supabase

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68abb825e9fc832194541890a0839375