### PR TITLE
feat: add mood tracking and motivation coach

### DIFF
--- a/components/coach/MotivationCoach.tsx
+++ b/components/coach/MotivationCoach.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { Alert } from '@/components/design-system/Alert';
+import { useMood } from '@/hooks/useMood';
+
+export default function MotivationCoach() {
+  const { logs, reflection, loading, error, addDaily, addWeekly } = useMood();
+  const [mood, setMood] = useState(5);
+  const [energy, setEnergy] = useState(5);
+  const [weeklyText, setWeeklyText] = useState('');
+
+  const avgMood = logs.length ? logs.reduce((a, b) => a + b.mood, 0) / logs.length : null;
+  const avgEnergy = logs.length ? logs.reduce((a, b) => a + b.energy, 0) / logs.length : null;
+
+  const submitDaily = async () => {
+    try {
+      await addDaily(mood, energy);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const submitWeekly = async () => {
+    try {
+      if (weeklyText.trim()) {
+        await addWeekly(weeklyText.trim());
+        setWeeklyText('');
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h3 className="font-slab text-h3 mb-2">Motivation Coach</h3>
+      {loading ? (
+        <p className="text-body">Loading...</p>
+      ) : error ? (
+        <Alert variant="error" className="mt-2">{error}</Alert>
+      ) : (
+        <>
+          {avgMood !== null ? (
+            <p className="text-body mb-4">
+              Last 7 days avg mood {avgMood.toFixed(1)} / energy {avgEnergy?.toFixed(1)}
+            </p>
+          ) : (
+            <p className="text-body mb-4">No mood entries yet.</p>
+          )}
+          {reflection ? (
+            <p className="text-body mb-4 italic">{reflection.reflection}</p>
+          ) : null}
+          <div className="flex flex-col gap-2 mb-2">
+            <div className="flex gap-2 items-center">
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={mood}
+                onChange={(e) => setMood(Number(e.target.value))}
+                className="w-16 border p-1 rounded"
+                aria-label="mood"
+              />
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={energy}
+                onChange={(e) => setEnergy(Number(e.target.value))}
+                className="w-16 border p-1 rounded"
+                aria-label="energy"
+              />
+              <Button onClick={submitDaily} size="sm" variant="primary" className="rounded-ds-xl">
+                Log
+              </Button>
+            </div>
+            <div className="flex gap-2 items-center">
+              <input
+                type="text"
+                placeholder="Weekly reflection"
+                value={weeklyText}
+                onChange={(e) => setWeeklyText(e.target.value)}
+                className="flex-1 border p-1 rounded"
+              />
+              <Button onClick={submitWeekly} size="sm" variant="secondary" className="rounded-ds-xl">
+                Save
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/hooks/useMood.ts
+++ b/hooks/useMood.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type MoodLog = {
+  id: string;
+  entry_date: string;
+  mood: number;
+  energy: number;
+  note?: string | null;
+};
+
+export type WeeklyReflection = {
+  id: string;
+  week_start: string;
+  reflection: string;
+};
+
+export function useMood() {
+  const [logs, setLogs] = useState<MoodLog[]>([]);
+  const [reflection, setReflection] = useState<WeeklyReflection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const res = await fetch('/api/coach/mood');
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to load');
+      setLogs(json.logs || []);
+      setReflection(json.reflection || null);
+    } catch (e: any) {
+      setError(e.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const addDaily = useCallback(
+    async (mood: number, energy: number, note?: string) => {
+      const res = await fetch('/api/coach/mood', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'daily', mood, energy, note })
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to submit');
+      await load();
+    },
+    [load]
+  );
+
+  const addWeekly = useCallback(
+    async (reflectionText: string) => {
+      const res = await fetch('/api/coach/mood', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'weekly', reflection: reflectionText })
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to submit');
+      await load();
+    },
+    [load]
+  );
+
+  return { logs, reflection, loading, error, reload: load, addDaily, addWeekly };
+}

--- a/pages/api/coach/mood.ts
+++ b/pages/api/coach/mood.ts
@@ -1,0 +1,91 @@
+import { env } from '@/lib/env';
+import { createClient } from '@supabase/supabase-js';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+function getLastMonday(date: Date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
+  d.setDate(diff);
+  d.setHours(0,0,0,0);
+  return d;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const supabase = createClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: { Cookie: req.headers.cookie || '' } } }
+  );
+
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const since = new Date();
+    since.setDate(since.getDate() - 7);
+    const sinceStr = since.toISOString().split('T')[0];
+
+    const { data: logs, error: logsErr } = await supabase
+      .from('mood_logs')
+      .select('id, entry_date, mood, energy, note')
+      .eq('user_id', user.id)
+      .gte('entry_date', sinceStr)
+      .order('entry_date', { ascending: false });
+
+    const { data: reflection, error: reflErr } = await supabase
+      .from('weekly_reflections')
+      .select('id, week_start, reflection')
+      .eq('user_id', user.id)
+      .order('week_start', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (logsErr || reflErr) {
+      return res.status(500).json({ error: logsErr?.message || reflErr?.message });
+    }
+
+    return res.status(200).json({ logs: logs || [], reflection });
+  }
+
+  if (req.method === 'POST') {
+    const { type } = req.body;
+    if (type === 'daily') {
+      const { mood, energy, note, date } = req.body;
+      const { error } = await supabase
+        .from('mood_logs')
+        .insert({
+          user_id: user.id,
+          entry_date: date || new Date().toISOString().split('T')[0],
+          mood,
+          energy,
+          note
+        });
+      if (error) {
+        return res.status(500).json({ error: error.message });
+      }
+      return res.status(200).json({ success: true });
+    }
+    if (type === 'weekly') {
+      const { reflection, week_start } = req.body;
+      const ws = week_start || getLastMonday(new Date()).toISOString().split('T')[0];
+      const { error } = await supabase
+        .from('weekly_reflections')
+        .insert({
+          user_id: user.id,
+          week_start: ws,
+          reflection
+        });
+      if (error) {
+        return res.status(500).json({ error: error.message });
+      }
+      return res.status(200).json({ success: true });
+    }
+    return res.status(400).json({ error: 'Invalid type' });
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -17,6 +17,7 @@ import { useStreak } from '@/hooks/useStreak';
 import { getDayKeyInTZ } from '@/lib/streak';
 import StudyCalendar from '@/components/feature/StudyCalendar';
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
+import MotivationCoach from '@/components/coach/MotivationCoach';
 
 type AIPlan = {
   suggestedGoal?: number;
@@ -283,6 +284,11 @@ export default function Dashboard() {
               </Button>
             </div>
           </Card>
+        </div>
+
+        {/* Motivation coach */}
+        <div className="mt-10">
+          <MotivationCoach />
         </div>
 
         {/* Coach notes */}

--- a/supabase/migrations/20250901_mood_logs.sql
+++ b/supabase/migrations/20250901_mood_logs.sql
@@ -1,0 +1,34 @@
+-- Mood tracking tables
+
+create table if not exists public.mood_logs (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  entry_date date not null default current_date,
+  mood int check (mood between 1 and 10),
+  energy int check (energy between 1 and 10),
+  note text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.weekly_reflections (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  week_start date not null,
+  reflection text,
+  created_at timestamptz default now()
+);
+
+-- Row level security
+alter table public.mood_logs enable row level security;
+create policy "Users manage own mood_logs"
+  on public.mood_logs
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+alter table public.weekly_reflections enable row level security;
+create policy "Users manage own weekly_reflections"
+  on public.weekly_reflections
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase tables for mood logs and weekly reflections with RLS
- implement API endpoints and React hooks to log and retrieve mood data
- build MotivationCoach component and surface on dashboard

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/GramorX/components/ai/SidebarAI.test.ts in a cycle)*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50e1d92083219ce54835fdf260d1