### PR TITLE
feat: centralize profile options

### DIFF
--- a/lib/profile-options.test.ts
+++ b/lib/profile-options.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+
+import { LEVELS, TIME } from './profile-options';
+import { levelGoalMap, timeMultiplierMap } from '../pages/api/ai/profile-suggest';
+
+assert.deepEqual(Object.keys(levelGoalMap), Array.from(LEVELS));
+assert.deepEqual(Object.keys(timeMultiplierMap), Array.from(TIME));
+
+console.log('Profile option maps are synchronized.');

--- a/lib/profile-options.ts
+++ b/lib/profile-options.ts
@@ -1,0 +1,25 @@
+export const COUNTRIES = [
+  'Pakistan',
+  'India',
+  'Bangladesh',
+  'United Arab Emirates',
+  'Saudi Arabia',
+  'United Kingdom',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand',
+] as const;
+
+export const LEVELS = [
+  'Beginner',
+  'Elementary',
+  'Pre-Intermediate',
+  'Intermediate',
+  'Upper-Intermediate',
+  'Advanced',
+] as const;
+
+export const TIME = ['1h/day', '2h/day', 'Flexible'] as const;
+
+export const PREFS = ['Listening', 'Reading', 'Writing', 'Speaking'] as const;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint",
     "pin:hash": "ts-node tools/hash-pin.ts",
     "diagnose": "powershell -ExecutionPolicy Bypass -File .\\\\tools\\\\report-build-issues.ps1",
-    "test": "NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"verbatimModuleSyntax\":false}' node -r ts-node/register lib/routeAccess.test.ts && NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"esnext\",\"verbatimModuleSyntax\":false,\"jsx\":\"react-jsx\"}' node --loader ts-node/esm components/ai/SidebarAI.test.ts"
+    "test": "NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"verbatimModuleSyntax\":false}' node -r ts-node/register lib/routeAccess.test.ts && NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"verbatimModuleSyntax\":false}' node -r ts-node/register lib/profile-options.test.ts && NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon TS_NODE_COMPILER_OPTIONS='{\"module\":\"esnext\",\"verbatimModuleSyntax\":false,\"jsx\":\"react-jsx\"}' node --loader ts-node/esm components/ai/SidebarAI.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/pages/placement/result.tsx
+++ b/pages/placement/result.tsx
@@ -6,6 +6,7 @@ import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { GradientText } from '@/components/design-system/GradientText';
+import { PREFS } from '@/lib/profile-options';
 
 export default function PlacementResult() {
   return (
@@ -16,7 +17,7 @@ export default function PlacementResult() {
           <h1 className="font-slab text-display mb-3"><GradientText>Your estimated bands</GradientText></h1>
           <Card className="p-6 rounded-ds-2xl">
             <div className="grid sm:grid-cols-4 gap-4 text-center">
-              {['Listening','Reading','Writing','Speaking'].map(s=>(
+              {PREFS.map(s=>(
                 <div key={s} className="p-4 rounded-ds border border-gray-200 dark:border-white/10">
                   <div className="text-small opacity-80">{s}</div>
                   <div className="text-h1">—</div>

--- a/pages/profile/setup.tsx
+++ b/pages/profile/setup.tsx
@@ -9,11 +9,7 @@ import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { Select } from '@/components/design-system/Select';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
-
-const COUNTRIES = ['Pakistan','India','Bangladesh','United Arab Emirates','Saudi Arabia','United Kingdom','United States','Canada','Australia','New Zealand'];
-const LEVELS: Array<'Beginner'|'Elementary'|'Pre-Intermediate'|'Intermediate'|'Upper-Intermediate'|'Advanced'> = ['Beginner','Elementary','Pre-Intermediate','Intermediate','Upper-Intermediate','Advanced'];
-const TIME = ['1h/day','2h/day','Flexible'];
-const PREFS = ['Listening','Reading','Writing','Speaking'];
+import { COUNTRIES, LEVELS, TIME, PREFS } from '@/lib/profile-options';
 
 /** ---- ISO week helpers for travel/festival/exam windows ---- */
 function getWeekRange(isoWeek: string) {
@@ -62,8 +58,8 @@ export default function ProfileSetup() {
   const [festivalWeek, setFestivalWeek] = useState('');
   const [examWeek, setExamWeek] = useState('');
 
-  const [prefs, setPrefs] = useState<string[]>([]);
-  const [time, setTime] = useState<string>('');
+  const [prefs, setPrefs] = useState<typeof PREFS[number][]>([]);
+  const [time, setTime] = useState<typeof TIME[number] | ''>('');
   const [lang, setLang] = useState('en');
   const [explanationLang, setExplanationLang] = useState('en');
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>();
@@ -142,14 +138,14 @@ export default function ProfileSetup() {
     if (!level) return null;
     const base = { 'Beginner': 5.5, 'Elementary': 6.0, 'Pre-Intermediate': 6.5, 'Intermediate': 7.0, 'Upper-Intermediate': 7.5, 'Advanced': 8.0 } as const;
     const suggestedGoal = base[level];
-    const focus = prefs.length ? prefs : ['Listening','Reading','Writing','Speaking'];
+    const focus = prefs.length ? prefs : [...PREFS];
     const etaWeeks = Math.max(4, Math.round((suggestedGoal - 5) * 6)); // rough ETA
     return { suggestedGoal, etaWeeks, sequence: focus };
   }, [level, prefs]);
 
   useEffect(() => { setAi(localAISuggest); }, [localAISuggest]);
 
-  const togglePref = (p: string) => {
+  const togglePref = (p: typeof PREFS[number]) => {
     setPrefs(prev => prev.includes(p) ? prev.filter(x => x !== p) : [...prev, p]);
   };
 


### PR DESCRIPTION
## Summary
- centralize profile-related option lists
- reuse profile constants in profile setup, AI suggestions, and placement result
- test to ensure option lists stay aligned with heuristics

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68aefc6fef5c832182468c559be07b92