### PR TITLE
Expand test coverage and add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/pages/mock-tests.test.ts
+++ b/pages/mock-tests.test.ts
@@ -1,0 +1,10 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const content = readFileSync(join(__dirname, 'mock-tests.tsx'), 'utf8');
+
+assert.match(content, /Mock Tests/);
+assert.match(content, /timed full tests with band score simulation/);
+
+console.log('mock tests page content verified');

--- a/tools/run-tests.ts
+++ b/tools/run-tests.ts
@@ -19,13 +19,25 @@ function run(cmd: string, compilerOptions: Record<string, unknown>) {
 const commonOptions = { module: 'commonjs', verbatimModuleSyntax: false };
 
 try {
+  // Auth workflow
   run('node -r ts-node/register lib/routeAccess.test.ts', commonOptions);
+
+  // Profile options utility
   run('node -r ts-node/register lib/profile-options.test.ts', commonOptions);
+
+  // Learning workflow
+  run('node -r ts-node/register lib/listening/score.test.ts', commonOptions);
+
+  // Mock tests workflow
+  run('node -r ts-node/register pages/mock-tests.test.ts', commonOptions);
+
+  // Component-specific test
   run('node --loader ts-node/esm components/ai/SidebarAI.test.ts', {
     module: 'esnext',
     verbatimModuleSyntax: false,
     jsx: 'react-jsx',
   });
+
   console.log('All tests passed.');
 } catch {
   process.exit(1);


### PR DESCRIPTION
## Summary
- broaden run-tests script to cover auth, learning, and mock-test workflows
- add mock test page content check
- introduce CI workflow running lint, tests, and build

## Testing
- `npm test` *(fails: ts-node: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1f0cf9508321acaeffdb5a0ac989