### PR TITLE
Add study calendar and streak API integration

### DIFF
--- a/components/feature/StudyCalendar.tsx
+++ b/components/feature/StudyCalendar.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { useStreak } from '@/hooks/useStreak';
+import { getDayKeyInTZ } from '@/lib/streak';
+
+export const StudyCalendar: React.FC = () => {
+  const { current, lastDayKey, loading } = useStreak();
+
+  const days = useMemo(() => {
+    const arr: { key: string; date: Date; completed: boolean }[] = [];
+    const today = new Date();
+    for (let i = 27; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(today.getDate() - i);
+      const key = getDayKeyInTZ(d);
+      let completed = false;
+      if (lastDayKey) {
+        const last = new Date(lastDayKey);
+        const diff = Math.floor((last.getTime() - d.getTime()) / (1000 * 60 * 60 * 24));
+        if (diff >= 0 && diff < current) completed = true;
+      }
+      arr.push({ key, date: d, completed });
+    }
+    return arr;
+  }, [current, lastDayKey]);
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h3 className="font-slab text-h3 mb-4">Study Calendar</h3>
+      <div className="grid grid-cols-7 gap-2 text-center text-xs">
+        {days.map((day) => (
+          <div
+            key={day.key}
+            className={[
+              'h-8 flex items-center justify-center rounded',
+              day.completed
+                ? 'bg-electricBlue text-white'
+                : 'bg-muted text-muted-foreground dark:bg-white/10',
+            ].join(' ')}
+            title={day.key}
+          >
+            {day.date.getDate()}
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+export default StudyCalendar;

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -42,15 +42,40 @@ export type StreakData = {
 };
 
 /** Fetch current streak for the logged-in user */
+const handle = async (res: Response, fallbackMsg: string): Promise<StreakData> => {
+  let json: any = null;
+  try {
+    json = await res.json();
+  } catch {
+    // ignore
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || fallbackMsg);
+  }
+  return {
+    current_streak: json?.current_streak ?? 0,
+    last_activity_date: json?.last_activity_date ?? null,
+  };
+};
+
+/** Fetch current streak for the logged-in user */
 export async function fetchStreak(): Promise<StreakData> {
-  const res = await fetch('/api/streak');
-  if (!res.ok) throw new Error('Failed to fetch streak');
-  return res.json();
+  try {
+    const res = await fetch('/api/streak');
+    return await handle(res, 'Failed to fetch streak');
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
 }
 
 /** Mark today's activity and return the updated streak */
 export async function incrementStreak(): Promise<StreakData> {
-  const res = await fetch('/api/streak', { method: 'POST' });
-  if (!res.ok) throw new Error('Failed to update streak');
-  return res.json();
+  try {
+    const res = await fetch('/api/streak', { method: 'POST' });
+    return await handle(res, 'Failed to update streak');
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
 }


### PR DESCRIPTION
## Summary
- add Supabase-backed streak API with GET/POST endpoints
- improve streak library with error handling
- introduce StudyCalendar component and render on dashboard

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1be2100c8321acd932ff808856d6