### PR TITLE
Disable Supabase auth persistence and handle sessions manually

### DIFF
--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -9,8 +9,8 @@ const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 const getClient = () =>
   createClient(url, anon, {
     auth: {
-      persistSession: true,
-      autoRefreshToken: true,
+      persistSession: false,
+      autoRefreshToken: false,
       // keep default storageKey (sb-<project>-auth-token)
     },
   });

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -43,6 +43,13 @@ export default function Dashboard() {
     let cancelled = false;
 
     (async () => {
+      if (typeof window !== 'undefined') {
+        const url = window.location.href;
+        if (url.includes('code=') || url.includes('access_token=')) {
+          const { error } = await supabaseBrowser.auth.exchangeCodeForSession(url);
+          if (!error) router.replace('/dashboard');
+        }
+      }
       const { data: { session } } = await supabaseBrowser.auth.getSession();
 
       if (!session?.user) {

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -21,7 +21,13 @@ export default function LoginWithEmail() {
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
     if (error) return setErr(error.message);
-    if (data.session) window.location.assign('/dashboard');
+    if (data.session) {
+      await supabase.auth.setSession({
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+      });
+      window.location.assign('/dashboard');
+    }
   }
 
   const RightPanel = (

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -21,7 +21,13 @@ export default function LoginWithPassword() {
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
     if (error) return setErr(error.message);
-    if (data.session) window.location.assign('/dashboard');
+    if (data.session) {
+      await supabase.auth.setSession({
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+      });
+      window.location.assign('/dashboard');
+    }
   }
 
   const RightPanel = (

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -34,7 +34,13 @@ export default function LoginWithPhone() {
     const { data, error } = await supabase.auth.signInWithOtp({ phone, token: code });
     setLoading(false);
     if (error) return setErr(error.message);
-    if (data.session) window.location.assign('/dashboard');
+    if (data.session) {
+      await supabase.auth.setSession({
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+      });
+      window.location.assign('/dashboard');
+    }
   }
 
   const RightPanel = (

--- a/pages/profile-setup.tsx
+++ b/pages/profile-setup.tsx
@@ -13,7 +13,13 @@ import { Select } from '@/components/design-system/Select';
 /** Supabase browser client */
 const supabase = createClient(
   env.NEXT_PUBLIC_SUPABASE_URL,
-  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  }
 );
 
 const COUNTRIES = ['Pakistan','India','Bangladesh','United Arab Emirates','Saudi Arabia','United Kingdom','United States','Canada','Australia','New Zealand'];
@@ -43,6 +49,13 @@ export default function ProfileSetup() {
   useEffect(() => {
     (async () => {
       setLoading(true);
+      if (typeof window !== 'undefined') {
+        const url = window.location.href;
+        if (url.includes('code=') || url.includes('access_token=')) {
+          const { error } = await supabase.auth.exchangeCodeForSession(url);
+          if (!error) router.replace('/profile-setup');
+        }
+      }
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.user) {
         router.replace('/login');

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -33,7 +33,13 @@ export default function SignupWithPhone() {
     const { data, error } = await supabase.auth.verifyOtp({ phone, token: code, type: 'sms' });
     setLoading(false);
     if (error) return setErr(error.message);
-    if (data.session) window.location.assign('/profile-setup');
+    if (data.session) {
+      await supabase.auth.setSession({
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+      });
+      window.location.assign('/profile-setup');
+    }
   }
 
   const RightPanel = (


### PR DESCRIPTION
## Summary
- stop storing Supabase auth tokens in the browser and disable auto refresh
- ensure login and signup flows manually store sessions via `setSession`
- handle OAuth callbacks on dashboard and profile setup pages with `exchangeCodeForSession`

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden fetching stripe package)*

------
https://chatgpt.com/codex/tasks/task_e_68adb6e3394483219fc61278cff0c3e6