### PR TITLE
refactor: centralize profile and AIPlan types

### DIFF
--- a/components/visa/GapToGoal.tsx
+++ b/components/visa/GapToGoal.tsx
@@ -2,16 +2,13 @@ import React, { useEffect, useState } from 'react';
 
 import { Card } from '@/components/design-system/Card';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import type { Profile } from '@/types/profile';
 
 interface VisaTarget {
   user_id: string;
   institution: string;
   target_band: number;
   deadline: string | null;
-}
-
-interface Profile {
-  goal_band: number | null;
 }
 
 export const GapToGoal: React.FC = () => {

--- a/pages/admin/students/index.tsx
+++ b/pages/admin/students/index.tsx
@@ -4,14 +4,7 @@ import Head from 'next/head';
 import { AdminGuard } from '@/components/auth/AdminGuard';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { Container } from '@/components/design-system/Container';
-
-type Profile = {
-  id: string;
-  full_name: string | null;
-  email: string | null;
-  created_at?: string | null;
-  role?: string | null;
-};
+import type { Profile } from '@/types/profile';
 
 export default function Students() {
   const [q, setQ] = useState('');

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -6,12 +6,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Input } from '@/components/design-system/Input';
-
-type Profile = {
-  id: string;
-  full_name?: string | null;
-  role: 'student' | 'teacher' | 'admin';
-};
+import type { Profile } from '@/types/profile';
 
 const ROLES: Profile['role'][] = ['student','teacher','admin'];
 

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -20,28 +20,7 @@ import StudyCalendar from '@/components/feature/StudyCalendar';
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
 import GapToGoal from '@/components/visa/GapToGoal';
 import MotivationCoach from '@/components/coach/MotivationCoach';
-
-type AIPlan = {
-  suggestedGoal?: number;
-  etaWeeks?: number;
-  sequence?: string[];
-  notes?: string[];
-};
-
-type Profile = {
-  user_id: string;
-  full_name: string;
-  country: string | null;
-  english_level: string | null;
-  goal_band: number | null;
-  study_prefs: string[] | null;
-  time_commitment: string | null;
-  preferred_language: string | null;
-  avatar_url: string | null;
-  exam_date?: string | null;
-  ai_recommendation: AIPlan | null;
-  draft: boolean;
-};
+import type { Profile, AIPlan } from '@/types/profile';
 
 export default function Dashboard() {
   const router = useRouter();

--- a/pages/learning/skills/[skill].tsx
+++ b/pages/learning/skills/[skill].tsx
@@ -9,32 +9,13 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { StreakIndicator } from '@/components/design-system/StreakIndicator';
+import type { Profile, AIPlan } from '@/types/profile';
 
 const supabase = createClient(
   env.NEXT_PUBLIC_SUPABASE_URL,
   env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
-type CoachAI = {
-  suggestedGoal?: number;
-  etaWeeks?: number;
-  sequence?: string[];
-  notes?: string[];
-};
-
-type Profile = {
-  user_id: string;
-  full_name: string;
-  country: string | null;
-  english_level: string | null;
-  goal_band: number | null;
-  study_prefs: string[] | null;
-  time_commitment: string | null;
-  preferred_language: string | null;
-  avatar_url: string | null;
-  ai_recommendation: CoachAI | null;
-  draft: boolean;
-};
 
 export default function Dashboard() {
   const router = useRouter();
@@ -85,7 +66,7 @@ export default function Dashboard() {
     );
   }
 
-  const ai: CoachAI = profile?.ai_recommendation ?? {};
+  const ai: AIPlan = profile?.ai_recommendation ?? {};
   const prefs = profile?.study_prefs ?? [];
   const notes = Array.isArray(ai.notes) ? ai.notes : [];
 

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -1,0 +1,25 @@
+export interface AIPlan {
+  suggestedGoal?: number;
+  etaWeeks?: number;
+  sequence?: string[];
+  notes?: string[];
+}
+
+export interface Profile {
+  id?: string;
+  user_id?: string;
+  full_name?: string | null;
+  email?: string | null;
+  created_at?: string | null;
+  role?: 'student' | 'teacher' | 'admin' | string | null;
+  country?: string | null;
+  english_level?: string | null;
+  goal_band?: number | null;
+  study_prefs?: string[] | null;
+  time_commitment?: string | null;
+  preferred_language?: string | null;
+  avatar_url?: string | null;
+  exam_date?: string | null;
+  ai_recommendation?: AIPlan | null;
+  draft?: boolean;
+}


### PR DESCRIPTION
## Summary
- add shared `Profile` interface and `AIPlan` type in `types/profile`
- replace local profile declarations with imports
- consolidate profile-based types across dashboard, admin, and learning pages

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68aefc6b7db8832185f58442f07978c1