### PR TITLE
Add visa target tracking and dashboard summary

### DIFF
--- a/components/visa/GapToGoal.tsx
+++ b/components/visa/GapToGoal.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+
+import { Card } from '@/components/design-system/Card';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+interface VisaTarget {
+  user_id: string;
+  institution: string;
+  target_band: number;
+  deadline: string | null;
+}
+
+interface Profile {
+  goal_band: number | null;
+}
+
+export const GapToGoal: React.FC = () => {
+  const [target, setTarget] = useState<VisaTarget | null>(null);
+  const [currentBand, setCurrentBand] = useState<number | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const {
+        data: { user },
+      } = await supabaseBrowser.auth.getUser();
+      if (!user) return;
+
+      const [targetRes, profileRes] = await Promise.all([
+        supabaseBrowser
+          .from<VisaTarget>('visa_targets')
+          .select('*')
+          .eq('user_id', user.id)
+          .maybeSingle(),
+        supabaseBrowser
+          .from<Profile>('user_profiles')
+          .select('goal_band')
+          .eq('user_id', user.id)
+          .maybeSingle(),
+      ]);
+
+      if (targetRes.data) setTarget(targetRes.data);
+      if (profileRes.data) setCurrentBand(profileRes.data.goal_band);
+    })();
+  }, []);
+
+  if (!target) return null;
+
+  const gap = target.target_band - (currentBand ?? 0);
+
+  return (
+    <Card className="p-6 rounded-ds-2xl">
+      <h3 className="font-slab text-h3 mb-2">Visa Target</h3>
+      <p className="text-body">
+        {target.institution}: band {target.target_band}
+      </p>
+      {currentBand !== null && (
+        <p className="mt-2 text-body">
+          Gap to goal: {gap <= 0 ? 'achieved' : gap.toFixed(1)}
+        </p>
+      )}
+      {target.deadline && (
+        <p className="mt-1 text-small opacity-80">
+          Deadline: {new Date(target.deadline).toLocaleDateString()}
+        </p>
+      )}
+    </Card>
+  );
+};
+
+export default GapToGoal;

--- a/components/visa/TargetScoreForm.tsx
+++ b/components/visa/TargetScoreForm.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+
+import { Input } from '@/components/design-system/Input';
+import { Button } from '@/components/design-system/Button';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+interface VisaTarget {
+  user_id: string;
+  institution: string;
+  target_band: number;
+  deadline: string | null;
+}
+
+export const TargetScoreForm: React.FC = () => {
+  const [institution, setInstitution] = useState('');
+  const [targetBand, setTargetBand] = useState('');
+  const [deadline, setDeadline] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const {
+        data: { user },
+      } = await supabaseBrowser.auth.getUser();
+      if (!user) return;
+      const { data } = await supabaseBrowser
+        .from<VisaTarget>('visa_targets')
+        .select('*')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      if (data) {
+        setInstitution(data.institution);
+        setTargetBand(data.target_band?.toString() ?? '');
+        setDeadline(data.deadline ?? '');
+      }
+    })();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const {
+      data: { user },
+    } = await supabaseBrowser.auth.getUser();
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    await supabaseBrowser.from('visa_targets').upsert({
+      user_id: user.id,
+      institution,
+      target_band: targetBand ? parseFloat(targetBand) : null,
+      deadline: deadline || null,
+    });
+    setLoading(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input
+        label="Institution"
+        value={institution}
+        onChange={(e) => setInstitution(e.target.value)}
+        required
+      />
+      <Input
+        label="Target Band"
+        type="number"
+        step="0.5"
+        min="4"
+        max="9"
+        value={targetBand}
+        onChange={(e) => setTargetBand(e.target.value)}
+        required
+      />
+      <Input
+        label="Deadline"
+        type="date"
+        value={deadline}
+        onChange={(e) => setDeadline(e.target.value)}
+      />
+      <Button type="submit" loading={loading} className="rounded-ds-xl">
+        Save Target
+      </Button>
+    </form>
+  );
+};
+
+export default TargetScoreForm;

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -17,6 +17,7 @@ import { useStreak } from '@/hooks/useStreak';
 import { getDayKeyInTZ } from '@/lib/streak';
 import StudyCalendar from '@/components/feature/StudyCalendar';
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
+import GapToGoal from '@/components/visa/GapToGoal';
 
 type AIPlan = {
   suggestedGoal?: number;
@@ -208,6 +209,11 @@ export default function Dashboard() {
               ))}
             </div>
           </Card>
+        </div>
+
+        {/* Visa gap summary */}
+        <div className="mt-10">
+          <GapToGoal />
         </div>
 
         {/* Study calendar */}

--- a/pages/visa/index.tsx
+++ b/pages/visa/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { Container } from '@/components/design-system/Container';
+import TargetScoreForm from '@/components/visa/TargetScoreForm';
+import GapToGoal from '@/components/visa/GapToGoal';
+
+export default function VisaPage() {
+  return (
+    <section className="py-10">
+      <Container>
+        <h1 className="font-slab text-h1 mb-6">Visa Targets</h1>
+        <GapToGoal />
+        <div className="mt-8">
+          <TargetScoreForm />
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/supabase/migrations/20250901_visa_targets.sql
+++ b/supabase/migrations/20250901_visa_targets.sql
@@ -1,0 +1,27 @@
+-- table
+create table if not exists public.visa_targets (
+  user_id uuid references auth.users(id) on delete cascade,
+  institution text not null,
+  target_band numeric(2,1) not null check (target_band between 4.0 and 9.0),
+  deadline date,
+  created_at timestamptz default now(),
+  primary key (user_id, institution)
+);
+
+-- RLS
+alter table public.visa_targets enable row level security;
+
+-- Policies
+create policy "select own visa targets" on public.visa_targets
+for select to authenticated
+using (auth.uid() = user_id);
+
+create policy "insert own visa targets" on public.visa_targets
+for insert with check (auth.uid() = user_id);
+
+create policy "update own visa targets" on public.visa_targets
+for update using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "delete own visa targets" on public.visa_targets
+for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- introduce `visa_targets` table storing institution, target band, and deadline with row level security
- add Visa management page with target form and gap-to-goal summary
- surface visa gap summary on the dashboard

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53b9f984832189434337c5f906ca