### PR TITLE
feat: support right slot in AuthLayout

### DIFF
--- a/components/layouts/AuthLayout.tsx
+++ b/components/layouts/AuthLayout.tsx
@@ -8,6 +8,11 @@ type Props = {
   title: string;
   subtitle?: string;
   children: React.ReactNode;
+  /**
+   * Optional element rendered on the right side of the layout.
+   * `rightIllustration` is kept for backwards compatibility.
+   */
+  right?: React.ReactNode;
   rightIllustration?: React.ReactNode;
 };
 
@@ -17,7 +22,14 @@ const DefaultRight = () => (
   </div>
 );
 
-export default function AuthLayout({ title, subtitle, children, rightIllustration }: Props) {
+export default function AuthLayout({
+  title,
+  subtitle,
+  children,
+  right,
+  rightIllustration,
+}: Props) {
+  const rightContent = right ?? rightIllustration ?? <DefaultRight />;
   return (
     <div className="min-h-screen flex bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
       {/* Left: content */}
@@ -35,7 +47,7 @@ export default function AuthLayout({ title, subtitle, children, rightIllustratio
       </div>
 
       {/* Right: illustration */}
-      {rightIllustration ?? <DefaultRight />}
+      {rightContent}
 
       {/* Theme toggle */}
       <div className="absolute top-4 right-4">

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -46,10 +46,7 @@ export default function LoginWithEmail() {
   );
 
   return (
-    <AuthLayout title="Sign in with Email" subtitle="Use your email & password."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot
-      right={RightPanel}
-    >
+    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -97,7 +97,6 @@ export default function LoginOptions() {
     <AuthLayout
       title="Welcome back"
       subtitle="Choose a sign-in method."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot in this build
       right={RightPanel}
     >
       {err && (

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -42,10 +42,7 @@ export default function LoginWithPassword() {
   );
 
   return (
-    <AuthLayout title="Sign in with Email" subtitle="Use your email & password."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot
-      right={RightPanel}
-    >
+    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -53,10 +53,7 @@ export default function LoginWithPhone() {
   );
 
   return (
-    <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot
-      right={RightPanel}
-    >
+    <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
 
       {stage === 'request' ? (

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -38,10 +38,7 @@ export default function SignupOptions() {
   );
 
   return (
-    <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot
-      right={RightPanel}
-    >
+    <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method." right={RightPanel}>
       <div className="grid gap-3">
         <Button onClick={() => signUpOAuth('apple')} variant="secondary" className="rounded-ds-xl w-full">
           <span className="inline-flex items-center gap-3"><i className="fab fa-apple text-xl" aria-hidden /> Sign up with Apple</span>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -54,7 +54,7 @@ export default function SignupWithPassword() {
   }
 
   // Right side: large logo only (preserves your split-screen design)
-  const RightIllustration = (
+  const RightPanel = (
     <div className="hidden md:flex w-1/2 relative items-center justify-center bg-primary/10 dark:bg-dark">
       <Image
         src="/brand/logo.png"
@@ -71,7 +71,7 @@ export default function SignupWithPassword() {
     <AuthLayout
       title="Sign up with Email"
       subtitle="Create an account using email & password."
-      rightIllustration={RightIllustration}
+      right={RightPanel}
     >
       {err && (
         <Alert variant="error" title="Error" className="mb-4">

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -52,10 +52,7 @@ export default function SignupWithPhone() {
   );
 
   return (
-    <AuthLayout title="Phone Verification" subtitle="Sign up with an SMS code."
-      // @ts-expect-error TODO: AuthLayout supports an optional `right` slot
-      right={RightPanel}
-    >
+    <AuthLayout title="Phone Verification" subtitle="Sign up with an SMS code." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
 
       {stage === 'request' ? (


### PR DESCRIPTION
## Summary
- allow AuthLayout to accept a `right` slot while keeping `rightIllustration` for backwards compatibility
- update login and signup pages to pass the new `right` prop without suppressing TypeScript

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68ad33ff45188321abd927100d46f67f