### PR TITLE
Add premium theme definitions

### DIFF
--- a/premium-ui/theme/premium-themes.ts
+++ b/premium-ui/theme/premium-themes.ts
@@ -1,0 +1,9 @@
+export const PREMIUM_THEMES = [
+  { id: 'carbon', label: 'Carbon Noir' },
+  { id: 'ivory', label: 'Ivory Quartz' },
+  { id: 'royal', label: 'Royal Aster' },
+  { id: 'aurora', label: 'Aurora Neo' },
+] as const;
+
+export type PremiumThemeId = typeof PREMIUM_THEMES[number]['id'];
+


### PR DESCRIPTION
## Summary
- define PREMIUM_THEMES and PremiumThemeId for premium UI

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden when fetching stripe)
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add80724008321a671e9e4f05ac420