### PR TITLE
Consolidate AI sidebar split-screen styles

### DIFF
--- a/components/ai/SidebarAI.tsx
+++ b/components/ai/SidebarAI.tsx
@@ -210,24 +210,22 @@ import { useRouter } from 'next/router';
   useEffect(() => {
     if (!isBrowser) return;
     const root = document.documentElement;
-    const app = document.getElementById('__next');
-    if (!app) return;
     if (open) {
       if (isMobile) {
         root.classList.add('gx-ai-open-bottom');
         root.classList.remove('gx-ai-open');
-        app.style.paddingBottom = `${mHeight}px`;
-        app.style.paddingRight = '';
+        root.style.setProperty('--gx-ai-bottom', `${mHeight}px`);
+        root.style.setProperty('--gx-ai-right', '0px');
       } else {
         root.classList.add('gx-ai-open');
         root.classList.remove('gx-ai-open-bottom');
-        app.style.paddingRight = `${width}px`;
-        app.style.paddingBottom = '';
+        root.style.setProperty('--gx-ai-right', `${width}px`);
+        root.style.setProperty('--gx-ai-bottom', '0px');
       }
     } else {
       root.classList.remove('gx-ai-open', 'gx-ai-open-bottom');
-      app.style.paddingRight = '';
-      app.style.paddingBottom = '';
+      root.style.setProperty('--gx-ai-right', '0px');
+      root.style.setProperty('--gx-ai-bottom', '0px');
     }
   }, [open, width, mHeight, isMobile]);
 
@@ -550,14 +548,6 @@ import { useRouter } from 'next/router';
           </div>
         </div>
       </aside>
-
-      {/* Global split-screen helper classes (kept minimal) */}
-      <style jsx global>{`
-        html.gx-ai-open #__next { padding-right: var(--gx-ai-right); box-sizing: border-box; }
-        @media (max-width: 767px) {
-          html.gx-ai-open-bottom #__next { padding-bottom: var(--gx-ai-bottom); box-sizing: border-box; }
-        }
-      `}</style>
     </Fragment>
   );
  }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -193,15 +193,11 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
   @apply bg-vibrantPurple/10 text-lightText dark:text-white;
 }
 
-:root { --gx-ai-offset: 0px; }
+/* AI sidebar split view */
+:root { --gx-ai-right: 0px; --gx-ai-bottom: 0px; }
 
-/* Split view: push content left by the sidebar width */
-body.gx-ai-split {
-  padding-right: var(--gx-ai-offset);
-  transition: padding-right 300ms ease;
-}
-
-/* Don’t split on mobile */
+/* Push content when AI sidebar is open */
+html.gx-ai-open #__next { padding-right: var(--gx-ai-right); box-sizing: border-box; }
 @media (max-width: 767px) {
-  body.gx-ai-split { padding-right: 0; }
+  html.gx-ai-open-bottom #__next { padding-bottom: var(--gx-ai-bottom); box-sizing: border-box; }
 }


### PR DESCRIPTION
## Summary
- centralize AI sidebar split-screen rules in `globals.css`
- toggle html classes and CSS vars to shift content for desktop and mobile

## Testing
- `npm test` *(fails: NEXT_PUBLIC_SUPABASE_URL undefined)*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae486164e4832182dd08a2f8edd3b2