### PR TITLE
fix: relocate design system barrel from API route

### DIFF
--- a/components/design-system/EmptyState.tsx
+++ b/components/design-system/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@/components/design-system/Button';
+import { Button } from './Button';
 
 export type EmptyStateProps = {
   /** Heading text */

--- a/components/design-system/index.tsx
+++ b/components/design-system/index.tsx
@@ -41,9 +41,9 @@ export { default as QuestionRenderer } from '../reading/QuestionRenderer';
 export { default as Recorder } from '../speaking/Recorder';
 
 // ——— Premium/Admin (export only if these exist; otherwise comment out)
-export { default as PinGate } from '../../premium-ui/PinGate';
-export { default as PinManager } from '../../premium-ui/PinManager';
-export { default as PinLock } from '../../premium-ui/composed/PinLock';
+// export { default as PinGate } from '../../premium-ui/PinGate';
+// export { default as PinManager } from '../../premium-ui/PinManager';
+// export { default as PinLock } from '../../premium-ui/composed/PinLock';
 
 // ——— Future DS components (enable when files land)
 // export { Select } from './Select';


### PR DESCRIPTION
## Summary
- move design system barrel into `components/design-system/index.tsx`
- switch internal design-system imports to relative paths
- drop mistaken API route `pages/api/reading/recompute.ts`

## Testing
- `npm run build` *(fails: tailwindcss not found)*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68add2a656748321bbfb68e84592ed30