### PR TITLE
refactor: use muted text color tokens

### DIFF
--- a/components/sections/Modules.tsx
+++ b/components/sections/Modules.tsx
@@ -127,7 +127,7 @@ export const Modules: React.FC = () => {
                   {m.bullets.map((b) => (
                     <li
                       key={b}
-                      className="py-2 pl-6 border-b border-dashed border-purpleVibe/20 relative text-[#d0d0e0] dark:text-[#d0d0e0]"
+                      className="py-2 pl-6 border-b border-dashed border-purpleVibe/20 relative text-mutedText dark:text-mutedText"
                     >
                       <span className="absolute left-0 top-2 text-neonGreen font-bold">
                         ✓

--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -78,7 +78,7 @@ export const Pricing: React.FC = () => {
                 {t.features.map((f) => (
                   <li
                     key={f}
-                    className="py-2 border-b border-dashed border-purpleVibe/20 text-[#d0d0e0] dark:text-[#d0d0e0]"
+                    className="py-2 border-b border-dashed border-purpleVibe/20 text-mutedText dark:text-mutedText"
                   >
                     {f}
                   </li>

--- a/design-system/tokens/colors.js
+++ b/design-system/tokens/colors.js
@@ -21,4 +21,5 @@ module.exports = {
   sunsetRed: '#ff4d4d',     // CTA gradient end
   lightCard: '#ffffff',     // light surface bg
   lightBorder: '#e0e0e0',   // light surface border
+  mutedText: '#d0d0e0',     // subtle text color
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,6 +32,7 @@ html, body, #__next { height: 100%; }
 
   --color-lightCard:     255 255 255;  /* #ffffff */
   --color-lightBorder:   224 224 224;  /* #e0e0e0 */
+  --color-mutedText:     208 208 224;  /* #d0d0e0 */
 }
 
 /* Light = default; Dark via .dark on <html> (next-themes) */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,7 +31,8 @@ module.exports = {
         lightText:     'rgb(var(--color-lightText) / <alpha-value>)',
         grayish:       'rgb(var(--color-grayish) / <alpha-value>)',
         lightCard:     'rgb(var(--color-lightCard) / <alpha-value>)',
-        lightBorder:    'rgb(var(--color-lightBorder) / <alpha-value>)',
+        lightBorder:   'rgb(var(--color-lightBorder) / <alpha-value>)',
+        mutedText:     'rgb(var(--color-mutedText) / <alpha-value>)',
       },
 
       borderRadius: {


### PR DESCRIPTION
## Summary
- add mutedText token and wire it into Tailwind
- refactor Pricing and Modules sections to use mutedText utility

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8030bb88321a5c351fb9295bc13