### PR TITLE
feat: add mistakes book with spaced repetition

### DIFF
--- a/components/mistakes/MistakeCard.tsx
+++ b/components/mistakes/MistakeCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+
+export type Mistake = {
+  id: string;
+  mistake: string;
+  correction: string | null;
+  type: string;
+  next_review: string | null;
+  repetitions: number;
+};
+
+export type MistakeCardProps = {
+  mistake: Mistake;
+  onReview: (id: string, repetitions: number) => void;
+};
+
+export const MistakeCard: React.FC<MistakeCardProps> = ({ mistake, onReview }) => {
+  const next = mistake.next_review
+    ? new Date(mistake.next_review).toLocaleDateString()
+    : 'today';
+
+  return (
+    <Card className="p-4 rounded-ds-2xl">
+      <div className="font-medium">{mistake.mistake}</div>
+      {mistake.correction && (
+        <div className="text-sm text-gray-600 dark:text-grayish mt-1">
+          Correct: {mistake.correction}
+        </div>
+      )}
+      <div className="text-xs text-gray-600 dark:text-grayish mt-2">
+        Next review: {next}
+      </div>
+      <Button
+        size="sm"
+        variant="secondary"
+        className="mt-3 rounded-ds"
+        onClick={() => onReview(mistake.id, mistake.repetitions)}
+      >
+        Mark reviewed
+      </Button>
+    </Card>
+  );
+};
+
+export default MistakeCard;

--- a/lib/spacedRepetition.ts
+++ b/lib/spacedRepetition.ts
@@ -1,0 +1,13 @@
+const intervals = [1, 3, 7, 14, 30];
+
+/**
+ * Returns the next review date given the number of completed repetitions.
+ * The interval grows over time following a simple spaced repetition sequence.
+ */
+export function scheduleReview(repetitions: number): Date {
+  const idx = Math.min(repetitions, intervals.length - 1);
+  const days = intervals[idx];
+  const next = new Date();
+  next.setDate(next.getDate() + days);
+  return next;
+}

--- a/pages/api/mistakes/index.ts
+++ b/pages/api/mistakes/index.ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabase = createClient(url, anon, {
+    global: { headers: { Cookie: req.headers.cookie || '' } },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('mistakes_book')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('next_review', { ascending: true });
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json(data);
+  }
+
+  if (req.method === 'POST') {
+    const { mistake, correction, type } = req.body as {
+      mistake?: string; correction?: string; type?: string;
+    };
+    if (!mistake) {
+      return res.status(400).json({ error: 'Missing mistake' });
+    }
+    const { data, error } = await supabase
+      .from('mistakes_book')
+      .insert({ user_id: user.id, mistake, correction, type })
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(201).json(data);
+  }
+
+  if (req.method === 'PUT') {
+    const { id, ...fields } = req.body as { id?: string; [key: string]: any };
+    if (!id) {
+      return res.status(400).json({ error: 'Missing id' });
+    }
+    const { data, error } = await supabase
+      .from('mistakes_book')
+      .update(fields)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json(data);
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.body as { id?: string };
+    if (!id) {
+      return res.status(400).json({ error: 'Missing id' });
+    }
+    const { error } = await supabase
+      .from('mistakes_book')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', 'GET,POST,PUT,DELETE');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/mistakes/index.tsx
+++ b/pages/mistakes/index.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+import { Container } from '@/components/design-system/Container';
+import { Input } from '@/components/design-system/Input';
+import { Textarea } from '@/components/design-system/Textarea';
+import { Select } from '@/components/design-system/Select';
+import { Button } from '@/components/design-system/Button';
+import MistakeCard, { Mistake } from '@/components/mistakes/MistakeCard';
+import { scheduleReview } from '@/lib/spacedRepetition';
+
+export default function MistakesPage() {
+  const [mistakes, setMistakes] = useState<Mistake[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState({ mistake: '', correction: '', type: 'grammar' });
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/mistakes');
+        if (!active) return;
+        if (res.ok) {
+          const data = await res.json();
+          setMistakes(data as Mistake[]);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, []);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.mistake) return;
+    const res = await fetch('/api/mistakes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setMistakes((m) => [data as Mistake, ...m]);
+      setForm({ mistake: '', correction: '', type: 'grammar' });
+    }
+  };
+
+  const handleReview = async (id: string, reps: number) => {
+    const next = scheduleReview(reps + 1).toISOString();
+    const res = await fetch('/api/mistakes', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, repetitions: reps + 1, next_review: next }),
+    });
+    if (res.ok) {
+      setMistakes((arr) =>
+        arr.map((m) => (m.id === id ? { ...m, repetitions: reps + 1, next_review: next } : m)),
+      );
+    }
+  };
+
+  return (
+    <Container className="py-10">
+      <h1 className="font-slab text-h2 mb-6">Mistakes Book</h1>
+      <form onSubmit={submit} className="grid gap-4 mb-8 max-w-xl">
+        <Input
+          label="Mistake"
+          value={form.mistake}
+          onChange={(e) => setForm({ ...form, mistake: e.target.value })}
+          required
+        />
+        <Textarea
+          label="Correction"
+          value={form.correction}
+          onChange={(e) => setForm({ ...form, correction: e.target.value })}
+        />
+        <div className="flex gap-2 items-end">
+          <Select
+            label="Type"
+            value={form.type}
+            onChange={(e) => setForm({ ...form, type: e.target.value })}
+            options={[
+              { value: 'grammar', label: 'Grammar' },
+              { value: 'vocab', label: 'Vocabulary' },
+            ]}
+            className="flex-1"
+          />
+          <Button type="submit" className="rounded-ds self-end">
+            Add
+          </Button>
+        </div>
+      </form>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="grid gap-4">
+          {mistakes.map((m) => (
+            <MistakeCard key={m.id} mistake={m} onReview={handleReview} />
+          ))}
+        </div>
+      )}
+    </Container>
+  );
+}

--- a/supabase/migrations/20250901_mistakes_book.sql
+++ b/supabase/migrations/20250901_mistakes_book.sql
@@ -1,0 +1,24 @@
+create table if not exists public.mistakes_book (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  mistake text not null,
+  correction text,
+  type text check (type in ('grammar','vocab')) default 'grammar',
+  repetitions integer default 0,
+  next_review timestamptz default now(),
+  created_at timestamptz default now()
+);
+
+alter table public.mistakes_book enable row level security;
+
+create policy "select own mistakes" on public.mistakes_book
+  for select using (auth.uid() = user_id);
+
+create policy "insert own mistakes" on public.mistakes_book
+  for insert with check (auth.uid() = user_id);
+
+create policy "update own mistakes" on public.mistakes_book
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy "delete own mistakes" on public.mistakes_book
+  for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase migration for `mistakes_book` table with RLS policies
- implement `/api/mistakes` CRUD API
- create mistakes page, card component, and spaced repetition scheduler

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68ae51e9e2f0832193e506d68d897c3a