### PR TITLE
refactor: use spacing utilities for modules and header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -232,7 +232,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                   <div
                     id="desktop-modules-menu"
                     role="menu"
-                    className="absolute left-1/2 -translate-x-1/2 top-full mt-3 w-[880px] max-w-[90vw] bg-lightBg dark:bg-dark border border-purpleVibe/20 rounded-2xl shadow-lg overflow-hidden"
+                    className="absolute left-1/2 -translate-x-1/2 top-full mt-3 w-220 max-w-[90vw] bg-lightBg dark:bg-dark border border-purpleVibe/20 rounded-2xl shadow-lg overflow-hidden"
                   >
                     <div className="grid grid-cols-12">
                       <div className="col-span-8 p-6 sm:p-7">

--- a/components/sections/Modules.tsx
+++ b/components/sections/Modules.tsx
@@ -116,7 +116,7 @@ export const Modules: React.FC = () => {
                   {m.status}
                 </Badge>
 
-                <div className="w-[70px] h-[70px] rounded-full flex items-center justify-center mb-6 text-white text-2xl bg-gradient-to-br from-purpleVibe to-electricBlue">
+                <div className="w-17.5 h-17.5 rounded-full flex items-center justify-center mb-6 text-white text-2xl bg-gradient-to-br from-purpleVibe to-electricBlue">
                   <i className={`fas ${m.icon}`} />
                 </div>
                 <h3 className="text-xl font-semibold mb-3 flex items-center gap-2">

--- a/design-system/tokens/scale.js
+++ b/design-system/tokens/scale.js
@@ -10,10 +10,12 @@ module.exports = {
   },
   spacing: {
     // extends Tailwind's scale with project-specific steps
-    3.5: '0.875rem', // 14px
-    18: '4.5rem',    // 72px
-    22: '5.5rem',    // 88px
-    30: '7.5rem'     // 120px
+    3.5: '0.875rem',  // 14px
+    17.5: '4.375rem', // 70px
+    18: '4.5rem',     // 72px
+    22: '5.5rem',     // 88px
+    30: '7.5rem',     // 120px
+    220: '55rem'      // 880px
   },
   typeScale: {
     // Existing


### PR DESCRIPTION
## Summary
- replace fixed pixel values with spacing utilities in Modules icon and header menu
- extend design-system spacing tokens for 70px and 880px dimensions

## Testing
- ⚠️ `npm test` *(Cannot find module 'ts-node/register')*
- ⚠️ `npm install` *(403 Forbidden fetching stripe)*

------
https://chatgpt.com/codex/tasks/task_e_68adb80bd9fc8321bf52296aaa2744a6