### PR TITLE
feat: add progress share links

### DIFF
--- a/components/dashboard/ShareLinkCard.tsx
+++ b/components/dashboard/ShareLinkCard.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+
+export function ShareLinkCard() {
+  const [token, setToken] = React.useState<string | null>(null);
+  const [link, setLink] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const generate = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/progress/share', { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setToken(data.token);
+        const base =
+          process.env.NEXT_PUBLIC_BASE_URL ||
+          (typeof window !== 'undefined' ? window.location.origin : '');
+        setLink(`${base}/progress/${data.token}`);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copy = async () => {
+    if (!link) return;
+    try {
+      await navigator.clipboard.writeText(link);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h2 className="font-slab text-h2 mb-4">Share progress</h2>
+      {token ? (
+        <div className="flex items-center gap-2">
+          <input
+            readOnly
+            value={link}
+            className="flex-1 rounded border p-2 bg-transparent text-sm"
+          />
+          <Button onClick={copy} variant="secondary" className="rounded-ds-xl">
+            Copy
+          </Button>
+        </div>
+      ) : (
+        <Button
+          onClick={generate}
+          variant="primary"
+          className="rounded-ds-xl"
+          disabled={loading}
+        >
+          {loading ? 'Generating...' : 'Generate link'}
+        </Button>
+      )}
+    </Card>
+  );
+}
+
+export default ShareLinkCard;

--- a/pages/api/progress/share.ts
+++ b/pages/api/progress/share.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const supabase = createClient(
+      env.NEXT_PUBLIC_SUPABASE_URL,
+      env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      { global: { headers: { Cookie: req.headers.cookie || '' } } }
+    );
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const { data, error } = await supabaseAdmin
+      .from('progress_share_links')
+      .insert({ user_id: user.id })
+      .select('token')
+      .single();
+
+    if (error) return res.status(500).json({ error: error.message });
+
+    return res.status(200).json({ token: data.token });
+  }
+
+  if (req.method === 'GET') {
+    const token = req.query.token;
+    if (typeof token !== 'string') {
+      return res.status(400).json({ error: 'Token required' });
+    }
+
+    const { data: link, error } = await supabaseAdmin
+      .from('progress_share_links')
+      .select('user_id')
+      .eq('token', token)
+      .maybeSingle();
+
+    if (error) return res.status(500).json({ error: error.message });
+    if (!link) return res.status(404).json({ error: 'Invalid token' });
+
+    const { data: reading } = await supabaseAdmin
+      .from('reading_user_stats')
+      .select('attempts,total_score,total_max,accuracy_pct,avg_duration_ms,last_attempt_at')
+      .eq('user_id', link.user_id)
+      .maybeSingle();
+
+    return res.status(200).json({ user_id: link.user_id, reading });
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/pages/progress/[token].tsx
+++ b/pages/progress/[token].tsx
@@ -1,0 +1,78 @@
+import { GetServerSideProps } from 'next';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+
+interface Props {
+  reading: {
+    attempts: number;
+    total_score: number;
+    total_max: number;
+    accuracy_pct: number | null;
+    avg_duration_ms: number | null;
+    last_attempt_at: string | null;
+  } | null;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ params }) => {
+  const token = params?.token;
+  if (typeof token !== 'string') return { notFound: true };
+
+  const { data: link } = await supabaseAdmin
+    .from('progress_share_links')
+    .select('user_id')
+    .eq('token', token)
+    .maybeSingle();
+
+  if (!link) {
+    return { notFound: true };
+  }
+
+  const { data: reading } = await supabaseAdmin
+    .from('reading_user_stats')
+    .select('attempts,total_score,total_max,accuracy_pct,avg_duration_ms,last_attempt_at')
+    .eq('user_id', link.user_id)
+    .maybeSingle();
+
+  return {
+    props: {
+      reading: reading ?? null,
+    },
+  };
+};
+
+export default function PublicProgress({ reading }: Props) {
+  return (
+    <section className="py-10">
+      <Container>
+        <Card className="p-6 rounded-ds-2xl">
+          <h1 className="font-slab text-h2 mb-4">Reading progress</h1>
+          {reading ? (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div>
+                <div className="text-sm text-gray-600 dark:text-grayish">Attempts</div>
+                <div className="text-xl font-semibold">{reading.attempts}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-600 dark:text-grayish">Points</div>
+                <div className="text-xl font-semibold">{reading.total_score}/{reading.total_max}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-600 dark:text-grayish">Accuracy</div>
+                <div className="text-xl font-semibold">{reading.accuracy_pct ?? '—'}%</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-600 dark:text-grayish">Last attempt</div>
+                <div className="text-xl font-semibold">
+                  {reading.last_attempt_at ? new Date(reading.last_attempt_at).toLocaleDateString() : '—'}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p>No progress found.</p>
+          )}
+        </Card>
+      </Container>
+    </section>
+  );
+}

--- a/supabase/migrations/20250831_progress_share_links.sql
+++ b/supabase/migrations/20250831_progress_share_links.sql
@@ -1,0 +1,26 @@
+-- Create table for progress share links
+create table if not exists public.progress_share_links (
+  token uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+-- Enable RLS
+alter table public.progress_share_links enable row level security;
+
+-- Allow users to manage their own links
+create policy "Users can insert own share links"
+  on public.progress_share_links for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can view own share links"
+  on public.progress_share_links for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+-- Allow anonymous read access by token
+create policy "Anonymous access to share links"
+  on public.progress_share_links for select
+  to anon
+  using (true);


### PR DESCRIPTION
## Summary
- create migration and table for progress share tokens
- issue and validate share tokens via API
- share link UI card and public progress page

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68ae51f04b2483218c4f72c342381c82