### PR TITLE
feat: add streak shields

### DIFF
--- a/components/design-system/StreakIndicator.tsx
+++ b/components/design-system/StreakIndicator.tsx
@@ -21,7 +21,7 @@ const safeGetLocalDayKey = (d?: Date) => {
 };
 
 export const StreakIndicator: React.FC<Props> = ({ className = '', value }) => {
-  const { current, lastDayKey, completeToday, loading } = useStreak();
+  const { current, lastDayKey, completeToday, loading, shields } = useStreak();
 
   const [justCelebrated, setJustCelebrated] = useState(false);
   const todayKey = useMemo(() => safeGetLocalDayKey(), []);
@@ -58,11 +58,13 @@ export const StreakIndicator: React.FC<Props> = ({ className = '', value }) => {
         justCelebrated ? 'shadow-[0_0_0_6px_rgba(0,187,249,0.25)] transition-shadow' : '',
         className,
       ].join(' ')}
-      aria-label={`Current streak ${streakValue} days`}
+      aria-label={`Current streak ${streakValue} days, ${shields} shields left`}
       title={`Streak: ${streakValue}`}
     >
       <i className="fas fa-fire" aria-hidden="true" />
       <span className="font-semibold tabular-nums">{Math.max(streakValue, 0)}</span>
+      <i className="fas fa-shield-alt ml-3" aria-hidden="true" />
+      <span className="font-semibold tabular-nums">{shields}</span>
     </div>
   );
 };

--- a/hooks/useStreak.ts
+++ b/hooks/useStreak.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { fetchStreak, incrementStreak } from '@/lib/streak';
+import { fetchStreak, incrementStreak, claimShield, getDayKeyInTZ } from '@/lib/streak';
 
 export type StreakState = {
   loading: boolean;
   current: number;
   lastDayKey: string | null;
+  shields: number;
   error?: string;
 };
 
@@ -13,6 +14,7 @@ export function useStreak() {
     loading: true,
     current: 0,
     lastDayKey: null,
+    shields: 0,
   });
 
   const load = useCallback(async () => {
@@ -23,6 +25,7 @@ export function useStreak() {
         loading: false,
         current: data.current_streak ?? 0,
         lastDayKey: data.last_activity_date ?? null,
+        shields: data.shields ?? 0,
       });
     } catch (e: any) {
       setState(s => ({ ...s, loading: false, error: e.message || 'Failed to load' }));
@@ -33,17 +36,46 @@ export function useStreak() {
 
   const completeToday = useCallback(async () => {
     try {
-      const data = await incrementStreak();
+      const today = getDayKeyInTZ();
+      const yesterday = getDayKeyInTZ(new Date(Date.now() - 864e5));
+      const useShield = state.lastDayKey !== today && state.lastDayKey !== yesterday && state.shields > 0;
+      const data = await incrementStreak({ useShield });
       setState(s => ({
         ...s,
         current: data.current_streak ?? s.current,
         lastDayKey: data.last_activity_date ?? s.lastDayKey,
+        shields: data.shields ?? s.shields,
       }));
     } catch (e: any) {
       setState(s => ({ ...s, error: e.message || 'Failed to update' }));
       throw e;
     }
+  }, [state.lastDayKey, state.shields]);
+
+  const claim = useCallback(async () => {
+    try {
+      const data = await claimShield();
+      setState(s => ({ ...s, shields: data.shields ?? s.shields }));
+    } catch (e: any) {
+      setState(s => ({ ...s, error: e.message || 'Failed to claim' }));
+      throw e;
+    }
   }, []);
 
-  return { ...state, reload: load, completeToday };
+  const useShieldFn = useCallback(async () => {
+    try {
+      const data = await incrementStreak({ useShield: true });
+      setState(s => ({
+        ...s,
+        current: data.current_streak ?? s.current,
+        lastDayKey: data.last_activity_date ?? s.lastDayKey,
+        shields: data.shields ?? s.shields,
+      }));
+    } catch (e: any) {
+      setState(s => ({ ...s, error: e.message || 'Failed to use' }));
+      throw e;
+    }
+  }, []);
+
+  return { ...state, reload: load, completeToday, claimShield: claim, useShield: useShieldFn };
 }

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -39,6 +39,7 @@ export const getDayKeyInTZ = (
 export type StreakData = {
   current_streak: number;
   last_activity_date: string | null;
+  shields: number;
 };
 
 /** Fetch current streak for the logged-in user */
@@ -55,6 +56,7 @@ const handle = async (res: Response, fallbackMsg: string): Promise<StreakData> =
   return {
     current_streak: json?.current_streak ?? 0,
     last_activity_date: json?.last_activity_date ?? null,
+    shields: json?.shields ?? 0,
   };
 };
 
@@ -70,10 +72,30 @@ export async function fetchStreak(): Promise<StreakData> {
 }
 
 /** Mark today's activity and return the updated streak */
-export async function incrementStreak(): Promise<StreakData> {
+export async function incrementStreak(options: { useShield?: boolean } = {}): Promise<StreakData> {
   try {
-    const res = await fetch('/api/streak', { method: 'POST' });
+    const body = options.useShield ? { action: 'use' } : {};
+    const res = await fetch('/api/streak', {
+      method: 'POST',
+      headers: Object.keys(body).length ? { 'Content-Type': 'application/json' } : undefined,
+      body: Object.keys(body).length ? JSON.stringify(body) : undefined,
+    });
     return await handle(res, 'Failed to update streak');
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+/** Claim a new streak shield */
+export async function claimShield(): Promise<StreakData> {
+  try {
+    const res = await fetch('/api/streak', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'claim' }),
+    });
+    return await handle(res, 'Failed to claim shield');
   } catch (e) {
     console.error(e);
     throw e;

--- a/pages/api/streak.ts
+++ b/pages/api/streak.ts
@@ -2,7 +2,11 @@ import { env } from "@/lib/env";
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-type StreakResponse = { current_streak: number; last_activity_date: string | null };
+type StreakResponse = {
+  current_streak: number;
+  last_activity_date: string | null;
+  shields: number;
+};
 type ErrorResponse = { error: string };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<StreakResponse | ErrorResponse>) {
@@ -18,36 +22,71 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   }
 
   if (req.method === 'GET') {
-    const { data, error } = await supabase
+    const { data: streakData, error: streakErr } = await supabase
       .from('user_streaks')
       .select('current_streak, last_activity_date')
       .eq('user_id', user.id)
       .maybeSingle();
+    const { data: shieldData, error: shieldErr } = await supabase
+      .from('streak_shields')
+      .select('tokens')
+      .eq('user_id', user.id)
+      .maybeSingle();
 
-    if (error) {
-      return res.status(500).json({ error: error.message });
+    if (streakErr || shieldErr) {
+      return res.status(500).json({ error: streakErr?.message || shieldErr?.message || 'Failed to fetch' });
     }
 
     return res.status(200).json({
-      current_streak: data?.current_streak ?? 0,
-      last_activity_date: data?.last_activity_date ?? null,
+      current_streak: streakData?.current_streak ?? 0,
+      last_activity_date: streakData?.last_activity_date ?? null,
+      shields: shieldData?.tokens ?? 0,
     });
   }
 
   if (req.method === 'POST') {
+    const { action } = (req.body as { action?: string }) || {};
     const today = new Date().toISOString().split('T')[0];
     const { data: existing, error: fetchErr } = await supabase
       .from('user_streaks')
       .select('current_streak, last_activity_date')
       .eq('user_id', user.id)
       .maybeSingle();
+    const { data: shieldRow, error: shieldErr } = await supabase
+      .from('streak_shields')
+      .select('tokens')
+      .eq('user_id', user.id)
+      .maybeSingle();
 
-    if (fetchErr) {
-      return res.status(500).json({ error: fetchErr.message });
+    if (fetchErr || shieldErr) {
+      return res.status(500).json({ error: fetchErr?.message || shieldErr?.message || 'Fetch failed' });
+    }
+
+    const currentTokens = shieldRow?.tokens ?? 0;
+
+    if (action === 'claim') {
+      const tokens = currentTokens + 1;
+      const { error: upsertErr } = await supabase
+        .from('streak_shields')
+        .upsert({ user_id: user.id, tokens });
+      if (upsertErr) {
+        return res.status(500).json({ error: upsertErr.message });
+      }
+      await supabase.from('streak_shield_logs').insert({ user_id: user.id, action: 'claim' });
+      return res.status(200).json({
+        current_streak: existing?.current_streak ?? 0,
+        last_activity_date: existing?.last_activity_date ?? null,
+        shields: tokens,
+      });
     }
 
     let newStreak = 1;
-    if (existing) {
+    let shields = currentTokens;
+
+    if (action === 'use' && currentTokens > 0) {
+      newStreak = (existing?.current_streak ?? 0) + 1;
+      shields = currentTokens - 1;
+    } else if (existing) {
       if (existing.last_activity_date === today) {
         newStreak = existing.current_streak;
       } else {
@@ -72,7 +111,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       return res.status(500).json({ error: error.message });
     }
 
-    return res.status(200).json({ current_streak: newStreak, last_activity_date: today });
+    if (action === 'use' && currentTokens > 0) {
+      const { error: shieldUpdateErr } = await supabase
+        .from('streak_shields')
+        .upsert({ user_id: user.id, tokens: shields });
+      if (shieldUpdateErr) {
+        return res.status(500).json({ error: shieldUpdateErr.message });
+      }
+      await supabase.from('streak_shield_logs').insert({ user_id: user.id, action: 'use' });
+    }
+
+    return res.status(200).json({ current_streak: newStreak, last_activity_date: today, shields });
   }
 
   res.setHeader('Allow', 'GET,POST');

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -50,6 +50,9 @@ export default function Dashboard() {
     lastDayKey,
     loading: streakLoading,
     completeToday,
+    shields,
+    claimShield,
+    useShield,
   } = useStreak();
 
   const handleShare = () => {
@@ -161,6 +164,14 @@ export default function Dashboard() {
 
           <div className="flex items-center gap-4">
             <StreakIndicator value={streak} />
+            <Button onClick={claimShield} variant="secondary" className="rounded-ds-xl">
+              Claim Shield
+            </Button>
+            {shields > 0 && (
+              <Button onClick={useShield} variant="secondary" className="rounded-ds-xl">
+                Use Shield
+              </Button>
+            )}
             {streak >= 7 && <Badge variant="success" size="sm">🔥 {streak}-day streak!</Badge>}
 
             {profile?.avatar_url ? (

--- a/supabase/migrations/20250901_streak_shield.sql
+++ b/supabase/migrations/20250901_streak_shield.sql
@@ -1,0 +1,45 @@
+create table if not exists public.streak_shields (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  tokens int not null default 0,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table public.streak_shields enable row level security;
+
+create policy "read own shields" on public.streak_shields
+for select using (auth.uid() = user_id);
+
+create policy "insert own shields" on public.streak_shields
+for insert with check (auth.uid() = user_id);
+
+create policy "update own shields" on public.streak_shields
+for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create table if not exists public.streak_shield_logs (
+  id bigserial primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  action text not null check (action in ('claim','use')),
+  created_at timestamptz default now()
+);
+
+alter table public.streak_shield_logs enable row level security;
+
+create policy "read own shield logs" on public.streak_shield_logs
+for select using (auth.uid() = user_id);
+
+create policy "insert own shield logs" on public.streak_shield_logs
+for insert with check (auth.uid() = user_id);
+
+-- trigger for updated_at
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+drop trigger if exists trg_streak_shields_updated on public.streak_shields;
+create trigger trg_streak_shields_updated
+before update on public.streak_shields
+for each row execute procedure public.set_updated_at();


### PR DESCRIPTION
## Summary
- add Supabase tables for streak shields and usage logs
- consume shields to protect streak progress
- expose shield counts in UI with claim/use actions

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68ae53bb29788321ac90898750f6fff8