### PR TITLE
Add exam rehearsal tools and scheduling API

### DIFF
--- a/components/exam/AnxietyScripts.tsx
+++ b/components/exam/AnxietyScripts.tsx
@@ -1,0 +1,21 @@
+import { Card } from '@/components/design-system/Card';
+
+const scripts = [
+  'Take a deep breath and focus on the present task.',
+  'Remember, this rehearsal is for practice and learning.',
+  'If you make a mistake, note it and move on—perfection is not the goal today.',
+];
+
+export default function AnxietyScripts() {
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl mb-6">
+      <h2 className="font-slab text-h2 mb-2">Anxiety Scripts</h2>
+      <p className="mb-4 text-grayish">Read these prompts aloud to calm nerves before the exam.</p>
+      <ul className="list-disc pl-5 space-y-2">
+        {scripts.map((s, i) => (
+          <li key={i}>{s}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/components/exam/DeviceCheck.tsx
+++ b/components/exam/DeviceCheck.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+
+export default function DeviceCheck() {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const checkMic = async () => {
+    try {
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+      setStatus('Microphone access granted.');
+    } catch (err) {
+      setStatus('Microphone access denied.');
+    }
+  };
+
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl mb-6">
+      <h2 className="font-slab text-h2 mb-2">Device &amp; Mic Check</h2>
+      <p className="mb-4 text-grayish">Ensure your microphone works before the exam.</p>
+      <Button onClick={checkMic} variant="primary" className="mb-3">
+        Check Microphone
+      </Button>
+      {status && <p className="text-small">{status}</p>}
+    </Card>
+  );
+}

--- a/components/exam/ExamChecklist.tsx
+++ b/components/exam/ExamChecklist.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Checkbox } from '@/components/design-system/Checkbox';
+
+const items = [
+  { id: 'id', label: 'Photo ID ready' },
+  { id: 'headphones', label: 'Headphones connected' },
+  { id: 'internet', label: 'Stable internet connection' },
+];
+
+export default function ExamChecklist() {
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl mb-6">
+      <h2 className="font-slab text-h2 mb-2">Exam Day Checklist</h2>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id}>
+            <Checkbox
+              label={item.label}
+              checked={!!checked[item.id]}
+              onChange={() => toggle(item.id)}
+            />
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/components/exam/TimingRehearsal.tsx
+++ b/components/exam/TimingRehearsal.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { Input } from '@/components/design-system/Input';
+import { Timer } from '@/components/design-system/Timer';
+
+export default function TimingRehearsal() {
+  const [minutes, setMinutes] = useState(2);
+  const [running, setRunning] = useState(false);
+  const [startSec, setStartSec] = useState(120);
+
+  const startTimer = async () => {
+    const m = Math.max(1, minutes);
+    setStartSec(m * 60);
+    setRunning(true);
+    try {
+      await fetch('/api/exam/schedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minutes: m }),
+      });
+    } catch (e) {
+      // ignore network errors
+    }
+  };
+
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl mb-6">
+      <h2 className="font-slab text-h2 mb-2">Timing Rehearsal</h2>
+      <p className="mb-4 text-grayish">Practice with a countdown timer to simulate exam pressure.</p>
+      <div className="flex items-end gap-3 mb-4">
+        <Input
+          type="number"
+          label="Minutes"
+          value={minutes}
+          min={1}
+          onChange={(e) => setMinutes(parseInt(e.target.value || '1', 10))}
+          className="w-24"
+        />
+        <Button variant="primary" onClick={startTimer} disabled={running}>
+          Start
+        </Button>
+        {running && (
+          <Button variant="secondary" onClick={() => setRunning(false)}>
+            Stop
+          </Button>
+        )}
+      </div>
+      {running && <Timer initialSeconds={startSec} mode="countdown" running={running} onComplete={() => setRunning(false)} />}
+    </Card>
+  );
+}

--- a/pages/api/exam/schedule.ts
+++ b/pages/api/exam/schedule.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+const InSchema = z.object({ minutes: z.number().min(1).max(300) });
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const parsed = InSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body' });
+  }
+
+  const { minutes } = parsed.data;
+  const start = Date.now();
+  const end = start + minutes * 60 * 1000;
+
+  return res.status(200).json({ start, end });
+}

--- a/pages/exam/rehearsal.tsx
+++ b/pages/exam/rehearsal.tsx
@@ -1,0 +1,19 @@
+import DeviceCheck from '@/components/exam/DeviceCheck';
+import TimingRehearsal from '@/components/exam/TimingRehearsal';
+import AnxietyScripts from '@/components/exam/AnxietyScripts';
+import ExamChecklist from '@/components/exam/ExamChecklist';
+import { Container } from '@/components/design-system/Container';
+
+export default function ExamRehearsalPage() {
+  return (
+    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+      <Container>
+        <h1 className="font-slab text-h1 mb-8">Exam Rehearsal</h1>
+        <DeviceCheck />
+        <TimingRehearsal />
+        <AnxietyScripts />
+        <ExamChecklist />
+      </Container>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce exam rehearsal page with device check, timing rehearsal, anxiety scripts, and checklist
- add reusable components for exam preparation
- provide `/api/exam/schedule` endpoint for timed practice runs

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae51e910e48321b54a83ea8f39d593