### PR TITLE
feat: add user role helpers

### DIFF
--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -1,19 +1,48 @@
 import type { User } from '@supabase/supabase-js';
 
-export type AppRole = 'admin' | 'teacher' | 'student' | null;
+// Centralized user-role helpers. Roles are mutually exclusive and ordered by
+// privilege (admin > teacher > student).
 
-export function extractRole(user: User | null): AppRole {
+export type AppRole = 'admin' | 'teacher' | 'student';
+
+// Extract the canonical role from Supabase user metadata. Returns `null` if the
+// user has no recognized role.
+export function extractRole(user: User | null | undefined): AppRole | null {
   if (!user) return null;
   const r =
     (user.app_metadata as any)?.role ??
     (user.user_metadata as any)?.role ??
     null;
   const v = r ? String(r).toLowerCase() : null;
-  return (v === 'admin' || v === 'teacher' || v === 'student') ? v : null;
+  return v === 'admin' || v === 'teacher' || v === 'student' ? (v as AppRole) : null;
 }
 
-export const isAdmin   = (u: User | null) => extractRole(u) === 'admin';
-export const isTeacher = (u: User | null) => {
+// Generic role checker. Admin should pass any role gate automatically.
+export function hasRole(
+  user: User | null | undefined,
+  allowed: AppRole | AppRole[],
+): boolean {
+  const role = extractRole(user);
+  if (!role) return false;
+  if (role === 'admin') return true;
+  const set = new Set(Array.isArray(allowed) ? allowed : [allowed]);
+  return set.has(role);
+}
+
+export const isAdmin = (u: User | null | undefined) => extractRole(u) === 'admin';
+
+// Teachers inherit admin privileges. Admins therefore pass `isTeacher` checks.
+export const isTeacher = (u: User | null | undefined) => {
   const r = extractRole(u);
-  return r === 'teacher' || r === 'admin'; // admin passes teacher checks
+  return r === 'teacher' || r === 'admin';
 };
+
+// Student-facing areas are accessible to any authenticated role. This helper
+// therefore returns true for students, teachers and admins.
+export const isStudent = (u: User | null | undefined) => {
+  const r = extractRole(u);
+  return r === 'student' || r === 'teacher' || r === 'admin';
+};
+
+export type { AppRole as Role };
+

--- a/lib/routeAccess.ts
+++ b/lib/routeAccess.ts
@@ -1,13 +1,11 @@
 // lib/routeAccess.ts
 import type { User } from '@supabase/supabase-js';
-
-export type AppRole = 'student' | 'teacher' | 'admin';
+import { extractRole, type AppRole } from './roles';
+export type { AppRole } from './roles';
 
 // Extract role from user/app metadata (null if none)
 export const getUserRole = (user: User | null | undefined): AppRole | null =>
-  (user?.user_metadata?.role as AppRole | undefined) ||
-  (user?.app_metadata?.role as AppRole | undefined) ||
-  null;
+  extractRole(user);
 
 export const isPublicRoute = (path: string) => {
   // Allow-list public pages. Adjust as needed.


### PR DESCRIPTION
## Summary
- centralize user-role extraction and checks for admin, teacher, and student
- reuse new helpers inside route access logic

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adba1ae6f083218f01b64e341f9b84