### PR TITLE
Add explanation language and translate feedback

### DIFF
--- a/lib/explanations.ts
+++ b/lib/explanations.ts
@@ -1,0 +1,15 @@
+export async function translateExplanation(text: string, target: string): Promise<string> {
+  if (!text || target === 'en') return text;
+  try {
+    const res = await fetch('/api/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, target }),
+    });
+    if (!res.ok) throw new Error('Translation failed');
+    const data = await res.json();
+    return typeof data.text === 'string' ? data.text : text;
+  } catch {
+    return text;
+  }
+}

--- a/lib/locale.tsx
+++ b/lib/locale.tsx
@@ -3,12 +3,16 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 interface LocaleContextValue {
   locale: string;
   setLocale: (lng: string) => void;
+  explanationLocale: string;
+  setExplanationLocale: (lng: string) => void;
   t: (key: string) => string;
 }
 
 const LocaleContext = createContext<LocaleContextValue>({
   locale: 'en',
   setLocale: () => {},
+  explanationLocale: 'en',
+  setExplanationLocale: () => {},
   t: (key: string) => key,
 });
 
@@ -24,6 +28,7 @@ async function loadMessages(locale: string) {
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [locale, setLocale] = useState('en');
+  const [explanationLocale, setExplanationLocale] = useState('en');
   const [messages, setMessages] = useState<Record<string, any>>({});
 
   useEffect(() => {
@@ -35,7 +40,7 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   };
 
   return (
-    <LocaleContext.Provider value={{ locale, setLocale, t }}>
+    <LocaleContext.Provider value={{ locale, setLocale, explanationLocale, setExplanationLocale, t }}>
       {children}
     </LocaleContext.Provider>
   );

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -31,7 +31,7 @@ export default function VerifyPage() {
       if (error) {
         setError(error.message);
       } else {
-        router.replace('/profile-setup');
+        router.replace('/profile/setup');
       }
     })();
   }, [hasCode, router]);

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -232,7 +232,7 @@ export default function BlogIndex() {
               <div className="font-semibold mb-1">Account</div>
               <div className="flex flex-wrap gap-2">
                 <NavLink href="/pricing" label="Pricing" />
-                <NavLink href="/profile-setup" label="Profile" />
+                      <NavLink href="/profile/setup" label="Profile" />
                 <NavLink href="/support" label="Support" />
               </div>
             </Card>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -136,7 +136,7 @@ export default function FAQPage() {
               <div className="font-semibold mb-1">Account</div>
               <div className="flex flex-wrap gap-2">
                 <Link className="underline" href="/pricing">Pricing</Link>
-                <Link className="underline" href="/profile-setup">Profile</Link>
+                <Link className="underline" href="/profile/setup">Profile</Link>
                 <Link className="underline" href="/support">Support</Link>
               </div>
             </Card>

--- a/pages/learning/skills/[skill].tsx
+++ b/pages/learning/skills/[skill].tsx
@@ -55,7 +55,7 @@ export default function Dashboard() {
 
       if (error) console.error(error);
       if (!data || data.draft) {
-        router.replace('/profile-setup');
+        router.replace('/profile/setup');
         return;
       }
 
@@ -162,7 +162,7 @@ export default function Dashboard() {
               <Alert variant="info" className="mt-3">Add more details in <b>Profile</b> to refine your AI plan.</Alert>
             )}
             <div className="mt-4">
-              <Button as="a" href="/profile-setup" variant="secondary" className="rounded-ds-xl">Edit Profile</Button>
+              <Button as="a" href="/profile/setup" variant="secondary" className="rounded-ds-xl">Edit Profile</Button>
             </div>
           </Card>
         </div>

--- a/pages/profile/setup.tsx
+++ b/pages/profile/setup.tsx
@@ -20,7 +20,7 @@ const PREFS = ['Listening','Reading','Writing','Speaking'];
 
 export default function ProfileSetup() {
   const router = useRouter();
-  const { t, setLocale } = useLocale();
+  const { t, setLocale, setExplanationLocale } = useLocale();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,6 +35,7 @@ export default function ProfileSetup() {
   const [prefs, setPrefs] = useState<string[]>([]);
   const [time, setTime] = useState<string>('');
   const [lang, setLang] = useState('en');
+  const [explanationLang, setExplanationLang] = useState('en');
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>();
   const [ai, setAi] = useState<{suggestedGoal:number; etaWeeks:number; sequence:string[]} | null>(null);
 
@@ -46,7 +47,7 @@ export default function ProfileSetup() {
         const url = window.location.href;
         if (url.includes('code=') || url.includes('access_token=')) {
           const { error } = await supabase.auth.exchangeCodeForSession(url);
-          if (!error) router.replace('/profile-setup');
+          if (!error) router.replace('/profile/setup');
         }
       }
       const { data: { session } } = await supabase.auth.getSession();
@@ -71,7 +72,12 @@ export default function ProfileSetup() {
         setExamDate(data.exam_date ?? '');
         setPrefs((data.study_prefs as string[]) ?? []);
         setTime(data.time_commitment ?? '');
-        setLang(data.preferred_language ?? 'en');
+        const pl = data.preferred_language ?? 'en';
+        setLang(pl);
+        setLocale(pl);
+        const el = data.explanation_language ?? 'en';
+        setExplanationLang(el);
+        setExplanationLocale(el);
         setAvatarUrl(data.avatar_url ?? undefined);
         try {
           const rec = data.ai_recommendation ?? {};
@@ -115,6 +121,7 @@ export default function ProfileSetup() {
       study_prefs: prefs,
       time_commitment: time || null,
       preferred_language: lang || 'en',
+      explanation_language: explanationLang || 'en',
       avatar_url: avatarUrl || null,
       ai_recommendation: ai ? {
         suggestedGoal: ai.suggestedGoal,
@@ -222,6 +229,20 @@ export default function ProfileSetup() {
                     onChange={e => {
                       setLang(e.target.value);
                       setLocale(e.target.value);
+                    }}
+                  >
+                    <option value="en">English</option>
+                    <option value="ur">Urdu</option>
+                    <option value="ar">Arabic</option>
+                    <option value="hi">Hindi</option>
+                  </Select>
+
+                  <Select
+                    label={t('profileSetup.explanationLanguage')}
+                    value={explanationLang}
+                    onChange={e => {
+                      setExplanationLang(e.target.value);
+                      setExplanationLocale(e.target.value);
                     }}
                   >
                     <option value="en">English</option>

--- a/pages/reading/review/[attemptId].tsx
+++ b/pages/reading/review/[attemptId].tsx
@@ -5,6 +5,8 @@ import { Card } from '@/components/design-system/Card';
 import { Badge } from '@/components/design-system/Badge';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
+import { useLocale } from '@/lib/locale';
+import { translateExplanation } from '@/lib/explanations';
 
 type ReviewItem = {
   id: string; qNo: number; type: string; prompt: string;
@@ -23,6 +25,7 @@ export default function ReadingReviewPage() {
   const [data, setData] = useState<ReviewPayload | null>(null);
   const [err, setErr] = useState<string | undefined>();
   const [explainBusy, setExplainBusy] = useState<string | null>(null);
+  const { explanationLocale } = useLocale();
 
   useEffect(() => {
     if (!attemptId) return;
@@ -47,9 +50,10 @@ export default function ReadingReviewPage() {
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json?.error || 'Could not fetch explanation');
+      const text = await translateExplanation(json.text, explanationLocale);
       setData(prev => !prev ? prev : ({
         ...prev,
-        items: prev.items.map(i => i.id === qid ? { ...i, explanation: json.text } : i)
+        items: prev.items.map(i => i.id === qid ? { ...i, explanation: text } : i)
       }));
     } catch (e:any) {
       setErr(e?.message || 'Explain failed');

--- a/pages/reading/review/index.tsx
+++ b/pages/reading/review/index.tsx
@@ -5,6 +5,8 @@ import type { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { createClient } from '@supabase/supabase-js';
+import { useLocale } from '@/lib/locale';
+import { translateExplanation } from '@/lib/explanations';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -143,6 +145,7 @@ const ReviewPage: NextPage<Props> = ({ passage, questions, notFound, error }) =>
   const [answers, setAnswers] = useState<Record<string, any> | null>(null);
   const [explanations, setExplanations] = useState<Record<string, string>>({});
   const [loadErr, setLoadErr] = useState<string | null>(null);
+  const { explanationLocale } = useLocale();
 
   // Load answers:
   // 1) If attemptId: fetch attempt from Supabase with user token
@@ -260,7 +263,8 @@ const ReviewPage: NextPage<Props> = ({ passage, questions, notFound, error }) =>
       });
       const json = await res.json();
       if (json?.explanation) {
-        setExplanations((prev) => ({ ...prev, [q.id]: json.explanation }));
+        const text = await translateExplanation(json.explanation, explanationLocale);
+        setExplanations((prev) => ({ ...prev, [q.id]: text }));
       }
     } catch {
       setExplanations((prev) => ({ ...prev, [q.id]: 'Could not load explanation right now.' }));

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -10,7 +10,7 @@ export default function SignupOptions() {
     await supabase.auth.signInWithOAuth({
       provider,
       options: {
-        redirectTo: typeof window !== 'undefined' ? `${window.location.origin}/profile-setup` : undefined,
+        redirectTo: typeof window !== 'undefined' ? `${window.location.origin}/profile/setup` : undefined,
       },
     });
   }

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -38,7 +38,7 @@ export default function SignupWithPhone() {
         access_token: data.session.access_token,
         refresh_token: data.session.refresh_token,
       });
-      window.location.assign('/profile-setup');
+      window.location.assign('/profile/setup');
     }
   }
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,6 +6,7 @@
     "completeProfile": "Complete your profile",
     "description": "We’ll tune your study plan with AI and personalize your dashboard.",
     "preferredLanguage": "Preferred UI language",
+    "explanationLanguage": "Explanation language",
     "saveDraft": "Save draft",
     "finishContinue": "Finish & continue"
   },

--- a/public/locales/ur/common.json
+++ b/public/locales/ur/common.json
@@ -6,6 +6,7 @@
     "completeProfile": "اپنی پروفائل مکمل کریں",
     "description": "ہم آپ کے مطالعہ منصوبہ کو AI سے بہتر بنائیں گے اور آپ کے ڈیش بورڈ کو حسبِ ضرورت بنائیں گے۔",
     "preferredLanguage": "ترجیحی زبان",
+    "explanationLanguage": "تشریحی زبان",
     "saveDraft": "ڈرافٹ محفوظ کریں",
     "finishContinue": "ختم کریں اور جاری رکھیں"
   },

--- a/supabase/migrations/20250920_explanation_language.sql
+++ b/supabase/migrations/20250920_explanation_language.sql
@@ -1,0 +1,3 @@
+-- Add explanation_language column to user_profiles
+alter table if exists public.user_profiles
+  add column if not exists explanation_language text default 'en';


### PR DESCRIPTION
## Summary
- store explanation_language on user_profiles via migration
- track explanationLocale in locale provider and translation helper
- move profile setup page to /profile/setup with explanation language selector
- translate reading review feedback to chosen language

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53b5a1448321bf7250ca2bb89ede