### PR TITLE
fix: use dynamic viewport height

### DIFF
--- a/components/auth/RoleGuard.tsx
+++ b/components/auth/RoleGuard.tsx
@@ -35,7 +35,7 @@ export function RoleGuard({ allow, children }: Props) {
 
   if (ok === null) {
     return (
-      <div className="min-h-screen grid place-items-center">
+      <div className="min-h-[100dvh] grid place-items-center">
         <div className="animate-pulse h-6 w-40 rounded bg-gray-200 dark:bg-white/10" />
       </div>
     );

--- a/components/layouts/AuthLayout.tsx
+++ b/components/layouts/AuthLayout.tsx
@@ -31,7 +31,7 @@ export default function AuthLayout({
 }: Props) {
   const rightContent = right ?? rightIllustration ?? <DefaultRight />;
   return (
-    <div className="min-h-screen flex bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+    <div className="min-h-[100dvh] flex bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
       {/* Left: content */}
       <div className="flex flex-col justify-center w-full md:w-1/2 px-8 py-12">
         <div className="flex justify-between items-center mb-8">

--- a/pages/403.tsx
+++ b/pages/403.tsx
@@ -13,7 +13,7 @@ const ForbiddenPage: NextPage<Props> = () => {
       <Head>
         <title>403 — Forbidden</title>
       </Head>
-      <main className="min-h-screen flex items-center justify-center p-6">
+      <main className="min-h-[100dvh] flex items-center justify-center p-6">
         <div className="max-w-lg w-full text-center">
           <h1 className="text-4xl font-bold mb-2">403</h1>
           <p className="text-lg text-gray-600 dark:text-gray-300">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -48,7 +48,7 @@ const slab = Roboto_Slab({
 // Minimal loading shell for route guards
 function GuardSkeleton() {
   return (
-    <div className="min-h-screen grid place-items-center">
+    <div className="min-h-[100dvh] grid place-items-center">
       <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
     </div>
   );
@@ -220,7 +220,7 @@ function InnerApp({ Component, pageProps }: AppProps) {
       </Head>
 
       {/* Apply fonts to the whole app; DS uses var(--font-sans)/var(--font-display) */}
-      <div className={`${poppins.variable} ${slab.variable} ${poppins.className} min-h-screen`}>
+      <div className={`${poppins.variable} ${slab.variable} ${poppins.className} min-h-[100dvh]`}>
         <ToastProvider>
           {showLayout ? (
             <Layout>

--- a/pages/admin/imp-as.tsx
+++ b/pages/admin/imp-as.tsx
@@ -20,7 +20,7 @@ export default function ImpAs() {
   return (
     <>
       <Head><title>Switching…</title></Head>
-      <div className="min-h-screen grid place-items-center">
+      <div className="min-h-[100dvh] grid place-items-center">
         <div className="animate-pulse text-sm opacity-70">Switching to impersonated session…</div>
       </div>
     </>

--- a/pages/admin/premium/pin.tsx
+++ b/pages/admin/premium/pin.tsx
@@ -31,7 +31,7 @@ export default function AdminPremiumPin() {
   };
 
   return (
-    <main className="pr-min-h-screen pr-flex pr-items-center pr-justify-center pr-bg-gradient-to-b pr-from-black pr-to-neutral-900 pr-text-white pr-p-4">
+    <main className="pr-min-h-[100dvh] pr-flex pr-items-center pr-justify-center pr-bg-gradient-to-b pr-from-black pr-to-neutral-900 pr-text-white pr-p-4">
       <div className="pr-w-full pr-max-w-md pr-space-y-4 pr-rounded-xl pr-border pr-border-white/10 pr-bg-white/5 pr-backdrop-blur pr-p-6">
         <h1 className="pr-text-xl pr-font-semibold">Admin · Premium PIN</h1>
 

--- a/pages/admin/stop-impersonation.tsx
+++ b/pages/admin/stop-impersonation.tsx
@@ -20,7 +20,7 @@ export default function StopImpersonation() {
   return (
     <>
       <Head><title>Returning…</title></Head>
-      <div className="min-h-screen grid place-items-center">
+      <div className="min-h-[100dvh] grid place-items-center">
         <div className="animate-pulse text-sm opacity-70">Signing out and returning to Admin…</div>
       </div>
     </>

--- a/pages/forgot-password.tsx
+++ b/pages/forgot-password.tsx
@@ -37,7 +37,7 @@ const ForgotPassword: NextPage = () => {
       <Head>
         <title>Forgot Password</title>
       </Head>
-      <main className="min-h-screen flex items-center justify-center p-6">
+      <main className="min-h-[100dvh] flex items-center justify-center p-6">
         <div className="w-full max-w-md">
           <h1 className="text-2xl font-semibold mb-4">Reset your password</h1>
 

--- a/pages/premium/pin.tsx
+++ b/pages/premium/pin.tsx
@@ -50,7 +50,7 @@ export default function PremiumPinPage() {
         <title>Enter Premium PIN</title>
       </Head>
 
-      <main className="min-h-screen grid place-items-center bg-lightBg text-lightText dark:bg-gradient-to-br dark:from-darker dark:to-dark dark:text-white">
+      <main className="min-h-[100dvh] grid place-items-center bg-lightBg text-lightText dark:bg-gradient-to-br dark:from-darker dark:to-dark dark:text-white">
         <section className="w-full max-w-md mx-auto p-6">
           <div className="card-surface rounded-ds-2xl border border-purpleVibe/20 p-6 md:p-8 shadow-sm">
             <h1 className="font-slab text-h2 mb-2">Enter Premium PIN</h1>

--- a/premium-ui/theme/PremiumThemeProvider.tsx
+++ b/premium-ui/theme/PremiumThemeProvider.tsx
@@ -61,7 +61,7 @@ export function PremiumThemeProvider({ children, initialTheme }: Props) {
   return (
     <ThemeCtx.Provider value={value}>
       {/* wrapper can hold bg/surface classes for quick theming */}
-      <div className="pr min-h-screen bg-[var(--pr-bg)] text-[var(--pr-fg)]">
+      <div className="pr min-h-[100dvh] bg-[var(--pr-bg)] text-[var(--pr-fg)]">
         {children}
       </div>
     </ThemeCtx.Provider>


### PR DESCRIPTION
## Summary
- replace `min-h-screen` with `min-h-[100dvh]` across components and pages to support dynamic mobile viewport height

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, @next/next/no-html-link-for-pages, etc.)*
- `npm test` *(fails: Required env vars NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4558b5048321bdbb90d93a60ea14