### PR TITLE
Enforce roles and add account verification

### DIFF
--- a/lib/routeAccess.test.cjs
+++ b/lib/routeAccess.test.cjs
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert');
+require('ts-node/register');
+const { canAccess } = require('./routeAccess');
+
+test('student cannot access admin', () => {
+  assert.strictEqual(canAccess('/admin', 'student'), false);
+});
+
+test('student cannot access teacher', () => {
+  assert.strictEqual(canAccess('/teacher', 'student'), false);
+});

--- a/lib/routeAccess.ts
+++ b/lib/routeAccess.ts
@@ -1,5 +1,13 @@
 // lib/routeAccess.ts
+import type { User } from '@supabase/supabase-js';
+
 export type AppRole = 'student' | 'teacher' | 'admin';
+
+// Extract role from user/app metadata (null if none)
+export const getUserRole = (user: User | null | undefined): AppRole | null =>
+  (user?.user_metadata?.role as AppRole | undefined) ||
+  (user?.app_metadata?.role as AppRole | undefined) ||
+  null;
 
 export const isPublicRoute = (path: string) => {
   // Allow-list public pages. Adjust as needed.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,7 @@ import {
   isGuestOnlyRoute,
   canAccess,
   requiredRolesFor,
+  getUserRole,
   type AppRole,
 } from '@/lib/routeAccess';
 
@@ -86,10 +87,7 @@ export default function App({ Component, pageProps }: AppProps) {
           data: { session },
         } = await supabaseBrowser.auth.getSession();
         const user = session?.user ?? null;
-        const r =
-          (user?.user_metadata?.role as AppRole | undefined) ||
-          (user?.app_metadata?.role as AppRole | undefined) ||
-          null;
+        const r = getUserRole(user);
 
         if (!mounted) return;
         setIsAuthed(!!user);

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import AuthLayout from '@/components/layouts/AuthLayout';
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+
+export default function VerifyPage() {
+  const router = useRouter();
+  const { code, email } = router.query;
+  const [status, setStatus] = useState('Checking your verification status…');
+
+  useEffect(() => {
+    if (typeof code === 'string') {
+      setStatus('Verifying…');
+      supabase.auth.exchangeCodeForSession(code).then(({ data, error }) => {
+        if (error) {
+          setStatus('Verification link is invalid or expired.');
+          return;
+        }
+        if (data.session) {
+          router.replace('/profile-setup');
+        }
+      });
+    } else if (typeof email === 'string') {
+      setStatus(`A verification link has been sent to ${email}.`);
+    }
+  }, [code, email, router]);
+
+  return (
+    <AuthLayout title="Verify your account" subtitle={status} />
+  );
+}

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -19,7 +19,7 @@ export default function LoginWithPhone() {
     setErr(null);
     if (!phone) return setErr('Enter your phone number in E.164 format, e.g. +923001234567');
     setLoading(true);
-    const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: true } });
+    const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: false } });
     setLoading(false);
     if (error) return setErr(error.message);
     setStage('verify');

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -18,10 +18,19 @@ export default function SignupWithPassword() {
     setErr(null);
     if (!email || !pw) return setErr('Please fill in all fields.');
     setLoading(true);
-    const { error } = await supabase.auth.signUp({ email, password: pw });
+    const { error } = await supabase.auth.signUp({
+      email,
+      password: pw,
+      options: {
+        emailRedirectTo:
+          typeof window !== 'undefined'
+            ? `${window.location.origin}/auth/verify`
+            : undefined,
+      },
+    });
     setLoading(false);
     if (error) return setErr(error.message);
-    window.location.assign('/profile-setup');
+    window.location.assign(`/auth/verify?email=${encodeURIComponent(email)}`);
   }
 
   const RightPanel = (

--- a/supabase/migrations/20250825_role_based_policies.sql
+++ b/supabase/migrations/20250825_role_based_policies.sql
@@ -1,0 +1,12 @@
+-- Restrict admin and teacher operations via RLS policies
+alter table if exists public.profiles enable row level security;
+
+create policy "Admins can manage profiles"
+  on public.profiles
+  for all
+  using (auth.jwt()->>'role' = 'admin');
+
+create policy "Teachers can view profiles"
+  on public.profiles
+  for select
+  using (auth.jwt()->>'role' in ('teacher','admin'));


### PR DESCRIPTION
## Summary
- Centralize role extraction with `getUserRole` and apply it in app-wide guards
- Require email verification in signup flow and handle confirmation via new `/auth/verify` page
- Restrict phone login to existing users and add policies limiting admin/teacher access

## Testing
- `node --test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b3d05bc8321b9fce2f787672432