### PR TITLE
Fetch reading answers from database

### DIFF
--- a/pages/api/reading/recompute.ts
+++ b/pages/api/reading/recompute.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabaseService as supabase } from '@/lib/supabaseService';
 
 /**
  * Recompute result server-side.
  * Accepts: { slug: string, answers: Record<string, any> }
- * TODO: Replace stubbed correctAnswers & per-type mapping with DB-driven values.
- */
+*/
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
@@ -14,24 +14,38 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ error: 'Invalid payload' });
     }
 
-    // TODO: Fetch correct answers from DB by slug
-    // Stubbed canonical answers (match demo question ids):
-    const correctAnswers: Record<string, any> = {
-      q1: 'False',
-      q2: 'Skimming/Scanning',
-      q3: { 0: 'Definitions', 1: 'Skimming/Scanning' },
-      q4: 'Scanning',
-    };
+    // Fetch questions for this slug to build canonical answers and type mapping
+    const { data: questions, error } = await supabase
+      .from('reading_questions')
+      .select('id, correct, type')
+      .eq('test_slug', slug);
 
-    // Map id -> type (stub; in real life, derive from DB question records)
-    const byIdType: Record<string, 'tfng' | 'mcq' | 'matching' | 'short'> = {
-      q1: 'tfng',
-      q2: 'mcq',
-      q3: 'matching',
-      q4: 'short',
-    };
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+    if (!questions || questions.length === 0) {
+      return res.status(404).json({ error: 'Questions not found for slug' });
+    }
 
-    const ids = Object.keys({ ...answers, ...correctAnswers });
+    const correctAnswers: Record<string, any> = {};
+    const byIdType: Record<string, string> = {};
+
+    for (const q of questions) {
+      if (!q.id || typeof q.correct === 'undefined' || !q.type) {
+        return res.status(500).json({ error: 'Incomplete question data' });
+      }
+      correctAnswers[q.id] = q.correct;
+      byIdType[q.id] = q.type;
+    }
+
+    // Ensure provided answers correspond to known questions
+    for (const id of Object.keys(answers)) {
+      if (!(id in correctAnswers)) {
+        return res.status(400).json({ error: `Unknown question id: ${id}` });
+      }
+    }
+
+    const ids = questions.map((q: any) => q.id);
     let correct = 0;
     const byType: Record<string, { total: number; correct: number }> = {};
 


### PR DESCRIPTION
## Summary
- Fetch reading question metadata from Supabase instead of using hard-coded values
- Build correct answer and type maps from database query results
- Add validation for unknown or incomplete questions to avoid partial scoring

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb25bbbf083218e5f51c7d8dcb265