### PR TITLE
Define border color token for Tailwind

### DIFF
--- a/design-system/tokens/colors.js
+++ b/design-system/tokens/colors.js
@@ -22,5 +22,7 @@ module.exports = {
   sunsetRed: '#ff4d4d',     // CTA gradient end
   lightCard: '#ffffff',     // light surface bg
   lightBorder: '#e0e0e0',   // light surface border
+  // Generic border token (alias of lightBorder)
+  border: '#e0e0e0',
   mutedText: '#d0d0e0',     // subtle text color
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,6 +33,7 @@ html, body, #__next { height: 100%; }
 
   --color-lightCard:     255 255 255;  /* #ffffff */
   --color-lightBorder:   224 224 224;  /* #e0e0e0 */
+  --color-border:        224 224 224;  /* #e0e0e0 */
   --color-mutedText:     208 208 224;  /* #d0d0e0 */
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,7 @@ module.exports = {
         grayish:       'rgb(var(--color-grayish) / <alpha-value>)',
         lightCard:     'rgb(var(--color-lightCard) / <alpha-value>)',
         lightBorder:   'rgb(var(--color-lightBorder) / <alpha-value>)',
+        border:        'rgb(var(--color-border) / <alpha-value>)',
         mutedText:     'rgb(var(--color-mutedText) / <alpha-value>)',
       },
 


### PR DESCRIPTION
## Summary
- add generic border color token in Tailwind
- expose `--color-border` variable and design-system alias

## Testing
- `npm test` *(fails: ts-node not found)*
- `npm install` *(fails: 403 Forbidden for file-type package)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e3a6af883218b0a51cb31a39ed6