### PR TITLE
Move avatar change from header to profile page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -155,6 +155,15 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   }, []);
 
   useEffect(() => {
+    const onAvatarChanged = (e: Event) => {
+      const ce = e as CustomEvent<{ url: string }>;
+      setUser((u) => ({ ...u, avatarUrl: ce.detail.url }));
+    };
+    window.addEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
+    return () => window.removeEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
+  }, []);
+
+  useEffect(() => {
     const onClick = (e: MouseEvent) => {
       const t = e.target as Node;
       if (modulesRef.current && !modulesRef.current.contains(t)) setOpenDesktopModules(false);
@@ -300,7 +309,6 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                       email={user.email}
                       name={user.name}
                       avatarUrl={user.avatarUrl}
-                      onAvatarChange={(url) => setUser((u) => ({ ...u, avatarUrl: url }))}
                       onSignOut={async () => { await supabaseBrowser.auth.signOut(); setStreakState(0); router.replace('/login'); }}
                     />
                   </li>

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -7,23 +7,17 @@ import { StreakIndicator } from '@/components/design-system/StreakIndicator';
 import { SavedItems } from '@/components/dashboard/SavedItems';
 import { useStreak } from '@/hooks/useStreak';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
-
-interface Profile {
-  full_name: string;
-  country: string | null;
-  english_level: string | null;
-  goal_band: number | null;
-  study_prefs: string[] | null;
-  time_commitment: string | null;
-  exam_date: string | null;
-  preferred_language: string | null;
-  draft?: boolean;
-}
+import { useToast } from '@/components/design-system/Toast';
+import type { Profile } from '@/types/profile';
 
 export default function ProfilePage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const { error: toastError, success: toastSuccess } = useToast();
   const { current: streak } = useStreak();
 
   useEffect(() => {
@@ -33,7 +27,7 @@ export default function ProfilePage() {
         router.replace('/login');
         return;
       }
-
+      setUserId(session.user.id);
       const { data, error } = await supabase
         .from('user_profiles')
         .select('*')
@@ -49,6 +43,48 @@ export default function ProfilePage() {
       setLoading(false);
     })();
   }, [router]);
+
+  const triggerUpload = () => fileRef.current?.click();
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !userId) return;
+    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      toastError('Please select a JPG, PNG, or WEBP image.');
+      return;
+    }
+    if (file.size > 3 * 1024 * 1024) {
+      toastError('Image too large. Max 3 MB.');
+      return;
+    }
+    setUploading(true);
+    try {
+      const ext = file.name.split('.').pop() || 'jpg';
+      const path = `${userId}/avatar-${Date.now()}.${ext}`;
+      const { error: upErr } = await supabase.storage.from('avatars').upload(path, file, {
+        upsert: true,
+        contentType: file.type,
+      });
+      if (upErr) throw upErr;
+      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
+      const publicUrl = pub.publicUrl;
+      const { error: updErr } = await supabase.auth.updateUser({ data: { avatar_url: publicUrl } });
+      if (updErr) throw updErr;
+      const { error: profErr } = await supabase
+        .from('user_profiles')
+        .update({ avatar_url: publicUrl })
+        .eq('user_id', userId);
+      if (profErr) throw profErr;
+      setProfile((p) => (p ? { ...p, avatar_url: publicUrl } : p));
+      window.dispatchEvent(new CustomEvent('profile:avatar-changed', { detail: { url: publicUrl } }));
+      toastSuccess('Photo updated');
+    } catch (err: any) {
+      console.error(err);
+      toastError(err?.message || 'Could not upload image. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -68,6 +104,34 @@ export default function ProfilePage() {
             <div className="flex items-center justify-between mb-6">
               <h1 className="font-slab text-display">Profile</h1>
               <StreakIndicator value={streak} />
+            </div>
+            <div className="flex items-center gap-4 mb-6">
+              <div className="h-20 w-20 rounded-full bg-vibrantPurple/10 flex items-center justify-center overflow-hidden">
+                {profile?.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={profile.avatar_url} alt="Avatar" className="h-20 w-20 object-cover" />
+                ) : (
+                  <span className="text-2xl font-semibold text-vibrantPurple">
+                    {profile?.full_name?.[0] || 'U'}
+                  </span>
+                )}
+              </div>
+              <div>
+                <button
+                  onClick={triggerUpload}
+                  className="text-small px-4 py-2 rounded-ds bg-vibrantPurple/10 hover:bg-vibrantPurple/15 font-medium"
+                  disabled={uploading}
+                >
+                  {uploading ? 'Uploading…' : 'Change photo'}
+                </button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={handleFile}
+                />
+              </div>
             </div>
             <div className="space-y-2 text-body">
               <p><strong>Name:</strong> {profile?.full_name}</p>


### PR DESCRIPTION
## Summary
- remove avatar upload from header user menu
- allow avatar update on profile page and notify header when changed

## Testing
- `npm test` *(fails: ts-node not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6c072de88321ba5e0e0c0bcff719