### PR TITLE
feat: add dimming overlay for AI sidebar

### DIFF
--- a/components/ai/SidebarAI.tsx
+++ b/components/ai/SidebarAI.tsx
@@ -427,11 +427,10 @@ import { useRouter } from 'next/router';
         </button>
       )}
 
-      {/* Outside click catcher (does NOT darken UI) */}
+      {/* Darkened overlay behind the sidebar */}
       {open && (
         <div
-          className="fixed z-[60]"
-          style={isMobile ? { left: 0, right: 0, top: 0, bottom: mHeight } : { left: 0, top: 0, bottom: 0, right: width }}
+          className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm"
           onClick={() => setOpen(false)}
           aria-hidden
         />


### PR DESCRIPTION
## Summary
- darken page behind the AI sidebar with a full-screen overlay that closes it on click

## Testing
- `npm test` *(fails: NEXT_PUBLIC_SUPABASE_URL required)*
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae48579e64832183382f830a36c4e7