### PR TITLE
feat: score speaking clips with AI

### DIFF
--- a/pages/api/speaking/score-save.ts
+++ b/pages/api/speaking/score-save.ts
@@ -1,4 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  evaluateWithGemini,
+  evaluateWithGroq,
+  transcribeWithGroq,
+  fallbackFeedback,
+} from '@/lib/ai/evaluateSpeaking';
+
+export const config = {
+  api: { bodyParser: { sizeLimit: '25mb' } },
+};
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
@@ -9,8 +19,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
-    // TODO: plug in Gemini/Grok; for now, return fast, friendly advice.
-    const advice = 'Good start—add 1–2 supporting details to each answer.';
+    // --- Transcribe audio (Groq Whisper) ---
+    let transcript: string | null = null;
+    try {
+      const buf = Buffer.from(String(audioBase64), 'base64');
+      const ext = mime?.split('/')[1] || 'webm';
+      transcript = await transcribeWithGroq(buf, `clip.${ext}`);
+    } catch (err) {
+      console.error('transcription failed', err);
+    }
+
+    // --- Evaluate with available AI service ---
+    const evalInput = { transcript: transcript || undefined, ctx: part as 'p1' | 'p2' | 'p3' | 'chat' };
+    let feedback = await evaluateWithGemini(evalInput);
+    if (!feedback) feedback = await evaluateWithGroq(evalInput);
+    if (!feedback) feedback = fallbackFeedback();
+
+    const advice = feedback.summary || 'Great effort—keep practicing!';
 
     return res.status(200).json({ ok: true, advice, attemptId, path, clipId, mime });
   } catch (e) {


### PR DESCRIPTION
## Summary
- call Groq/Gemini scoring in `score-save` to provide real feedback from audio clips

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad337e88548321900965463d551944