### PR TITLE
Add autocomplete attributes for login forms

### DIFF
--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -56,8 +56,8 @@ export default function LoginWithEmail() {
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
-        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} autoComplete="email" required />
+        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -52,8 +52,8 @@ export default function LoginWithPassword() {
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
-        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} autoComplete="email" required />
+        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -65,7 +65,7 @@ export default function LoginWithPhone() {
 
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
-          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} required />
+          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} autoComplete="tel" required />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>


### PR DESCRIPTION
## Summary
- add `autoComplete="email"` and `autoComplete="current-password"` to login email/password forms
- add `autoComplete="tel"` to phone login form

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run build` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6785d0c48321ae11231ee884d73d