### PR TITLE
feat: add whatsapp opt-in and messaging

### DIFF
--- a/components/dashboard/WhatsAppOptIn.tsx
+++ b/components/dashboard/WhatsAppOptIn.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { Card } from "@/components/design-system/Card";
+import { Input } from "@/components/design-system/Input";
+import { Button } from "@/components/design-system/Button";
+
+export function WhatsAppOptIn() {
+  const [phone, setPhone] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch("/api/whatsapp/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError((j as any)?.error || "Request failed");
+        setStatus("error");
+        return;
+      }
+      setStatus("success");
+    } catch (err: any) {
+      setError(err?.message || "Request failed");
+      setStatus("error");
+    }
+  };
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h2 className="font-slab text-h2 mb-4">WhatsApp updates</h2>
+      {status === "success" ? (
+        <p className="text-sm text-gray-600 dark:text-grayish">
+          You're subscribed to WhatsApp reminders.
+        </p>
+      ) : (
+        <form onSubmit={onSubmit} className="grid gap-4 sm:flex sm:items-end">
+          <Input
+            label="Phone number"
+            placeholder="+14155552671"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            className="sm:flex-1"
+            error={error || undefined}
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            className="rounded-ds-xl"
+            disabled={status === "loading"}
+          >
+            {status === "loading" ? "Submitting..." : "Subscribe"}
+          </Button>
+        </form>
+      )}
+    </Card>
+  );
+}
+
+export default WhatsAppOptIn;

--- a/pages/api/whatsapp/subscribe.ts
+++ b/pages/api/whatsapp/subscribe.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+import Twilio from "twilio";
+import { env } from "@/lib/env";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const { phone } = req.body as { phone?: string };
+  if (!phone) return res.status(400).json({ error: "Phone required" });
+
+  const supabase = createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY, {
+    global: { headers: { Cookie: req.headers.cookie || "" } },
+  });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+  const { error } = await supabase
+    .from("whatsapp_optin")
+    .upsert({ user_id: user.id, phone, opted_in: true });
+  if (error) return res.status(500).json({ error: error.message });
+
+  try {
+    const client = Twilio(process.env.TWILIO_ACCOUNT_SID!, process.env.TWILIO_AUTH_TOKEN!);
+    await client.messages.create({
+      to: `whatsapp:${phone}`,
+      from: `whatsapp:${process.env.TWILIO_WHATSAPP_FROM}`,
+      body: "Thanks for subscribing to GramorX WhatsApp updates! Reply STOP to unsubscribe.",
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("[whatsapp subscribe] twilio", e);
+  }
+
+  return res.status(200).json({ success: true });
+}

--- a/pages/api/whatsapp/webhook.ts
+++ b/pages/api/whatsapp/webhook.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import Twilio from "twilio";
+import { createClient } from "@supabase/supabase-js";
+
+const {
+  TWILIO_AUTH_TOKEN,
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = process.env;
+
+const supa = createClient(NEXT_PUBLIC_SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!);
+
+export const config = { api: { bodyParser: true } };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const signature = req.headers["x-twilio-signature"] as string | undefined;
+  const url = `${process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"}/api/whatsapp/webhook`;
+  const valid = Twilio.validateRequest(TWILIO_AUTH_TOKEN!, signature || "", url, req.body);
+  if (!valid) return res.status(403).end("Invalid Twilio signature");
+
+  const body = req.body as Record<string, string>;
+  const from = body.From?.replace("whatsapp:", "") ?? "";
+  const msg = body.Body?.trim().toLowerCase();
+
+  if (msg === "stop" || msg === "unsubscribe") {
+    await supa.from("whatsapp_optin").delete().eq("phone", from);
+  }
+
+  res.setHeader("Content-Type", "text/xml");
+  res.status(200).send("<Response></Response>");
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,3 @@
+[functions.whatsapp-broadcast]
+verify_jwt = false
+schedule = "0 9 * * *"

--- a/supabase/functions/whatsapp-broadcast/index.ts
+++ b/supabase/functions/whatsapp-broadcast/index.ts
@@ -1,0 +1,34 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const TWILIO_ACCOUNT_SID = Deno.env.get("TWILIO_ACCOUNT_SID")!;
+const TWILIO_AUTH_TOKEN = Deno.env.get("TWILIO_AUTH_TOKEN")!;
+const TWILIO_WHATSAPP_FROM = Deno.env.get("TWILIO_WHATSAPP_FROM")!;
+
+Deno.serve(async () => {
+  const client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { data } = await client.from("whatsapp_optin").select("phone");
+
+  for (const row of data ?? []) {
+    const params = new URLSearchParams({
+      To: `whatsapp:${row.phone}`,
+      From: `whatsapp:${TWILIO_WHATSAPP_FROM}`,
+      Body: "Your daily practice reminder from GramorX.",
+    });
+
+    await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${btoa(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`)}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params,
+      },
+    );
+  }
+
+  return new Response("ok");
+});

--- a/supabase/migrations/20250831_whatsapp_optin.sql
+++ b/supabase/migrations/20250831_whatsapp_optin.sql
@@ -1,0 +1,36 @@
+-- whatsapp_optin table to store user phone numbers for whatsapp updates
+create table if not exists public.whatsapp_optin (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  phone text not null unique,
+  opted_in boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- trigger to keep updated_at fresh
+create or replace function public.set_whatsapp_optin_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end
+$$;
+
+drop trigger if exists trg_whatsapp_optin_updated on public.whatsapp_optin;
+create trigger trg_whatsapp_optin_updated
+before update on public.whatsapp_optin
+for each row execute procedure public.set_whatsapp_optin_updated_at();
+
+alter table public.whatsapp_optin enable row level security;
+
+create policy "select own whatsapp optin" on public.whatsapp_optin
+for select using (auth.uid() = user_id);
+
+create policy "insert own whatsapp optin" on public.whatsapp_optin
+for insert with check (auth.uid() = user_id);
+
+create policy "update own whatsapp optin" on public.whatsapp_optin
+for update using (auth.uid() = user_id);
+
+create policy "delete own whatsapp optin" on public.whatsapp_optin
+for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add migration for whatsapp_optin table with RLS and policies
- add API endpoints to subscribe and handle Twilio webhooks
- create dashboard component for WhatsApp opt-in
- add scheduled Supabase function to broadcast WhatsApp messages

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68ae51f265308321b223745aed5b2e48