### PR TITLE
fix: improve auth page color contrast

### DIFF
--- a/design-system/tokens/colors.js
+++ b/design-system/tokens/colors.js
@@ -14,7 +14,8 @@ module.exports = {
   darker: '#070710',
   lightBg: '#f0f2f5',
   lightText: '#1a1a2e',
-  grayish: '#8a8a9c',
+  // Darkened for improved contrast on light backgrounds
+  grayish: '#6a6a86',
 
   // Added (for desired_design alignment)
   vibrantPurple: '#9d4edd', // alias for utilities (same hue as purpleVibe)

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -47,7 +47,7 @@ export default function LoginWithEmail() {
         </ul>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        New here? <Link href="/signup" className="text-primary hover:underline">Create an account</Link>
+        New here? <Link href="/signup" className="text-primaryDark hover:underline">Create an account</Link>
       </div>
     </div>
   );

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -124,11 +124,11 @@ export default function LoginOptions() {
       <div className="pt-8">
         <div className="text-small text-grayish dark:text-gray-400">
           By continuing, you agree to our{' '}
-          <Link href="/legal/terms" className="text-primary hover:underline">
+          <Link href="/legal/terms" className="text-primaryDark hover:underline">
             Terms
           </Link>{' '}
           and{' '}
-          <Link href="/legal/privacy" className="text-primary hover:underline">
+          <Link href="/legal/privacy" className="text-primaryDark hover:underline">
             Privacy Policy
           </Link>
           .
@@ -226,7 +226,7 @@ export default function LoginOptions() {
           <div className="mt-6 flex items-center justify-between text-small text-grayish dark:text-gray-400">
             <div>
               New here?{' '}
-              <Link href={`/signup${selectedRole ? `?role=${selectedRole}` : ''}`} className="text-primary hover:underline">
+              <Link href={`/signup${selectedRole ? `?role=${selectedRole}` : ''}`} className="text-primaryDark hover:underline">
                 Create an account
               </Link>
             </div>

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -43,7 +43,7 @@ export default function LoginWithPassword() {
         </p>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Need an account? <Link href="/signup" className="text-primary hover:underline">Sign up</Link>
+        Need an account? <Link href="/signup" className="text-primaryDark hover:underline">Sign up</Link>
       </div>
     </div>
   );

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -54,7 +54,7 @@ export default function LoginWithPhone() {
         <p className="text-body text-grayish dark:text-gray-300 max-w-md">Use a one-time SMS code to sign in.</p>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Prefer email? <Link href="/login/email" className="text-primary hover:underline">Use email & password</Link>
+        Prefer email? <Link href="/login/email" className="text-primaryDark hover:underline">Use email & password</Link>
       </div>
     </div>
   );

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -32,7 +32,7 @@ export default function SignupOptions() {
         </ul>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Already have an account? <Link href="/login" className="text-primary hover:underline">Log in</Link>
+        Already have an account? <Link href="/login" className="text-primaryDark hover:underline">Log in</Link>
       </div>
     </div>
   );

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -52,7 +52,7 @@ export default function SignupWithPhone() {
         <p className="text-body text-grayish dark:text-gray-300 max-w-md">Create your account with a one-time SMS code.</p>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Prefer email? <Link href="/signup/password" className="text-primary hover:underline">Use Email & Password</Link>
+        Prefer email? <Link href="/signup/password" className="text-primaryDark hover:underline">Use Email & Password</Link>
       </div>
     </div>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,7 +28,8 @@ html, body, #__next { height: 100%; }
   --color-darker:          7   7  16;  /* #070710 */
   --color-lightBg:       240 242 245;  /* #f0f2f5 */
   --color-lightText:      26  26  46;  /* #1a1a2e */
-  --color-grayish:       138 138 156;  /* #8a8a9c */
+  /* darker gray for accessible body text on light backgrounds */
+  --color-grayish:       106 106 134;  /* #6a6a86 */
 
   --color-lightCard:     255 255 255;  /* #ffffff */
   --color-lightBorder:   224 224 224;  /* #e0e0e0 */


### PR DESCRIPTION
## Summary
- darken grayish text token for accessibility
- switch auth page links to primaryDark for stronger contrast

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae678915b0832198bfcd7abb9e44a1