### PR TITLE
Add viewport meta tag for responsive scaling

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- ensure mobile devices render at native scale by adding viewport meta tag in custom Document

## Testing
- `npm test` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY required)*

------
https://chatgpt.com/codex/tasks/task_e_68ae455239f483219dee3ff622c298bd