### PR TITLE
Add requireRole utility for admin endpoints

### DIFF
--- a/lib/requireRole.ts
+++ b/lib/requireRole.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest } from 'next';
+import type { User } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export type AppRole = 'admin' | 'teacher' | 'student';
+
+function getCookieToken(req: NextApiRequest): string | null {
+  const url = env.NEXT_PUBLIC_SUPABASE_URL as string;
+  const projectRef = url.replace(/^https?:\/\//, '').split('.')[0];
+  const cookieName = `sb-${projectRef}-auth-token`;
+  const raw = req.cookies[cookieName];
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function requireRole(
+  req: NextApiRequest,
+  allowed: AppRole[]
+): Promise<{ user: User; role: AppRole }> {
+  const authHeader = req.headers.authorization || '';
+  let token: string | null = null;
+  if (authHeader.startsWith('Bearer ')) {
+    token = authHeader.slice(7);
+  } else {
+    token = getCookieToken(req);
+  }
+  if (!token) throw new Error('unauthorized');
+
+  const { data, error } = await supabaseAdmin.auth.getUser(token);
+  if (error || !data?.user) throw new Error('unauthorized');
+  const user = data.user;
+
+  let role =
+    ((user.app_metadata as any)?.role as AppRole | undefined) ??
+    ((user.user_metadata as any)?.role as AppRole | undefined) ??
+    null;
+
+  if (!role) {
+    const { data: prof } = await supabaseAdmin
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+    role = (prof?.role as AppRole | undefined) ?? null;
+  }
+
+  if (!role || !allowed.includes(role)) throw new Error('forbidden');
+
+  return { user, role };
+}

--- a/pages/api/admin/dashboard.ts
+++ b/pages/api/admin/dashboard.ts
@@ -1,6 +1,7 @@
 // /pages/api/admin/dashboard.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { requireRole } from '@/lib/requireRole';
 
 type Stat = { label: string; value: string; sub?: string };
 type Signup = { id: string; name: string; email: string; joinedAt: string; cohort?: string };
@@ -270,6 +271,11 @@ async function studentsPaged(fromIso: string, toIso: string, cohort?: string, q?
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Payload | { error: string }>) {
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   try {
     const {
       from: fromYmd,

--- a/pages/api/admin/premium/clear-pin.ts
+++ b/pages/api/admin/premium/clear-pin.ts
@@ -1,8 +1,7 @@
-import { env } from "@/lib/env";
 // pages/api/admin/premium/clear-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createClient } from '@supabase/supabase-js';
-import { supabaseService, isAdminEmail } from '@/lib/supabaseService';
+import { supabaseService } from '@/lib/supabaseService';
+import { requireRole } from '@/lib/requireRole';
 
 type Resp =
   | { ok: true; userId: string }
@@ -12,17 +11,11 @@ type Resp =
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
 
-  const authHdr = req.headers.authorization || '';
-  const token = authHdr.startsWith('Bearer ') ? authHdr.slice(7) : null;
-  if (!token) return res.status(401).json({ error: 'Unauthorized' });
-
-  const supabaseCaller = createClient(
-    env.NEXT_PUBLIC_SUPABASE_URL as string,
-    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
-    { global: { headers: { Authorization: `Bearer ${token}` } } }
-  );
-  const { data: userData } = await supabaseCaller.auth.getUser();
-  if (!isAdminEmail(userData?.user?.email)) return res.status(403).json({ ok: false, reason: 'NOT_ADMIN' });
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ ok: false, reason: 'NOT_ADMIN' });
+  }
 
   const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
   const targetEmail: string | undefined = body?.email;

--- a/pages/api/admin/stop-impersonation.ts
+++ b/pages/api/admin/stop-impersonation.ts
@@ -1,7 +1,16 @@
 // pages/api/admin/stop-impersonation.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireRole } from '@/lib/requireRole';
 
-export default async function handler(_req: NextApiRequest, res: NextApiResponse<{ok:true}>) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ ok: true } | { error: string }>
+) {
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   // You can write a DB log here if desired.
   res.status(200).json({ ok: true });
 }

--- a/pages/api/admin/students/actions.ts
+++ b/pages/api/admin/students/actions.ts
@@ -1,6 +1,7 @@
 // pages/api/admin/students/actions.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { requireRole } from '@/lib/requireRole';
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ||
@@ -27,6 +28,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiOk | ApiErr>
 ) {
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ error: 'Method not allowed' });

--- a/pages/api/admin/students/export.ts
+++ b/pages/api/admin/students/export.ts
@@ -1,11 +1,17 @@
 // pages/api/admin/students/export.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { requireRole } from '@/lib/requireRole';
 
 function ymdToIsoStart(ymd: string) { return `${ymd}T00:00:00.000Z`; }
 function ymdToIsoEnd(ymd: string)   { return `${ymd}T23:59:59.999Z`; }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   try {
     const { from, to, q, cohort, role, status } = req.query as Record<string,string|undefined>;
 

--- a/pages/api/admin/students/list.ts
+++ b/pages/api/admin/students/list.ts
@@ -1,6 +1,7 @@
 // pages/api/admin/students/list.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { requireRole } from '@/lib/requireRole';
 
 type Row = {
   id: string;
@@ -25,6 +26,11 @@ function ymdToIsoStart(ymd: string) { return `${ymd}T00:00:00.000Z`; }
 function ymdToIsoEnd(ymd: string)   { return `${ymd}T23:59:59.999Z`; }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp | {error:string}>) {
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   try {
     const { from, to, q, cohort, role, status, page='1', size='20' } = req.query as Record<string,string|undefined>;
     const pageNum = Math.max(1, parseInt(page || '1', 10));

--- a/pages/api/admin/users/set-role.ts
+++ b/pages/api/admin/users/set-role.ts
@@ -1,6 +1,7 @@
 // pages/api/admin/users/set-role.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { requireRole } from '@/lib/requireRole';
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -9,6 +10,11 @@ const supabaseAdmin = createClient(
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   const { userId, role }: { userId: string; role: 'student' | 'teacher' | 'admin' } = req.body;
 
   // 1) set canonical role in app_metadata (JWT claim)


### PR DESCRIPTION
## Summary
- Add `requireRole` helper to validate Supabase token and enforce roles
- Gate admin API routes using the new role requirement utility

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe460f8c83218874481aabf709e6