### PR TITLE
feat: add PWA support and offline caching

### DIFF
--- a/lib/offlineSync.ts
+++ b/lib/offlineSync.ts
@@ -1,0 +1,28 @@
+const DB_NAME = 'offline-sync';
+const STORE = 'requests';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE, { autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function queueRequest(url: string, body: unknown, method = 'POST'): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, 'readwrite');
+  tx.objectStore(STORE).add({ url, body, method });
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+
+  if ('serviceWorker' in navigator && 'SyncManager' in window) {
+    const reg = await navigator.serviceWorker.ready;
+    await reg.sync.register('offline-queue');
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import withPWA from 'next-pwa';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -11,4 +13,17 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+export default withPWA({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  swSrc: 'public/sw.js',
+  workboxOptions: {
+    additionalManifestEntries: [
+      { url: '/brand/logo.png', revision: null },
+      { url: '/locales/en/common.json', revision: null },
+      { url: '/locales/ur/common.json', revision: null },
+      { url: '/premium.css', revision: null },
+    ],
+  },
+})(nextConfig);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "multiparty": "^4.2.3",
     "next": "14.2.31",
     "next-themes": "^0.3.0",
+    "next-pwa": "^5.6.0",
     "openai": "^5.12.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,6 +9,7 @@ export default function Document() {
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+        <link rel="manifest" href="/manifest.json" />
       </Head>
       <body>
         <Main />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "GramorX",
+  "short_name": "GramorX",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/brand/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-undef */
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+// Precache Next.js assets and additional static files used in drills
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+workbox.precaching.precacheAndRoute([
+  { url: '/brand/logo.png', revision: null },
+  { url: '/locales/en/common.json', revision: null },
+  { url: '/locales/ur/common.json', revision: null },
+  { url: '/premium.css', revision: null },
+]);
+
+// Cache practice, vocabulary, and drafts pages
+workbox.routing.registerRoute(
+  ({ url }) =>
+    url.pathname.startsWith('/practice') ||
+    url.pathname.startsWith('/vocab') ||
+    url.pathname.startsWith('/drafts'),
+  new workbox.strategies.NetworkFirst({ cacheName: 'pages-cache' })
+);
+
+// Background sync to flush queued requests when online
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'offline-queue') {
+    event.waitUntil(flushQueue());
+  }
+});
+
+async function flushQueue() {
+  const db = await openDB();
+  const tx = db.transaction('requests', 'readwrite');
+  const store = tx.objectStore('requests');
+  const all = store.getAll();
+  return new Promise((resolve, reject) => {
+    all.onsuccess = async () => {
+      const items = all.result;
+      for (const entry of items) {
+        try {
+          await fetch(entry.url, {
+            method: entry.method || 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(entry.body),
+          });
+        } catch (err) {
+          console.error('Sync failed', err);
+          reject(err);
+          return;
+        }
+      }
+      store.clear();
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    };
+    all.onerror = () => reject(all.error);
+  });
+}
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('offline-sync', 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore('requests', { autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}


### PR DESCRIPTION
## Summary
- configure Next.js with `next-pwa` and custom service worker
- add PWA manifest and service worker to cache practice, vocab, and drafts
- introduce offline sync utility to queue requests when offline

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68ae53b6d7cc8321907d8848fe27ce85