### PR TITLE
feat: add basic i18n support

### DIFF
--- a/components/design-system/UserMenu.tsx
+++ b/components/design-system/UserMenu.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { useLocale } from '@/lib/locale';
 
 type MenuItem = {
   label: string;
@@ -31,6 +32,7 @@ export const UserMenu: React.FC<{
   onSignOut,
   showEmail = true,
 }) => {
+  const { locale, setLocale, t } = useLocale();
   const [open, setOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [localAvatar, setLocalAvatar] = useState<string | null>(avatarUrl ?? null);
@@ -222,6 +224,27 @@ export const UserMenu: React.FC<{
               </div>
             </div>
           )}
+
+          <div className="px-4 py-3 border-b border-vibrantPurple/15">
+            <label className="block text-small mb-1">{t('userMenu.language')}</label>
+            <select
+              className="w-full rounded-md bg-lightBg dark:bg-dark border border-vibrantPurple/20 px-2 py-1"
+              value={locale}
+              onChange={async (e) => {
+                const lang = e.target.value;
+                setLocale(lang);
+                await supabaseBrowser
+                  .from('user_profiles')
+                  .update({ preferred_language: lang })
+                  .eq('user_id', userId);
+              }}
+            >
+              <option value="en">English</option>
+              <option value="ur">Urdu</option>
+              <option value="ar">Arabic</option>
+              <option value="hi">Hindi</option>
+            </select>
+          </div>
 
           <div className="py-1">
             {_items.map((it, idx) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 // pages/index.tsx
 import React, { useCallback, useEffect, useState } from 'react';
+import Head from 'next/head';
 import dynamic from 'next/dynamic';
+import { useLocale } from '@/lib/locale';
 
 // Robust dynamic import for Hero: supports default OR named export
 const Hero = dynamic(
@@ -21,6 +23,7 @@ const Pricing = (PricingMod as any).Pricing ?? (PricingMod as any).default;
 const Waitlist = (WaitlistMod as any).Waitlist ?? (WaitlistMod as any).default;
 
 export default function HomePage() {
+  const { t } = useLocale();
   // keep your streak logic intact
   const [streak, setStreak] = useState(0);
   const onStreakChange = useCallback((n: number) => setStreak(n), []);
@@ -50,6 +53,9 @@ export default function HomePage() {
 
   return (
     <>
+      <Head>
+        <title>{t('home.title')}</title>
+      </Head>
       <Hero streak={streak} onStreakChange={onStreakChange} />
 
       <section

--- a/pages/profile-setup.tsx
+++ b/pages/profile-setup.tsx
@@ -2,6 +2,7 @@ import { env } from "@/lib/env";
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { createClient } from '@supabase/supabase-js';
+import { useLocale } from '@/lib/locale';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Input } from '@/components/design-system/Input';
@@ -29,6 +30,7 @@ const PREFS = ['Listening','Reading','Writing','Speaking'];
 
 export default function ProfileSetup() {
   const router = useRouter();
+  const { t, setLocale } = useLocale();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -148,8 +150,8 @@ export default function ProfileSetup() {
         <Container>
           <div className="max-w-5xl mx-auto grid gap-6 lg:grid-cols-[1.2fr_.8fr]">
             <div>
-              <h1 className="font-slab text-display text-gradient-primary">Complete your profile</h1>
-              <p className="text-grayish mt-2">We’ll tune your study plan with AI and personalize your dashboard.</p>
+              <h1 className="font-slab text-display text-gradient-primary">{t('profileSetup.completeProfile')}</h1>
+              <p className="text-grayish mt-2">{t('profileSetup.description')}</p>
 
               {error && <Alert variant="error" title="Unable to save">{error}</Alert>}
               {notice && <Alert variant="success" title={notice} />}
@@ -213,7 +215,14 @@ export default function ProfileSetup() {
                     </label>
                   </div>
 
-                  <Select label="Preferred UI language" value={lang} onChange={e=>setLang(e.target.value)}>
+                  <Select
+                    label={t('profileSetup.preferredLanguage')}
+                    value={lang}
+                    onChange={e => {
+                      setLang(e.target.value);
+                      setLocale(e.target.value);
+                    }}
+                  >
                     <option value="en">English</option>
                     <option value="ur">Urdu</option>
                     <option value="ar">Arabic</option>
@@ -225,10 +234,10 @@ export default function ProfileSetup() {
 
                 <div className="mt-6 flex flex-wrap gap-3">
                   <Button onClick={()=>saveProfile(false)} disabled={saving} variant="secondary" className="rounded-ds-xl">
-                    {saving ? 'Saving…' : 'Save draft'}
+                    {saving ? 'Saving…' : t('profileSetup.saveDraft')}
                   </Button>
                   <Button onClick={()=>saveProfile(true)} disabled={saving || !canSubmit} variant="primary" className="rounded-ds-xl">
-                    {saving ? 'Saving…' : 'Finish & continue'}
+                    {saving ? 'Saving…' : t('profileSetup.finishContinue')}
                   </Button>
                 </div>
               </Card>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,15 @@
+{
+  "home": {
+    "title": "Welcome to GramorX"
+  },
+  "profileSetup": {
+    "completeProfile": "Complete your profile",
+    "description": "We’ll tune your study plan with AI and personalize your dashboard.",
+    "preferredLanguage": "Preferred UI language",
+    "saveDraft": "Save draft",
+    "finishContinue": "Finish & continue"
+  },
+  "userMenu": {
+    "language": "Language"
+  }
+}

--- a/public/locales/ur/common.json
+++ b/public/locales/ur/common.json
@@ -1,0 +1,15 @@
+{
+  "home": {
+    "title": "گرامور ایکس میں خوش آمدید"
+  },
+  "profileSetup": {
+    "completeProfile": "اپنی پروفائل مکمل کریں",
+    "description": "ہم آپ کے مطالعہ منصوبہ کو AI سے بہتر بنائیں گے اور آپ کے ڈیش بورڈ کو حسبِ ضرورت بنائیں گے۔",
+    "preferredLanguage": "ترجیحی زبان",
+    "saveDraft": "ڈرافٹ محفوظ کریں",
+    "finishContinue": "ختم کریں اور جاری رکھیں"
+  },
+  "userMenu": {
+    "language": "زبان"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple language context that loads JSON translations
- set locale from Supabase profile and allow switching in user menu
- translate home and profile setup pages with English and Urdu strings

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c0219348321ac0cc1d3d83d4e8f