### PR TITLE
feat: use password input component

### DIFF
--- a/components/design-system/PasswordInput.tsx
+++ b/components/design-system/PasswordInput.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Input, InputProps } from './Input';
+
+export const PasswordInput: React.FC<InputProps> = (props) => {
+  const [show, setShow] = React.useState(false);
+
+  return (
+    <Input
+      {...props}
+      type={show ? 'text' : 'password'}
+      iconRight={
+        <button
+          type="button"
+          onClick={() => setShow((s) => !s)}
+          aria-label={show ? 'Hide password' : 'Show password'}
+          className="focus:outline-none"
+        >
+          <i className={`fas ${show ? 'fa-eye-slash' : 'fa-eye'}`} />
+        </button>
+      }
+    />
+  );
+};

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
+import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -43,7 +44,7 @@ export default function LoginWithPassword() {
         </p>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Need an account? <Link href="/signup" className="text-primaryDark hover:underline">Sign up</Link>
+        Need an account? <Link href="/signup" className="text-primary hover:underline">Sign up</Link>
       </div>
     </div>
   );
@@ -53,7 +54,7 @@ export default function LoginWithPassword() {
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} autoComplete="email" required />
-        <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />
+        <PasswordInput label="Password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
+import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -89,9 +90,8 @@ export default function SignupWithPassword() {
           required
           autoComplete="email"
         />
-        <Input
+        <PasswordInput
           label="Password"
-          type="password"
           placeholder="Create a password"
           value={pw}
           onChange={(e) => setPw(e.target.value)}


### PR DESCRIPTION
## Summary
- add PasswordInput component with show/hide toggle
- use PasswordInput on login and signup password pages and align signup link style

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b79704c8321ae2ce141508dfc54