### PR TITLE
chore: reconcile password pages with password input

### DIFF
--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -53,8 +53,23 @@ export default function LoginWithPassword() {
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
-        <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} autoComplete="email" required />
-        <PasswordInput label="Password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />
+        <Input
+          label="Email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          autoComplete="email"
+          required
+        />
+        <PasswordInput
+          label="Password"
+          placeholder="Your password"
+          value={pw}
+          onChange={(e) => setPw(e.target.value)}
+          autoComplete="current-password"
+          required
+        />
         <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
           {loading ? 'Signing in…' : 'Continue'}
         </Button>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -87,16 +87,16 @@ export default function SignupWithPassword() {
           placeholder="you@example.com"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          required
           autoComplete="email"
+          required
         />
         <PasswordInput
           label="Password"
           placeholder="Create a password"
           value={pw}
           onChange={(e) => setPw(e.target.value)}
-          required
           autoComplete="new-password"
+          required
           hint="At least 8 characters, including letters and numbers"
         />
         <Button


### PR DESCRIPTION
## Summary
- format login password form and ensure PasswordInput keeps `autoComplete`
- keep new main attributes on signup password form alongside PasswordInput

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae724096fc8321990889220b383dca