### PR TITLE
feat: add bookmark system and saved items

### DIFF
--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/design-system/Button';
+
+type Props = {
+  resourceId: string;
+  type: string;
+};
+
+export const BookmarkButton: React.FC<Props> = ({ resourceId, type }) => {
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    if (!resourceId) return;
+    (async () => {
+      try {
+        const res = await fetch(`/api/bookmarks?resource_id=${resourceId}&type=${type}`);
+        if (active && res.ok) {
+          const data = await res.json();
+          setSaved(Array.isArray(data) && data.length > 0);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [resourceId, type]);
+
+  const toggle = async () => {
+    if (!resourceId) return;
+    if (saved) {
+      await fetch('/api/bookmarks', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resource_id: resourceId, type }),
+      });
+      setSaved(false);
+    } else {
+      await fetch('/api/bookmarks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resource_id: resourceId, type }),
+      });
+      setSaved(true);
+    }
+  };
+
+  return (
+    <Button
+      variant={saved ? 'accent' : 'secondary'}
+      size="sm"
+      onClick={toggle}
+      disabled={loading}
+      className="rounded-ds"
+      leadingIcon={<i className={`${saved ? 'fas' : 'far'} fa-bookmark`} />}
+    >
+      {saved ? 'Saved' : 'Save'}
+    </Button>
+  );
+};
+
+export default BookmarkButton;

--- a/components/dashboard/SavedItems.tsx
+++ b/components/dashboard/SavedItems.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+
+type Bookmark = {
+  resource_id: string;
+  type: string;
+  created_at: string;
+};
+
+export function SavedItems() {
+  const [loading, setLoading] = useState(true);
+  const [authed, setAuthed] = useState(true);
+  const [items, setItems] = useState<Bookmark[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/bookmarks');
+        if (!active) return;
+        if (res.status === 401) {
+          setAuthed(false);
+          setItems([]);
+        } else if (res.ok) {
+          const data = await res.json();
+          setItems(data as Bookmark[]);
+        }
+      } catch {
+        // ignore
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, []);
+
+  if (loading) {
+    return (
+      <Card className="p-6 rounded-ds-2xl">
+        <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+        <div className="mt-4 animate-pulse h-4 w-64 bg-gray-200 dark:bg-white/10 rounded" />
+      </Card>
+    );
+  }
+
+  if (!authed) {
+    return (
+      <Card className="p-6 rounded-ds-2xl flex items-center justify-between">
+        <div>
+          <div className="font-semibold mb-1">Saved items</div>
+          <div className="text-sm text-gray-600 dark:text-grayish">Sign in to access your bookmarks.</div>
+        </div>
+        <Button href="/login" variant="primary" className="rounded-ds-xl">Sign in</Button>
+      </Card>
+    );
+  }
+
+  const linkFor = (b: Bookmark) => {
+    if (b.type === 'reading') return `/reading/${b.resource_id}`;
+    if (b.type === 'listening') return `/listening/${b.resource_id}`;
+    return `/${b.type}/${b.resource_id}`;
+  };
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h2 className="font-slab text-h2 mb-4">Saved items</h2>
+      {items.length === 0 ? (
+        <div className="text-sm text-gray-600 dark:text-grayish">No saved items yet.</div>
+      ) : (
+        <ul className="grid gap-2">
+          {items.map((b) => (
+            <li key={`${b.type}:${b.resource_id}`} className="flex items-center justify-between">
+              <Link href={linkFor(b)} className="underline">
+                {b.type}: {b.resource_id}
+              </Link>
+              <span className="text-sm text-gray-600 dark:text-grayish">
+                {new Date(b.created_at).toLocaleDateString()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+export default SavedItems;

--- a/pages/api/bookmarks.ts
+++ b/pages/api/bookmarks.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabase = createClient(url, anon, {
+    global: { headers: { Cookie: req.headers.cookie || '' } },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const { resource_id, type } = req.query as { resource_id?: string; type?: string };
+    let query = supabase
+      .from('user_bookmarks')
+      .select('resource_id, type, created_at')
+      .eq('user_id', user.id);
+    if (resource_id) query = query.eq('resource_id', resource_id);
+    if (type) query = query.eq('type', type);
+    const { data, error } = await query;
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json(data);
+  }
+
+  if (req.method === 'POST') {
+    const { resource_id, type } = req.body as { resource_id?: string; type?: string };
+    if (!resource_id || !type) {
+      return res.status(400).json({ error: 'Missing resource_id or type' });
+    }
+    const { error } = await supabase
+      .from('user_bookmarks')
+      .upsert({ user_id: user.id, resource_id, type });
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(201).json({ success: true });
+  }
+
+  if (req.method === 'DELETE') {
+    const { resource_id, type } = req.body as { resource_id?: string; type?: string };
+    if (!resource_id || !type) {
+      return res.status(400).json({ error: 'Missing resource_id or type' });
+    }
+    const { error } = await supabase
+      .from('user_bookmarks')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('resource_id', resource_id)
+      .eq('type', type);
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', 'GET,POST,DELETE');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -10,6 +10,7 @@ import { Alert } from '@/components/design-system/Alert';
 import { StreakIndicator } from '@/components/design-system/StreakIndicator';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { ReadingStatsCard } from '@/components/reading/ReadingStatsCard';
+import { SavedItems } from '@/components/dashboard/SavedItems';
 import { fetchStreak } from '@/lib/streak';
 
 type AIPlan = {
@@ -191,6 +192,10 @@ export default function Dashboard() {
 
           {/* New: Reading Student Analysis */}
           <ReadingStatsCard />
+        </div>
+
+        <div className="mt-10">
+          <SavedItems />
         </div>
 
         {/* Upgrade */}

--- a/pages/listening/[slug].tsx
+++ b/pages/listening/[slug].tsx
@@ -12,6 +12,7 @@ import FocusGuard from '@/components/exam/FocusGuard';
 import { Timer } from '@/components/design-system/Timer';
 import { scoreAll } from '@/lib/listening/score';
 import { rawToBand } from '@/lib/listening/band';
+import { BookmarkButton } from '@/components/BookmarkButton';
 
 type MCQ = {
   id: string;
@@ -381,6 +382,7 @@ export default function ListeningTestPage() {
               <p className="text-grayish">Auto-play per section • Transcript toggle • Answer highlighting</p>
             </div>
             <div className="flex items-center gap-3">
+              <BookmarkButton resourceId={slug || ''} type="listening" />
               <Timer
                 initialSeconds={TOTAL_TIME_SEC}
                 onTick={(s) => setTimeLeft(Math.ceil(s))}

--- a/pages/reading/[slug].tsx
+++ b/pages/reading/[slug].tsx
@@ -9,6 +9,7 @@ import { Alert } from '@/components/design-system/Alert';
 import { QuestionBlock } from '@/components/reading/QuestionBlock';
 import { QuestionNav } from '@/components/reading/QuestionNav';
 import FocusGuard from '@/components/exam/FocusGuard';
+import { BookmarkButton } from '@/components/BookmarkButton';
 
 type BaseQ = { id: string; qNo: number; type: 'mcq'|'tfng'|'ynng'|'gap'|'match'; prompt: string };
 type MCQ = BaseQ & { type: 'mcq'; options: string[]; answer?: string };
@@ -227,6 +228,7 @@ export default function ReadingRunnerPage() {
                 ) : null
               ))}
 
+              <BookmarkButton resourceId={slug || ''} type="reading" />
               <Button variant="secondary" className="rounded-ds" onClick={() => router.back()}>Exit</Button>
               <Button variant="primary" className="rounded-ds" onClick={() => submit()} disabled={submitting}>
                 {submitting ? 'Submitting…' : 'Submit'}

--- a/supabase/migrations/20250830_user_bookmarks.sql
+++ b/supabase/migrations/20250830_user_bookmarks.sql
@@ -1,0 +1,19 @@
+create table if not exists public.user_bookmarks (
+  user_id uuid references auth.users(id) on delete cascade,
+  resource_id text not null,
+  type text not null,
+  created_at timestamptz default now(),
+  primary key (user_id, resource_id, type)
+);
+
+alter table public.user_bookmarks enable row level security;
+
+create policy "select own bookmarks" on public.user_bookmarks
+for select to authenticated
+using (auth.uid() = user_id);
+
+create policy "insert own bookmarks" on public.user_bookmarks
+for insert with check (auth.uid() = user_id);
+
+create policy "delete own bookmarks" on public.user_bookmarks
+for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `user_bookmarks` migration and API route
- create reusable `BookmarkButton` and place on reading and listening test pages
- surface saved bookmarks on dashboard

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1be5f83c8321a6d35a60a57e77ae