### PR TITLE
Validate redirect target for premium PIN

### DIFF
--- a/pages/premium/pin.tsx
+++ b/pages/premium/pin.tsx
@@ -3,13 +3,22 @@ import * as React from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
+function isInternalRoute(url: string) {
+  return url.startsWith('/') && !url.startsWith('//') && !url.includes('://');
+}
+
 export default function PremiumPinPage() {
   const router = useRouter();
-  const nextUrl =
+  let nextUrl =
     typeof router.query.next === 'string' && router.query.next ? router.query.next : '/premium';
 
   const [pin, setPin] = React.useState('');
   const [loading, setLoading] = React.useState(false);
+
+  if (!isInternalRoute(nextUrl)) {
+    nextUrl = '/premium';
+  }
+
   const [err, setErr] = React.useState<string | null>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
## Summary
- sanitize `next` query param for Premium PIN page to allow only internal routes
- introduce `isInternalRoute` helper for clarity

## Testing
- `npm test` *(fails: ts-node not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af478918ec83218df75b9abbb49ac2