### PR TITLE
feat: add markdown parser to SidebarAI

### DIFF
--- a/components/ai/SidebarAI.test.ts
+++ b/components/ai/SidebarAI.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { renderMarkdown } from './SidebarAI';
+
+function render(md: string) {
+  return renderToStaticMarkup(renderMarkdown(md));
+}
+
+// Plain text should render inside a paragraph
+let html = render('Hello world');
+assert(html.includes('<p>') && html.includes('Hello world'));
+
+// Bullet lists should be stripped to plain paragraphs
+html = render('* one\n- two\n1. three');
+assert(html.includes('<p>one</p>'));
+assert(html.includes('<p>two</p>'));
+assert(html.includes('<p>three</p>'));
+assert(!html.includes('<ul') && !html.includes('<ol'));
+
+// Code fences should render inside <pre><code> with language class
+html = render('```js\nconst x = 1;\n```');
+assert(html.includes('<pre'));
+assert(html.includes('const x = 1;'));
+assert(html.includes('language-js'));
+
+console.log('SidebarAI markdown tests passed.');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint",
     "pin:hash": "ts-node tools/hash-pin.ts",
     "diagnose": "powershell -ExecutionPolicy Bypass -File .\\\\tools\\\\report-build-issues.ps1",
-    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"verbatimModuleSyntax\":false}' node -r ts-node/register lib/routeAccess.test.ts"
+    "test": "NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"verbatimModuleSyntax\":false}' node -r ts-node/register lib/routeAccess.test.ts && NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"esnext\",\"verbatimModuleSyntax\":false,\"jsx\":\"react-jsx\"}' node --loader ts-node/esm components/ai/SidebarAI.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -30,10 +30,12 @@
     "openai": "^5.12.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-markdown": "^9.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "twilio": "^5.8.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.19.10",


### PR DESCRIPTION
## Summary
- replace ad-hoc renderer with `react-markdown` + `remark-gfm`
- strip list bullets while supporting code fences and language classes
- cover markdown rendering cases with new tests

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/GramorX/components/ai/SidebarAI.test.ts in a cycle)*


------
https://chatgpt.com/codex/tasks/task_e_68ae4864ae5883218b42d18184c95ec2