### PR TITLE
feat: add guidance hints for auth inputs

### DIFF
--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -20,7 +20,8 @@ export const Input: React.FC<InputProps> = ({
 }) => {
   const generatedId = useId();
   const inputId = id || generatedId;
-  const describedBy = error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
+  const describedBy =
+    error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
   const base = [
     'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
@@ -28,25 +29,45 @@ export const Input: React.FC<InputProps> = ({
     'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',
     'dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
-  const invalid = error ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange' : '';
+  const invalid = error
+    ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange'
+    : '';
 
   return (
     <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
+      {label && (
+        <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">
+          {label}
+        </span>
+      )}
       <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
-        {iconLeft && <span className="absolute left-3 text-gray-500 dark:text-white/50">{iconLeft}</span>}
+        {iconLeft && (
+          <span className="absolute left-3 text-gray-500 dark:text-white/50">
+            {iconLeft}
+          </span>
+        )}
         <input
           id={inputId}
-          className={`${base} ${invalid} ${iconLeft ? 'pl-10' : 'pl-4'} ${iconRight ? 'pr-10' : 'pr-4'} py-3`}
+          className={`${base} ${invalid} ${iconLeft ? 'pl-10' : 'pl-4'} ${
+            iconRight ? 'pr-10' : 'pr-4'
+          } py-3`}
           aria-describedby={describedBy}
           {...props}
         />
-        {iconRight && <span className="absolute right-3 text-gray-500 dark:text-white/50">{iconRight}</span>}
+        {iconRight && (
+          <span className="absolute right-3 text-gray-500 dark:text-white/50">
+            {iconRight}
+          </span>
+        )}
       </div>
       {error ? (
-        <span id={`${inputId}-error`} className="mt-1 block text-small text-sunsetOrange">{error}</span>
+        <span id={`${inputId}-error`} className="mt-1 block text-small text-sunsetOrange">
+          {error}
+        </span>
       ) : hint ? (
-        <span id={`${inputId}-hint`} className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span id={`${inputId}-hint`} className="mt-1 block text-small text-gray-600 dark:text-grayish">
+          {hint}
+        </span>
       ) : null}
     </label>
   );

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   label?: string;
@@ -15,8 +15,12 @@ export const Input: React.FC<InputProps> = ({
   iconLeft,
   iconRight,
   className = '',
+  id,
   ...props
 }) => {
+  const generatedId = useId();
+  const inputId = id || generatedId;
+  const describedBy = error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
   const base = [
     'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
@@ -32,15 +36,17 @@ export const Input: React.FC<InputProps> = ({
       <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
         {iconLeft && <span className="absolute left-3 text-gray-500 dark:text-white/50">{iconLeft}</span>}
         <input
+          id={inputId}
           className={`${base} ${invalid} ${iconLeft ? 'pl-10' : 'pl-4'} ${iconRight ? 'pr-10' : 'pr-4'} py-3`}
+          aria-describedby={describedBy}
           {...props}
         />
         {iconRight && <span className="absolute right-3 text-gray-500 dark:text-white/50">{iconRight}</span>}
       </div>
       {error ? (
-        <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
+        <span id={`${inputId}-error`} className="mt-1 block text-small text-sunsetOrange">{error}</span>
       ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span id={`${inputId}-hint`} className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
       ) : null}
     </label>
   );

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -10,7 +10,7 @@ import { redirectByRole } from '@/lib/routeAccess';
 
 export default function LoginWithPhone() {
   const [phone, setPhone] = useState('');
-  const [code, setCode] = useState('');
+  ￼const [code, setCode] = useState('');
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -65,7 +65,15 @@ export default function LoginWithPhone() {
 
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
-          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} required />
+          <Input
+            label="Phone number"
+            type="tel"
+            placeholder="+923001234567"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+            hint="Use E.164 format, e.g. +923001234567"
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -97,6 +97,7 @@ export default function SignupWithPassword() {
           onChange={(e) => setPw(e.target.value)}
           required
           autoComplete="new-password"
+          hint="At least 8 characters, including letters and numbers"
         />
         <Button
           type="submit"

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -63,7 +63,15 @@ export default function SignupWithPhone() {
 
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
-          <Input label="Phone number" type="tel" placeholder="+923001234567" value={phone} onChange={(e)=>setPhone(e.target.value)} required />
+          <Input
+            label="Phone number"
+            type="tel"
+            placeholder="+923001234567"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+            hint="Use E.164 format, e.g. +923001234567"
+          />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>


### PR DESCRIPTION
## Summary
- link Input hints via `aria-describedby`
- show phone number format hint on login and sign-up flows
- add password requirements hint on email sign-up

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68ae678879c883218d2e8c2746eb0fe6