### PR TITLE
chore: move mock tests into dedicated test directory

### DIFF
--- a/__tests__/mock-tests.test.ts
+++ b/__tests__/mock-tests.test.ts
@@ -2,9 +2,9 @@ import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const content = readFileSync(join(__dirname, 'mock-tests.tsx'), 'utf8');
+const content = readFileSync(join(__dirname, '..', 'pages', 'mock-tests', 'index.tsx'), 'utf8');
 
 assert.match(content, /Mock Tests/);
-assert.match(content, /timed full tests with band score simulation/);
+assert.match(content, /Timed full-length tests and section-wise practice with band score simulation/);
 
 console.log('mock tests page content verified');

--- a/tools/run-tests.ts
+++ b/tools/run-tests.ts
@@ -29,7 +29,7 @@ try {
   run('node -r ts-node/register lib/listening/score.test.ts', commonOptions);
 
   // Mock tests workflow
-  run('node -r ts-node/register pages/mock-tests.test.ts', commonOptions);
+  run('node -r ts-node/register __tests__/mock-tests.test.ts', commonOptions);
 
   // Component-specific test
   run('node --loader ts-node/esm components/ai/SidebarAI.test.ts', {


### PR DESCRIPTION
## Summary
- move `mock-tests` page test into `__tests__`
- update test runner to reference moved file

## Testing
- `npm test` *(fails: sh: 1: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e3472d0832183769efee6ec23e7