### PR TITLE
replace hard-coded border radius with token class

### DIFF
--- a/components/sections/Waitlist.tsx
+++ b/components/sections/Waitlist.tsx
@@ -195,8 +195,8 @@ export default function WaitlistSection() {
           )}
         </div>
 
-        {/* Glassy violet card with soft border + 20px radius */}
-        <Card className="card-glass rounded-[20px] p-6 md:p-8 max-w-4xl mx-auto">
+        {/* Glassy violet card with soft border + token-based radius */}
+        <Card className="card-glass rounded-ds-xl p-6 md:p-8 max-w-4xl mx-auto">
           <form onSubmit={onSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-5">
             {/* Row 1 */}
             <div>


### PR DESCRIPTION
## Summary
- use `rounded-ds-xl` instead of hard-coded `rounded-[20px]` in waitlist card
- remove remaining `rounded-[…]` usages by using token-based classes

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8095bd0832196425b439cec965b