### PR TITLE
feat: add accessible password input with toggle

### DIFF
--- a/components/design-system/PasswordInput.tsx
+++ b/components/design-system/PasswordInput.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Input, InputProps } from './Input';
+
+export type PasswordInputProps = Omit<InputProps, 'type' | 'iconRight'>;
+
+export const PasswordInput: React.FC<PasswordInputProps> = (props) => {
+  const [visible, setVisible] = useState(false);
+
+  const toggle = () => setVisible((v) => !v);
+
+  return (
+    <Input
+      {...props}
+      type={visible ? 'text' : 'password'}
+      iconRight={
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={visible ? 'Hide password' : 'Show password'}
+          aria-pressed={visible}
+          className="p-1"
+        >
+          <i className={`fas ${visible ? 'fa-eye-slash' : 'fa-eye'}`} aria-hidden />
+        </button>
+      }
+    />
+  );
+};
+
+export default PasswordInput;

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
+import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -57,7 +58,7 @@ export default function LoginWithEmail() {
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <PasswordInput label="Password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
+import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -53,7 +54,7 @@ export default function LoginWithPassword() {
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
+        <PasswordInput label="Password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} required />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
+import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -89,9 +90,8 @@ export default function SignupWithPassword() {
           required
           autoComplete="email"
         />
-        <Input
+        <PasswordInput
           label="Password"
-          type="password"
           placeholder="Create a password"
           value={pw}
           onChange={(e) => setPw(e.target.value)}


### PR DESCRIPTION
## Summary
- add `PasswordInput` component with accessible show/hide toggle button
- use `PasswordInput` on login and signup pages instead of raw password `<Input>` fields

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae678697088321baee355da82ec575