### PR TITLE
Focus first invalid input on auth forms

### DIFF
--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -8,40 +8,52 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   iconRight?: React.ReactNode;
 };
 
-export const Input: React.FC<InputProps> = ({
-  label,
-  hint,
-  error,
-  iconLeft,
-  iconRight,
-  className = '',
-  ...props
-}) => {
-  const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
-    'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
-    'disabled:opacity-60',
-    'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',
-    'dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
-  ].join(' ');
-  const invalid = error ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange' : '';
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    { label, hint, error, iconLeft, iconRight, className = '', ...props },
+    ref
+  ) => {
+    const base = [
+      'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+      'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
+      'disabled:opacity-60',
+      'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',
+      'dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
+    ].join(' ');
+    const invalid = error ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange' : '';
 
-  return (
-    <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
-      <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
-        {iconLeft && <span className="absolute left-3 text-gray-500 dark:text-white/50">{iconLeft}</span>}
-        <input
-          className={`${base} ${invalid} ${iconLeft ? 'pl-10' : 'pl-4'} ${iconRight ? 'pr-10' : 'pr-4'} py-3`}
-          {...props}
-        />
-        {iconRight && <span className="absolute right-3 text-gray-500 dark:text-white/50">{iconRight}</span>}
-      </div>
-      {error ? (
-        <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
-      ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
-      ) : null}
-    </label>
-  );
-};
+    return (
+      <label className={`block ${className}`}>
+        {label && (
+          <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">
+            {label}
+          </span>
+        )}
+        <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
+          {iconLeft && (
+            <span className="absolute left-3 text-gray-500 dark:text-white/50">{iconLeft}</span>
+          )}
+          <input
+            ref={ref}
+            className={`${base} ${invalid} ${iconLeft ? 'pl-10' : 'pl-4'} ${
+              iconRight ? 'pr-10' : 'pr-4'
+            } py-3`}
+            {...props}
+          />
+          {iconRight && (
+            <span className="absolute right-3 text-gray-500 dark:text-white/50">
+              {iconRight}
+            </span>
+          )}
+        </div>
+        {error ? (
+          <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
+        ) : hint ? (
+          <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        ) : null}
+      </label>
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
@@ -11,13 +11,22 @@ import { redirectByRole } from '@/lib/routeAccess';
 export default function LoginWithEmail() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
+  const emailRef = useRef<HTMLInputElement>(null);
+  const pwRef = useRef<HTMLInputElement>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!email || !pw) return setErr('Email and password are required.');
+    if (!email) {
+      emailRef.current?.focus();
+      return setErr('Email and password are required.');
+    }
+    if (!pw) {
+      pwRef.current?.focus();
+      return setErr('Email and password are required.');
+    }
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
@@ -56,8 +65,24 @@ export default function LoginWithEmail() {
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
-        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <Input
+          ref={emailRef}
+          label="Email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          ref={pwRef}
+          label="Password"
+          type="password"
+          placeholder="Your password"
+          value={pw}
+          onChange={(e) => setPw(e.target.value)}
+          required
+        />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
@@ -11,13 +11,22 @@ import { redirectByRole } from '@/lib/routeAccess';
 export default function LoginWithPassword() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
+  const emailRef = useRef<HTMLInputElement>(null);
+  const pwRef = useRef<HTMLInputElement>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!email || !pw) return setErr('Please fill in all fields.');
+    if (!email) {
+      emailRef.current?.focus();
+      return setErr('Please fill in all fields.');
+    }
+    if (!pw) {
+      pwRef.current?.focus();
+      return setErr('Please fill in all fields.');
+    }
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
@@ -52,8 +61,24 @@ export default function LoginWithPassword() {
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
-        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <Input
+          ref={emailRef}
+          label="Email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          ref={pwRef}
+          label="Password"
+          type="password"
+          placeholder="Your password"
+          value={pw}
+          onChange={(e) => setPw(e.target.value)}
+          required
+        />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
@@ -11,6 +11,8 @@ import { redirectByRole } from '@/lib/routeAccess';
 export default function LoginWithPhone() {
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
+  const phoneRef = useRef<HTMLInputElement>(null);
+  const codeRef = useRef<HTMLInputElement>(null);
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -18,7 +20,10 @@ export default function LoginWithPhone() {
   async function requestOtp(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!phone) return setErr('Enter your phone number in E.164 format, e.g. +923001234567');
+    if (!phone) {
+      phoneRef.current?.focus();
+      return setErr('Enter your phone number in E.164 format, e.g. +923001234567');
+    }
     setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: false } });
     setLoading(false);
@@ -29,7 +34,10 @@ export default function LoginWithPhone() {
   async function verifyOtp(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!code) return setErr('Enter the 6-digit code.');
+    if (!code) {
+      codeRef.current?.focus();
+      return setErr('Enter the 6-digit code.');
+    }
     setLoading(true);
     // @ts-expect-error `token` is supported for verification
     const { data, error } = await supabase.auth.signInWithOtp({ phone, token: code });
@@ -65,14 +73,30 @@ export default function LoginWithPhone() {
 
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
-          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} required />
+          <Input
+            ref={phoneRef}
+            label="Phone number"
+            type="tel"
+            placeholder="+923001234567"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>
         </form>
       ) : (
         <form onSubmit={verifyOtp} className="space-y-6 mt-2">
-          <Input label="Verification code" inputMode="numeric" placeholder="123456" value={code} onChange={(e)=>setCode(e.target.value)} required />
+          <Input
+            ref={codeRef}
+            label="Verification code"
+            inputMode="numeric"
+            placeholder="123456"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            required
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Verifying…' : 'Verify & Continue'}
           </Button>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -1,5 +1,5 @@
 // pages/signup/password.tsx
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
@@ -11,6 +11,8 @@ import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 export default function SignupWithPassword() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
+  const emailRef = useRef<HTMLInputElement>(null);
+  const pwRef = useRef<HTMLInputElement>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -18,7 +20,13 @@ export default function SignupWithPassword() {
     e.preventDefault();
     setErr(null);
 
-    if (!email || !pw) {
+    if (!email) {
+      emailRef.current?.focus();
+      setErr('Please fill in all fields.');
+      return;
+    }
+    if (!pw) {
+      pwRef.current?.focus();
       setErr('Please fill in all fields.');
       return;
     }
@@ -81,6 +89,7 @@ export default function SignupWithPassword() {
 
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input
+          ref={emailRef}
           label="Email"
           type="email"
           placeholder="you@example.com"
@@ -90,6 +99,7 @@ export default function SignupWithPassword() {
           autoComplete="email"
         />
         <Input
+          ref={pwRef}
           label="Password"
           type="password"
           placeholder="Create a password"

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
@@ -10,6 +10,8 @@ import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 export default function SignupWithPhone() {
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
+  const phoneRef = useRef<HTMLInputElement>(null);
+  const codeRef = useRef<HTMLInputElement>(null);
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -17,7 +19,10 @@ export default function SignupWithPhone() {
   async function requestOtp(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!phone) return setErr('Enter your phone number in E.164 format, e.g. +923001234567');
+    if (!phone) {
+      phoneRef.current?.focus();
+      return setErr('Enter your phone number in E.164 format, e.g. +923001234567');
+    }
     setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: true } });
     setLoading(false);
@@ -28,7 +33,10 @@ export default function SignupWithPhone() {
   async function verifyOtp(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    if (!code) return setErr('Enter the 6-digit code.');
+    if (!code) {
+      codeRef.current?.focus();
+      return setErr('Enter the 6-digit code.');
+    }
     setLoading(true);
     const { data, error } = await supabase.auth.verifyOtp({ phone, token: code, type: 'sms' });
     setLoading(false);
@@ -63,14 +71,30 @@ export default function SignupWithPhone() {
 
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
-          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} required />
+          <Input
+            ref={phoneRef}
+            label="Phone number"
+            type="tel"
+            placeholder="+923001234567"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>
         </form>
       ) : (
         <form onSubmit={verifyOtp} className="space-y-6 mt-2">
-          <Input label="Verification code" inputMode="numeric" placeholder="123456" value={code} onChange={(e)=>setCode(e.target.value)} required />
+          <Input
+            ref={codeRef}
+            label="Verification code"
+            inputMode="numeric"
+            placeholder="123456"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            required
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Verifying…' : 'Verify & Continue'}
           </Button>


### PR DESCRIPTION
## Summary
- forward refs through design-system Input for external access
- focus first invalid field on login and signup forms before showing errors

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68ae67862c70832190bbf009c18d8a86