### PR TITLE
feat: add accent mirror drills

### DIFF
--- a/components/speaking/AccentMirror.tsx
+++ b/components/speaking/AccentMirror.tsx
@@ -1,0 +1,60 @@
+// components/speaking/AccentMirror.tsx
+import React, { useEffect, useState } from 'react';
+import { Accent } from './AccentPicker';
+import MinimalPairs from './MinimalPairs';
+
+type AccentData = {
+  prompts: string[];
+  gaps: [string, string][];
+};
+
+export const AccentMirror: React.FC<{ accent: Accent }> = ({ accent }) => {
+  const [data, setData] = useState<AccentData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/speaking/accent-mirror?accent=${accent}`);
+        if (!res.ok) throw new Error('Failed to load prompts');
+        const json: AccentData = await res.json();
+        if (!ignore) setData(json);
+      } catch (e: any) {
+        if (!ignore) setError(e.message);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [accent]);
+
+  if (loading) return <p>Loading prompts...</p>;
+  if (error) return <p className="text-red-600">{error}</p>;
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-semibold mb-2">Alignment Prompts</h3>
+        <ul className="list-disc pl-5 space-y-1">
+          {data.prompts.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Gap Words</h3>
+        <MinimalPairs pairs={data.gaps} />
+      </div>
+    </div>
+  );
+};
+
+export default AccentMirror;

--- a/components/speaking/MinimalPairs.tsx
+++ b/components/speaking/MinimalPairs.tsx
@@ -1,0 +1,23 @@
+// components/speaking/MinimalPairs.tsx
+import React from 'react';
+
+export type MinimalPairsProps = {
+  pairs: [string, string][];
+};
+
+export const MinimalPairs: React.FC<MinimalPairsProps> = ({ pairs }) => {
+  if (!pairs?.length) return null;
+  return (
+    <ul className="grid gap-2">
+      {pairs.map(([a, b], idx) => (
+        <li key={idx} className="flex items-center gap-2">
+          <span className="font-medium">{a}</span>
+          <span className="opacity-60">/</span>
+          <span className="font-medium">{b}</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default MinimalPairs;

--- a/pages/api/speaking/accent-mirror.ts
+++ b/pages/api/speaking/accent-mirror.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Simple static dataset of prompts and minimal pair gap words for accent alignment
+const DATA: Record<string, { prompts: string[]; gaps: [string, string][] }> = {
+  US: {
+    prompts: [
+      'Repeat after me: The car is parked far from the bar.',
+      'Practice the rhotic R sound: Brother, father, and farmer.',
+    ],
+    gaps: [
+      ['cot', 'caught'],
+      ['bitter', 'bidder'],
+      ['ship', 'sheep'],
+    ],
+  },
+  UK: {
+    prompts: [
+      'Mind the R: The car is parked far from the bar.',
+      'Focus on non-rhotic endings: The teacher saw her.',
+    ],
+    gaps: [
+      ['spa', 'spar'],
+      ['caught', 'cot'],
+      ['full', 'fool'],
+    ],
+  },
+  AUS: {
+    prompts: [
+      'Flatten vowels: The cat sat on the mat.',
+      'Practice rising intonation: Are you coming today?',
+    ],
+    gaps: [
+      ['dawn', 'don'],
+      ['cart', 'cut'],
+      ['ferry', 'fairy'],
+    ],
+  },
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const accent = String((req.method === 'GET' ? req.query.accent : req.body.accent) || 'US').toUpperCase();
+  const data = DATA[accent] || DATA.US;
+  res.status(200).json({ accent, prompts: data.prompts, gaps: data.gaps });
+}
+

--- a/pages/speaking/practice.tsx
+++ b/pages/speaking/practice.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { Container } from '@/components/design-system/Container';
 import Recorder, { RecorderHandle } from '@/components/speaking/Recorder';
+import { AccentPicker, Accent } from '@/components/speaking/AccentPicker';
+import AccentMirror from '@/components/speaking/AccentMirror';
 
 // ---------- Modes & Focus ----------
 type Mode = 'part1' | 'part2' | 'part3';
@@ -230,6 +232,7 @@ export default function SpeakingPracticePage() {
   }, [bank]);
 
   const recRef = useRef<RecorderHandle | null>(null);
+  const [accent, setAccent] = useState<Accent>('US');
 
   const [ttsOn, setTtsOn] = useState(true);
   const [stage, setStage] = useState<Stage>('idle');
@@ -596,6 +599,15 @@ export default function SpeakingPracticePage() {
               </ul>
             </div>
           </div>
+        </div>
+
+        {/* Accent Mirror personalized drills */}
+        <div className="mt-12">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Accent Mirror</h2>
+            <AccentPicker value={accent} onChange={setAccent} />
+          </div>
+          <AccentMirror accent={accent} />
         </div>
       </Container>
     </>


### PR DESCRIPTION
## Summary
- add `/api/speaking/accent-mirror` endpoint returning alignment prompts and gap words
- implement `MinimalPairs` and `AccentMirror` components for accent drills
- embed accent mirror section in speaking practice page with accent picker

## Testing
- `npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm run lint` *(fails: missing ESLint rules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50f669ac8321a4d87ea5ffec6daf