### PR TITLE
Persist Supabase auth session after signup

### DIFF
--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -9,8 +9,10 @@ const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 const getClient = () =>
   createClient(url, anon, {
     auth: {
-      persistSession: false,
-      autoRefreshToken: false,
+      // Persist the auth session so that verification links
+      // and page reloads keep the user logged in.
+      persistSession: true,
+      autoRefreshToken: true,
       // keep default storageKey (sb-<project>-auth-token)
     },
   });

--- a/pages/profile-setup.tsx
+++ b/pages/profile-setup.tsx
@@ -1,7 +1,5 @@
-import { env } from "@/lib/env";
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
-import { createClient } from '@supabase/supabase-js';
 import { useLocale } from '@/lib/locale';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -10,18 +8,10 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { Select } from '@/components/design-system/Select';
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 
-/** Supabase browser client */
-const supabase = createClient(
-  env.NEXT_PUBLIC_SUPABASE_URL,
-  env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  {
-    auth: {
-      persistSession: false,
-      autoRefreshToken: false,
-    },
-  }
-);
+// Using the shared browser client ensures auth state is persisted
+// and reused across pages.
 
 const COUNTRIES = ['Pakistan','India','Bangladesh','United Arab Emirates','Saudi Arabia','United Kingdom','United States','Canada','Australia','New Zealand'];
 const LEVELS: Array<'Beginner'|'Elementary'|'Pre-Intermediate'|'Intermediate'|'Upper-Intermediate'|'Advanced'> = ['Beginner','Elementary','Pre-Intermediate','Intermediate','Upper-Intermediate','Advanced'];


### PR DESCRIPTION
## Summary
- ensure Supabase browser client stores and refreshes auth session
- use shared Supabase client on profile setup to maintain login state

## Testing
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' npm test`
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' npm run lint` *(fails: missing @typescript-eslint/no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3357901483219e525b1a43b8eb5e