### PR TITLE
refactor: centralize env config for API routes

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -7,51 +7,87 @@ const envSchema = z.object({
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
   NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES: z.coerce.number().default(30),
   NEXT_PUBLIC_DEBUG: z.string().optional(),
+  NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
 
-  // Server-only (optional in many places)
-  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  // Server-only vars
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_KEY: z.string().min(1),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
   ADMIN_EMAILS: z.string().optional(),
   GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
   GROQ_API_KEY: z.string().optional(),
   GROQ_MODEL: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
+  OPENAI_MODEL: z.string().optional(),
   GEMINI_API_KEY: z.string().optional(),
+  GEMINI_MODEL: z.string().optional(),
+  GX_AI_PROVIDER: z.string().optional(),
   PREMIUM_MASTER_PIN: z.string().optional(),
+  PREMIUM_PIN_HASH: z.string().optional(),
+  PREMIUM_PIN_SALT: z.string().optional(),
+  PREMIUM_PIN_RATE: z.coerce.number().optional(),
+  PREMIUM_PIN_WINDOW_SEC: z.coerce.number().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
   SPEAKING_DAILY_LIMIT: z.coerce.number().optional(),
   SPEAKING_BUCKET: z.string().optional(),
+  TWILIO_ACCOUNT_SID: z.string().min(1),
+  TWILIO_AUTH_TOKEN: z.string().min(1),
+  TWILIO_VERIFY_SERVICE_SID: z.string().min(1),
+  TWILIO_WHATSAPP_FROM: z.string().min(1),
+  LOCAL_ADMIN_TOKEN: z.string().optional(),
+  ADMIN_API_TOKEN: z.string().optional(),
+  SITE_URL: z.string().url().optional(),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 });
 
-// Pick specific keys (safe for client bundle)
 const raw = {
   NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
   NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES: process.env.NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES,
   NEXT_PUBLIC_DEBUG: process.env.NEXT_PUBLIC_DEBUG,
+  NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
 
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_KEY,
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
   ADMIN_EMAILS: process.env.ADMIN_EMAILS,
   GOOGLE_GENERATIVE_AI_API_KEY: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
   GROQ_API_KEY: process.env.GROQ_API_KEY,
   GROQ_MODEL: process.env.GROQ_MODEL,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  GEMINI_MODEL: process.env.GEMINI_MODEL,
+  GX_AI_PROVIDER: process.env.GX_AI_PROVIDER,
   PREMIUM_MASTER_PIN: process.env.PREMIUM_MASTER_PIN,
+  PREMIUM_PIN_HASH: process.env.PREMIUM_PIN_HASH,
+  PREMIUM_PIN_SALT: process.env.PREMIUM_PIN_SALT,
+  PREMIUM_PIN_RATE: process.env.PREMIUM_PIN_RATE,
+  PREMIUM_PIN_WINDOW_SEC: process.env.PREMIUM_PIN_WINDOW_SEC,
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
   STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
   SPEAKING_DAILY_LIMIT: process.env.SPEAKING_DAILY_LIMIT,
   SPEAKING_BUCKET: process.env.SPEAKING_BUCKET,
+  TWILIO_ACCOUNT_SID: process.env.TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN: process.env.TWILIO_AUTH_TOKEN,
+  TWILIO_VERIFY_SERVICE_SID: process.env.TWILIO_VERIFY_SERVICE_SID,
+  TWILIO_WHATSAPP_FROM: process.env.TWILIO_WHATSAPP_FROM,
+  LOCAL_ADMIN_TOKEN: process.env.LOCAL_ADMIN_TOKEN,
+  ADMIN_API_TOKEN: process.env.ADMIN_API_TOKEN,
+  SITE_URL: process.env.SITE_URL,
   NODE_ENV: process.env.NODE_ENV as any,
 };
 
 const parsed = envSchema.safeParse(raw);
 
-// Crash only on server if required vars are missing
 if (!parsed.success && typeof window === 'undefined') {
-  throw parsed.error;
+  const errors = parsed.error.issues
+    .map((i) => `${i.path.join('.')}: ${i.message}`)
+    .join('\n');
+  console.error('Invalid environment variables:\n' + errors);
+  throw new Error('Invalid environment variables');
 }
 
 export const env = (parsed.success

--- a/pages/api/admin/reviews/index.ts
+++ b/pages/api/admin/reviews/index.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import { requireRole } from '@/lib/requireRole';
+import { env } from '@/lib/env';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY! // needs RLS-bypass (server only)
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY // needs RLS-bypass (server only)
 );
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/admin/students/actions.ts
+++ b/pages/api/admin/students/actions.ts
@@ -2,10 +2,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { requireRole } from '@/lib/requireRole';
+import { env } from '@/lib/env';
 
 const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ||
-  process.env.SITE_URL ||
+  env.NEXT_PUBLIC_SITE_URL ||
+  env.SITE_URL ||
   'http://localhost:3000';
 
 type Action =

--- a/pages/api/admin/users/set-role.ts
+++ b/pages/api/admin/users/set-role.ts
@@ -3,10 +3,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import { requireRole } from '@/lib/requireRole';
 import type { Role } from '@/lib/roles';
+import { env } from '@/lib/env';
 
 const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY! // server-only
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY // server-only
 );
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/ai/health.ts
+++ b/pages/api/ai/health.ts
@@ -1,14 +1,15 @@
 // pages/api/ai/health.ts
+import { env } from '@/lib/env';
 export const config = { runtime: 'edge' };
 
 type Provider = 'gemini' | 'groq' | 'openai';
 
 function pick(): Provider | 'none' {
-  const pref = (process.env.GX_AI_PROVIDER || '').toLowerCase() as Provider;
+  const pref = (env.GX_AI_PROVIDER || '').toLowerCase() as Provider;
   if (pref) return pref;
-  if (process.env.GEMINI_API_KEY) return 'gemini';
-  if (process.env.GROQ_API_KEY) return 'groq';
-  if (process.env.OPENAI_API_KEY) return 'openai';
+  if (env.GEMINI_API_KEY) return 'gemini';
+  if (env.GROQ_API_KEY) return 'groq';
+  if (env.OPENAI_API_KEY) return 'openai';
   return 'none';
 }
 
@@ -20,9 +21,9 @@ export default async function handler() {
       ok,
       provider,
       keys: {
-        gemini: !!process.env.GEMINI_API_KEY,
-        groq: !!process.env.GROQ_API_KEY,
-        openai: !!process.env.OPENAI_API_KEY,
+        gemini: !!env.GEMINI_API_KEY,
+        groq: !!env.GROQ_API_KEY,
+        openai: !!env.OPENAI_API_KEY,
       },
     }),
     { headers: { 'Content-Type': 'application/json' }, status: 200 }

--- a/pages/api/blog/[slug].ts
+++ b/pages/api/blog/[slug].ts
@@ -1,6 +1,7 @@
 // pages/api/blog/[slug].ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 export interface BlogPostResponse {
   ok: boolean;
@@ -28,8 +29,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const slug = String(req.query.slug || '').trim();
   if (!slug) return res.status(400).json({ ok: false, message: 'Missing slug' });
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) return res.status(500).json({ ok: false, message: 'Server misconfigured' });
 
   const supa = createClient(url, serviceKey, { auth: { persistSession: false, autoRefreshToken: false } });

--- a/pages/api/blog/index.ts
+++ b/pages/api/blog/index.ts
@@ -1,6 +1,7 @@
 // pages/api/blog/index.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 /** ===== Types ===== */
 type Category = 'Listening' | 'Reading' | 'Writing' | 'Speaking' | 'Study Plan' | 'Product';
@@ -117,8 +118,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<BlogListResponse | BlogCreateResponse>
 ) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) return bad(res, 500, 'Server misconfigured: missing Supabase env.');
 
   const supa = createClient(url, serviceKey, {

--- a/pages/api/blog/moderate.ts
+++ b/pages/api/blog/moderate.ts
@@ -1,6 +1,7 @@
 // pages/api/blog/moderate.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 export interface ModerateRequest {
   slug: string;
@@ -30,12 +31,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return bad(res, 405, 'Method Not Allowed');
   }
   // Admin gate
-  if (!process.env.ADMIN_API_TOKEN || req.headers['x-admin-token'] !== process.env.ADMIN_API_TOKEN) {
+  if (!env.ADMIN_API_TOKEN || req.headers['x-admin-token'] !== env.ADMIN_API_TOKEN) {
     return bad(res, 403, 'Forbidden');
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) return bad(res, 500, 'Server misconfigured.');
 
   const parsed = validate(req.body as unknown);

--- a/pages/api/blog/modqueue.ts
+++ b/pages/api/blog/modqueue.ts
@@ -1,6 +1,7 @@
 // pages/api/blog/modqueue.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 export interface ModQueueItem {
   id: string;
@@ -30,12 +31,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return bad(res, 405, 'Method Not Allowed');
   }
   // Simple admin gate
-  if (!process.env.ADMIN_API_TOKEN || req.headers['x-admin-token'] !== process.env.ADMIN_API_TOKEN) {
+  if (!env.ADMIN_API_TOKEN || req.headers['x-admin-token'] !== env.ADMIN_API_TOKEN) {
     return bad(res, 403, 'Forbidden');
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) return bad(res, 500, 'Server misconfigured.');
 
   const supa = createClient(url, serviceKey, { auth: { persistSession: false, autoRefreshToken: false } });

--- a/pages/api/blog/submit.ts
+++ b/pages/api/blog/submit.ts
@@ -1,6 +1,7 @@
 // pages/api/blog/submit.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 export interface BlogSubmitRequest {
   slug: string;               // draft slug to submit
@@ -28,8 +29,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return bad(res, 405, 'Method Not Allowed');
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) return bad(res, 500, 'Server misconfigured.');
 
   const parsed = validate(req.body as unknown);

--- a/pages/api/check-otp.ts
+++ b/pages/api/check-otp.ts
@@ -1,10 +1,11 @@
 // /api/check-otp.js (server)
 import Twilio from "twilio";
 import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
 
-const client = Twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
-const SERVICE_SID = process.env.TWILIO_VERIFY_SERVICE_SID;
-const supa = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY); // server only
+const client = Twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
+const SERVICE_SID = env.TWILIO_VERIFY_SERVICE_SID;
+const supa = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY); // server only
 
 export default async function checkOtp(req, res) {
   const { phone, code } = req.body;

--- a/pages/api/dev/grant-role.ts
+++ b/pages/api/dev/grant-role.ts
@@ -1,15 +1,16 @@
 // pages/api/dev/grant-role.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { env } from '@/lib/env';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (process.env.NODE_ENV === 'production') {
+  if (env.NODE_ENV === 'production') {
     return res.status(403).json({ error: 'Disabled in production' });
   }
   if (req.method !== 'POST') return res.status(405).end();
 
   const authz = req.headers.authorization?.replace('Bearer ', '');
-  if (!authz || authz !== process.env.LOCAL_ADMIN_TOKEN) {
+  if (!authz || authz !== env.LOCAL_ADMIN_TOKEN) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 

--- a/pages/api/premium/signout.ts
+++ b/pages/api/premium/signout.ts
@@ -1,14 +1,16 @@
 // pages/api/premium/signout.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/lib/env';
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-const parts = [
-`pr_pin_ok=`,
-`Path=/premium`,
-`HttpOnly`,
-`SameSite=Lax`,
-`Max-Age=0`,
-];
-if (process.env.NODE_ENV === 'production') parts.push('Secure');
-res.setHeader('Set-Cookie', parts.join('; '));
-res.status(200).json({ ok: true });
+  const parts = [
+    `pr_pin_ok=`,
+    `Path=/premium`,
+    `HttpOnly`,
+    `SameSite=Lax`,
+    `Max-Age=0`,
+  ];
+  if (env.NODE_ENV === 'production') parts.push('Secure');
+  res.setHeader('Set-Cookie', parts.join('; '));
+  res.status(200).json({ ok: true });
 }

--- a/pages/api/premium/verify-pin.ts
+++ b/pages/api/premium/verify-pin.ts
@@ -1,14 +1,15 @@
 // pages/api/premium/verify-pin.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { scryptSync, timingSafeEqual } from 'crypto';
+import { env } from '@/lib/env';
 
 // ----------- env -----------
-const HASH_HEX = (process.env.PREMIUM_PIN_HASH || '').trim();
-const SALT_HEX = (process.env.PREMIUM_PIN_SALT || '').trim();
-const MASTER   = (process.env.PREMIUM_MASTER_PIN || '').trim();
-const RATE     = Number(process.env.PREMIUM_PIN_RATE || 10);          // attempts
-const WINDOW_S = Number(process.env.PREMIUM_PIN_WINDOW_SEC || 60);    // seconds
-const ONE_DAY  = 60 * 60 * 24;
+const HASH_HEX = (env.PREMIUM_PIN_HASH || '').trim();
+const SALT_HEX = (env.PREMIUM_PIN_SALT || '').trim();
+const MASTER = (env.PREMIUM_MASTER_PIN || '').trim();
+const RATE = Number(env.PREMIUM_PIN_RATE || 10); // attempts
+const WINDOW_S = Number(env.PREMIUM_PIN_WINDOW_SEC || 60); // seconds
+const ONE_DAY = 60 * 60 * 24;
 
 // ----------- naive in‑memory rate limiter (per dev instance) -----------
 type Bucket = { resetAt: number; count: number };
@@ -45,7 +46,7 @@ function verifyWithHash(pin: string) {
 }
 
 function okCookie() {
-  const isProd = process.env.NODE_ENV === 'production';
+  const isProd = env.NODE_ENV === 'production';
   return [
     'pr_pin_ok=1',
     'Path=/',

--- a/pages/api/send-otp.ts
+++ b/pages/api/send-otp.ts
@@ -1,7 +1,8 @@
 // /api/send-otp.js (server)
 import Twilio from "twilio";
-const client = Twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
-const SERVICE_SID = process.env.TWILIO_VERIFY_SERVICE_SID; // starts with VA...
+import { env } from "@/lib/env";
+const client = Twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
+const SERVICE_SID = env.TWILIO_VERIFY_SERVICE_SID; // starts with VA...
 
 export default async function sendOtp(req, res) {
   const { phone } = req.body; // expect E.164: +9233....

--- a/pages/api/speaking/attempts/index.ts
+++ b/pages/api/speaking/attempts/index.ts
@@ -3,9 +3,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { createClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { env } from '@/lib/env';
 
-const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 const SectionSchema = z.enum(['part1', 'part2', 'part3']);
 const ScoreSchema = z.object({

--- a/pages/api/support.ts
+++ b/pages/api/support.ts
@@ -1,6 +1,7 @@
 // pages/api/support.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
 
 /** ========= Types ========= */
 type SupportCategory = 'account' | 'billing' | 'modules' | 'ai' | 'technical' | 'other';
@@ -86,8 +87,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   }
 
   // Validate env for server-only Supabase client
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceRoleKey) {
     return res.status(500).json({
       ok: false,

--- a/pages/api/twilio-status.ts
+++ b/pages/api/twilio-status.ts
@@ -2,15 +2,16 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import Twilio from "twilio";
 import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
 
-const { TWILIO_AUTH_TOKEN, SUPABASE_URL, SUPABASE_SERVICE_KEY } = process.env;
-const supa = createClient(SUPABASE_URL!, SUPABASE_SERVICE_KEY!);
+const { TWILIO_AUTH_TOKEN, SUPABASE_URL, SUPABASE_SERVICE_KEY } = env;
+const supa = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).end();
   const signature = req.headers["x-twilio-signature"] as string | undefined;
-  const url = `${process.env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com"}/api/twilio-status`;
-  const valid = Twilio.validateRequest(TWILIO_AUTH_TOKEN!, signature || "", url, req.body);
+  const url = `${env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com"}/api/twilio-status`;
+  const valid = Twilio.validateRequest(TWILIO_AUTH_TOKEN, signature || "", url, req.body);
 
   if (!valid) return res.status(403).end("Invalid Twilio signature");
 

--- a/pages/api/upload/index.ts
+++ b/pages/api/upload/index.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { env } from '@/lib/env';
 
 export const config = { api: { bodyParser: false, sizeLimit: '30mb' } };
 
@@ -18,8 +19,8 @@ function parseForm(req: NextApiRequest) {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+  const ANON = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   const supabase = createClient(URL, ANON, {
     global: { headers: { Cookie: req.headers.cookie || '' } },

--- a/pages/api/whatsapp/subscribe.ts
+++ b/pages/api/whatsapp/subscribe.ts
@@ -26,10 +26,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (error) return res.status(500).json({ error: error.message });
 
   try {
-    const client = Twilio(process.env.TWILIO_ACCOUNT_SID!, process.env.TWILIO_AUTH_TOKEN!);
+    const client = Twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
     await client.messages.create({
       to: `whatsapp:${phone}`,
-      from: `whatsapp:${process.env.TWILIO_WHATSAPP_FROM}`,
+      from: `whatsapp:${env.TWILIO_WHATSAPP_FROM}`,
       body: "Thanks for subscribing to GramorX WhatsApp updates! Reply STOP to unsubscribe.",
     });
   } catch (e) {

--- a/pages/api/whatsapp/webhook.ts
+++ b/pages/api/whatsapp/webhook.ts
@@ -1,14 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import Twilio from "twilio";
 import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
 
-const {
-  TWILIO_AUTH_TOKEN,
-  NEXT_PUBLIC_SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} = process.env;
+const { TWILIO_AUTH_TOKEN, NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = env;
 
-const supa = createClient(NEXT_PUBLIC_SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!);
+const supa = createClient(NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
 export const config = { api: { bodyParser: true } };
 
@@ -19,8 +16,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const signature = req.headers["x-twilio-signature"] as string | undefined;
-  const url = `${process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"}/api/whatsapp/webhook`;
-  const valid = Twilio.validateRequest(TWILIO_AUTH_TOKEN!, signature || "", url, req.body);
+  const url = `${env.NEXT_PUBLIC_SITE_URL || "https://example.com"}/api/whatsapp/webhook`;
+  const valid = Twilio.validateRequest(TWILIO_AUTH_TOKEN, signature || "", url, req.body);
   if (!valid) return res.status(403).end("Invalid Twilio signature");
 
   const body = req.body as Record<string, string>;


### PR DESCRIPTION
## Summary
- add validated `env` config using zod with clear startup errors
- wire API routes to use `env` instead of `process.env`

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af02c4ddd4832189a80d19657ad166