### PR TITLE
Add exam date column to user_profiles

### DIFF
--- a/supabase/migrations/20250921_add_exam_date_to_user_profiles.sql
+++ b/supabase/migrations/20250921_add_exam_date_to_user_profiles.sql
@@ -1,0 +1,2 @@
+alter table public.user_profiles
+  add column exam_date date;


### PR DESCRIPTION
## Summary
- add SQL migration to extend `user_profiles` with an `exam_date`

## Testing
- `supabase db push` *(fails: command not found)*
- `supabase gen types types/db` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/file-type)*
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af182dee58832195c6950131325da7