### PR TITLE
feat: add streak recovery schedule

### DIFF
--- a/components/feature/StudyCalendar.tsx
+++ b/components/feature/StudyCalendar.tsx
@@ -4,7 +4,7 @@ import { useStreak } from '@/hooks/useStreak';
 import { getDayKeyInTZ } from '@/lib/streak';
 
 export const StudyCalendar: React.FC = () => {
-  const { current, lastDayKey, loading } = useStreak();
+  const { current, lastDayKey, loading, nextRestart } = useStreak();
 
   const days = useMemo(() => {
     const arr: { key: string; date: Date; completed: boolean }[] = [];
@@ -47,6 +47,11 @@ export const StudyCalendar: React.FC = () => {
           </div>
         ))}
       </div>
+      {nextRestart && (
+        <div className="mt-4 text-center text-sm text-muted-foreground">
+          Restart scheduled on {nextRestart}
+        </div>
+      )}
     </Card>
   );
 };

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -39,6 +39,7 @@ export const getDayKeyInTZ = (
 export type StreakData = {
   current_streak: number;
   last_activity_date: string | null;
+  next_restart_date?: string | null;
 };
 
 /** Fetch current streak for the logged-in user */
@@ -55,6 +56,7 @@ const handle = async (res: Response, fallbackMsg: string): Promise<StreakData> =
   return {
     current_streak: json?.current_streak ?? 0,
     last_activity_date: json?.last_activity_date ?? null,
+    next_restart_date: json?.next_restart_date ?? null,
   };
 };
 
@@ -74,6 +76,21 @@ export async function incrementStreak(): Promise<StreakData> {
   try {
     const res = await fetch('/api/streak', { method: 'POST' });
     return await handle(res, 'Failed to update streak');
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+/** Schedule a streak recovery and return the planned restart */
+export async function scheduleRecovery(date: string): Promise<StreakData> {
+  try {
+    const res = await fetch('/api/streak/recovery', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ date }),
+    });
+    return await handle(res, 'Failed to schedule recovery');
   } catch (e) {
     console.error(e);
     throw e;

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -45,12 +45,13 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<Profile | null>(null);
 
-  const {
-    current: streak,
-    lastDayKey,
-    loading: streakLoading,
-    completeToday,
-  } = useStreak();
+    const {
+      current: streak,
+      lastDayKey,
+      loading: streakLoading,
+      completeToday,
+      nextRestart,
+    } = useStreak();
 
   const handleShare = () => {
     const text = `I'm studying for IELTS on GramorX with a ${streak}-day streak!`;
@@ -159,24 +160,30 @@ export default function Dashboard() {
             <p className="text-grayish">Let’s hit your target band with a personalized plan.</p>
           </div>
 
-          <div className="flex items-center gap-4">
-            <StreakIndicator value={streak} />
-            {streak >= 7 && <Badge variant="success" size="sm">🔥 {streak}-day streak!</Badge>}
+        <div className="flex items-center gap-4">
+          <StreakIndicator value={streak} />
+          {streak >= 7 && <Badge variant="success" size="sm">🔥 {streak}-day streak!</Badge>}
 
-            {profile?.avatar_url ? (
-              <Image
-                src={profile.avatar_url}
-                alt="Avatar"
-                width={56}
-                height={56}
-                className="rounded-full ring-2 ring-primary/40"
-              />
-            ) : null}
-          </div>
+          {profile?.avatar_url ? (
+            <Image
+              src={profile.avatar_url}
+              alt="Avatar"
+              width={56}
+              height={56}
+              className="rounded-full ring-2 ring-primary/40"
+            />
+          ) : null}
         </div>
+      </div>
 
-        {/* Top summary cards */}
-        <div className="mt-10 grid gap-6 md:grid-cols-3">
+      {nextRestart && (
+        <Alert variant="info" className="mt-6">
+          Streak will restart on {nextRestart}.
+        </Alert>
+      )}
+
+      {/* Top summary cards */}
+      <div className="mt-10 grid gap-6 md:grid-cols-3">
           <Card className="p-6 rounded-ds-2xl">
             <div className="text-small opacity-70 mb-1">Goal Band</div>
             <div className="text-h1 font-semibold">

--- a/supabase/migrations/20250901_streak_recovery.sql
+++ b/supabase/migrations/20250901_streak_recovery.sql
@@ -1,0 +1,33 @@
+create table if not exists public.streak_recovery (
+  user_id uuid references auth.users(id) on delete cascade,
+  slip_date date not null,
+  restart_date date not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  primary key (user_id, slip_date)
+);
+
+alter table public.streak_recovery enable row level security;
+
+create policy "read own recovery" on public.streak_recovery
+for select to authenticated
+using (auth.uid() = user_id);
+
+create policy "upsert own recovery" on public.streak_recovery
+for insert with check (auth.uid() = user_id);
+
+create policy "update own recovery" on public.streak_recovery
+for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- trigger for updated_at (reuse function if already created)
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+drop trigger if exists trg_streak_recovery_updated on public.streak_recovery;
+create trigger trg_streak_recovery_updated
+before update on public.streak_recovery
+for each row execute procedure public.set_updated_at();


### PR DESCRIPTION
## Summary
- add migration to track streak recovery plans
- expose scheduleRecovery helper and hook state
- show upcoming restart info in study calendar and dashboard notice

## Testing
- `npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm run lint` *(fails: missing eslint rules and hook usage warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50e8e33c832185f91a17396dbf1f