### PR TITLE
Handle microphone permission denial

### DIFF
--- a/components/ai/SidebarAI.tsx
+++ b/components/ai/SidebarAI.tsx
@@ -157,6 +157,7 @@ import { useRouter } from 'next/router';
   const [listening, setListening] = useState(false);
   const recRef = useRef<any>(null);
   const voiceSupported = typeof window !== 'undefined' && ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition);
+  const [voiceDenied, setVoiceDenied] = useState(false);
 
   // Refs
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -346,10 +347,11 @@ import { useRouter } from 'next/router';
   // Voice recognition (browser only)
   const startVoice = useCallback(() => {
     if (!voiceSupported) { setStatusNote('Voice input is not supported.'); setTimeout(() => setStatusNote(''), 1500); return; }
-    if (listening) return;
+    if (listening || voiceDenied) return;
     const SR: any = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
     const rec = new SR();
     rec.lang = 'en-US'; rec.interimResults = true; rec.maxAlternatives = 1;
+    let errored = false;
     rec.onstart = () => { setListening(true); setStatusNote('Listening…'); };
     let finalText = '';
     rec.onresult = (e: any) => {
@@ -361,10 +363,26 @@ import { useRouter } from 'next/router';
       const next = (finalText + ' ' + draft).trim();
       setInput(next);
     };
-    rec.onerror = () => { setListening(false); setStatus('error'); setStatusNote('Mic error.'); };
-    rec.onend = () => { setListening(false); setStatusNote(''); textareaRef.current?.focus(); };
+    rec.onerror = (e: any) => {
+      errored = true;
+      setListening(false);
+      setStatus('error');
+      if (e?.error === 'not-allowed') {
+        setStatusNote('Microphone access denied. Enable it in your browser settings.');
+        setVoiceDenied(true);
+        setTimeout(() => { setStatus('idle'); setStatusNote(''); }, 4000);
+      } else {
+        setStatusNote('Mic error.');
+        setTimeout(() => { setStatus('idle'); setStatusNote(''); }, 1500);
+      }
+    };
+    rec.onend = () => {
+      setListening(false);
+      if (!errored) setStatusNote('');
+      textareaRef.current?.focus();
+    };
     recRef.current = rec; rec.start();
-  }, [voiceSupported, listening]);
+  }, [voiceSupported, listening, voiceDenied]);
 
   const stopVoice = useCallback(() => { try { recRef.current?.stop(); } catch {} setListening(false); }, []);
   const toggleVoice = useCallback(() => { listening ? stopVoice() : startVoice(); }, [listening, startVoice, stopVoice]);
@@ -486,7 +504,12 @@ import { useRouter } from 'next/router';
               </div>
               <div className="mt-3 flex items-center justify-center gap-2">
                 <button onClick={newChat} className="text-caption rounded-full px-3 py-1 bg-card border border-border hover:bg-accent">New chat</button>
-                <button onClick={toggleVoice} disabled={!voiceSupported} className="text-caption rounded-full px-3 py-1 border border-border bg-card hover:bg-accent disabled:opacity-50" title={voiceSupported ? (listening ? 'Stop voice' : 'Speak') : 'Voice not supported'}>
+                <button
+                  onClick={toggleVoice}
+                  disabled={!voiceSupported || voiceDenied}
+                  className="text-caption rounded-full px-3 py-1 border border-border bg-card hover:bg-accent disabled:opacity-50"
+                  title={voiceSupported ? (voiceDenied ? 'Mic access denied' : listening ? 'Stop voice' : 'Speak') : 'Voice not supported'}
+                >
                   🎙 {listening ? 'Stop' : 'Speak'}
                 </button>
               </div>
@@ -521,9 +544,9 @@ import { useRouter } from 'next/router';
           <div className="flex items-end gap-2">
             <button
               onClick={toggleVoice}
-              disabled={!voiceSupported}
+              disabled={!voiceSupported || voiceDenied}
               className={`h-10 w-10 rounded-full border border-border ${listening ? 'bg-primary text-primary-foreground' : 'bg-card hover:bg-accent'} disabled:opacity-50`}
-              title={voiceSupported ? (listening ? 'Stop voice' : 'Speak') : 'Voice not supported'}
+              title={voiceSupported ? (voiceDenied ? 'Mic access denied' : listening ? 'Stop voice' : 'Speak') : 'Voice not supported'}
               aria-label="Voice input"
             >
               🎙


### PR DESCRIPTION
## Summary
- detect microphone permission errors in the AI sidebar
- show guidance when mic access is blocked and disable voice button
- clear error state after a timeout to restore idle UI

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=key npm test`
- `npm run lint` *(fails: React hooks rules errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae486651348321b23b1d257fd5437f