### PR TITLE
feat: add idle logout utility

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
+  NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES: z.coerce.number().default(30),
   ADMIN_EMAILS: z.string().optional(),
   SPEAKING_DAILY_LIMIT: z.coerce.number().optional(),
   SPEAKING_BUCKET: z.string().optional(),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,6 +5,7 @@ const envSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
+  NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES: z.coerce.number().default(30),
   ADMIN_EMAILS: z.string().optional(),
   GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
   GROQ_API_KEY: z.string().optional(),

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,8 @@ import '@/styles/globals.css';
 import { Layout } from '@/components/Layout';
 import { ToastProvider } from '@/components/design-system/Toast';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { env } from '@/lib/env';
+import { initIdleTimeout } from '@/utils/idleTimeout';
 import {
   isGuestOnlyRoute,
   canAccess,
@@ -72,6 +74,12 @@ export default function App({ Component, pageProps }: AppProps) {
 
   // Show Layout (header/footer) only if not premium, not auth page, not other no-chrome pages
   const showLayout = !isPremium && !isAuthPage && !isNoChromeRoute;
+
+  // --- Idle timeout ---
+  useEffect(() => {
+    const cleanup = initIdleTimeout(env.NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES);
+    return cleanup;
+  }, []);
 
   // --- Route guards (role-aware) ---
   const [isChecking, setIsChecking] = useState(true);

--- a/utils/idleTimeout.ts
+++ b/utils/idleTimeout.ts
@@ -1,0 +1,36 @@
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+/**
+ * Initializes an idle timeout handler. When no user activity is detected for
+ * the specified number of minutes, the current user session is terminated and
+ * the browser is redirected to the login page.
+ *
+ * @param minutes Idle timeout in minutes.
+ * @returns Cleanup function to remove listeners and clear the timer.
+ */
+export function initIdleTimeout(minutes: number) {
+  if (typeof window === 'undefined') return () => void 0;
+
+  let timer: ReturnType<typeof setTimeout>;
+
+  const events = ['mousemove', 'keydown', 'mousedown', 'touchstart', 'scroll'];
+
+  const resetTimer = () => {
+    clearTimeout(timer);
+    timer = setTimeout(async () => {
+      try {
+        await supabaseBrowser.auth.signOut();
+      } finally {
+        window.location.href = '/login';
+      }
+    }, minutes * 60 * 1000);
+  };
+
+  events.forEach((event) => window.addEventListener(event, resetTimer));
+  resetTimer();
+
+  return () => {
+    clearTimeout(timer);
+    events.forEach((event) => window.removeEventListener(event, resetTimer));
+  };
+}


### PR DESCRIPTION
## Summary
- add utility to track inactivity and sign out after timeout
- configure timeout via NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES
- initialize idle timeout globally in _app

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stripe)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb6e7cc388321afcd2b9bdad5efdb