### PR TITLE
feat: add study buddy matching

### DIFF
--- a/components/speaking/StudyBuddyMatch.tsx
+++ b/components/speaking/StudyBuddyMatch.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/design-system/Button';
+import { Input } from '@/components/design-system/Input';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+export const buddyPrompts = {
+  warmups: [
+    'Introduce yourself to your partner.',
+    'Share why you are preparing for IELTS.',
+  ],
+  topics: [
+    'Describe your hometown to your buddy.',
+    'Talk about a hobby you enjoy.',
+    'Explain a recent challenge you overcame.',
+  ],
+};
+
+export default function StudyBuddyMatch() {
+  const [timezone, setTimezone] = useState('');
+  const [goalBand, setGoalBand] = useState('');
+  const [status, setStatus] = useState('');
+  const [buddyId, setBuddyId] = useState<string | null>(null);
+
+  async function handleMatch() {
+    setStatus('Matching...');
+    const { data: { session } } = await supabaseBrowser.auth.getSession();
+    const res = await fetch('/api/buddy/match', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+      },
+      body: JSON.stringify({ timezone, goalBand: Number(goalBand) }),
+    });
+    const body = await res.json();
+    if (res.ok) {
+      if (body.matched) {
+        setBuddyId(body.buddyId);
+        setStatus('Matched! Start your practice.');
+      } else {
+        setStatus('Waiting for a buddy...');
+      }
+    } else {
+      setStatus(body.error || 'Error matching');
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h2 className="text-h2">Study Buddy</h2>
+      <p className="mt-2 text-grayish">Find a partner with similar goals and timezone.</p>
+      <div className="mt-4 flex flex-col gap-3">
+        <Input placeholder="Timezone" value={timezone} onChange={e => setTimezone(e.target.value)} />
+        <Input placeholder="Goal Band" value={goalBand} onChange={e => setGoalBand(e.target.value)} />
+        <Button onClick={handleMatch} className="rounded-ds-xl">Match</Button>
+      </div>
+      {status && <p className="mt-4">{status}</p>}
+      {buddyId && (
+        <div className="mt-6">
+          <h3 className="text-h3 mb-2">Prompt ideas</h3>
+          <ul className="list-disc ml-5 space-y-1">
+            {buddyPrompts.warmups.concat(buddyPrompts.topics).map(p => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/api/buddy/match.ts
+++ b/pages/api/buddy/match.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabaseFromRequest } from '@/lib/apiAuth';
+import { supabaseService } from '@/lib/supabaseService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { timezone, goalBand } = (req.body || {}) as { timezone?: string; goalBand?: number };
+  if (!timezone || !goalBand) {
+    return res.status(400).json({ error: 'Missing timezone or goalBand' });
+  }
+
+  const authed = supabaseFromRequest(req);
+  const { data: userData, error: userErr } = await authed.auth.getUser();
+  if (userErr || !userData?.user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const userId = userData.user.id;
+
+  // Try to find a waiting buddy
+  const { data: match } = await supabaseService
+    .from('study_buddies')
+    .select('id, user_id')
+    .eq('timezone', timezone)
+    .eq('goal_band', goalBand)
+    .is('buddy_id', null)
+    .neq('user_id', userId)
+    .order('created_at')
+    .limit(1)
+    .maybeSingle();
+
+  if (match) {
+    await supabaseService
+      .from('study_buddies')
+      .update({ buddy_id: userId, status: 'matched', matched_at: new Date().toISOString() })
+      .eq('id', match.id);
+    return res.status(200).json({ matched: true, buddyId: match.user_id });
+  }
+
+  // Otherwise, insert this user as waiting
+  await supabaseService.from('study_buddies').insert({
+    user_id: userId,
+    timezone,
+    goal_band: goalBand,
+    status: 'waiting'
+  });
+
+  return res.status(200).json({ matched: false });
+}

--- a/pages/speaking/buddy.tsx
+++ b/pages/speaking/buddy.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Container } from '@/components/design-system/Container';
+import StudyBuddyMatch from '@/components/speaking/StudyBuddyMatch';
+
+export default function SpeakingBuddyPage() {
+  return (
+    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+      <Container>
+        <StudyBuddyMatch />
+      </Container>
+    </section>
+  );
+}

--- a/supabase/migrations/20250901_study_buddies.sql
+++ b/supabase/migrations/20250901_study_buddies.sql
@@ -1,0 +1,21 @@
+create table if not exists public.study_buddies (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  buddy_id uuid references auth.users(id) on delete set null,
+  timezone text not null,
+  goal_band numeric(2,1) check (goal_band between 4.0 and 9.0),
+  status text not null default 'waiting',
+  matched_at timestamptz,
+  created_at timestamptz default now()
+);
+
+alter table public.study_buddies enable row level security;
+
+create policy "manage own study_buddy" on public.study_buddies
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "view paired study_buddy" on public.study_buddies
+for select
+using (auth.uid() = buddy_id);


### PR DESCRIPTION
## Summary
- store study buddy matches in new Supabase table
- match users by timezone and goal band
- add UI with prompts for pairing

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68ae51e91b80832183aa1fdc6a208dfb