### PR TITLE
Generate drills via OpenAI

### DIFF
--- a/pages/api/drills/generate.ts
+++ b/pages/api/drills/generate.ts
@@ -1,9 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/lib/env';
+import OpenAI from 'openai';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
   const { topic } = req.body as { topic?: string };
-  // TODO: call your AI provider here with `topic`
-  const text = `Sample drill for: ${topic}\n\n1) Read the passage and answer...\n2) ...`;
-  res.status(200).json({ text });
+  if (!topic) return res.status(400).json({ error: 'Missing topic' });
+  if (!env.OPENAI_API_KEY) return res.status(500).json({ error: 'OpenAI API key not configured' });
+
+  try {
+    const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      temperature: 0.7,
+      messages: [
+        { role: 'system', content: 'You are an English teacher creating short practice drills.' },
+        {
+          role: 'user',
+          content: `Create an IELTS-style drill about "${topic}". Provide numbered tasks or questions.`,
+        },
+      ],
+    });
+
+    const text = completion.choices[0]?.message?.content?.trim() || '';
+    return res.status(200).json({ text });
+  } catch (err: any) {
+    return res.status(500).json({ error: 'Failed to generate drill' });
+  }
 }


### PR DESCRIPTION
## Summary
- replace placeholder drill text with OpenAI completion call
- validate topic input and handle missing API key

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found after install errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3373ab508321aea1c9197d4983ff