### PR TITLE
Enable lint and type error checks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,12 +4,11 @@ import withPWA from 'next-pwa';
 const nextConfig = {
   reactStrictMode: true,
 
-  // TEMP: unblock build on Vercel while we fix code
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   env: {
     JAZZCASH_MERCHANT_ID: process.env.JAZZCASH_MERCHANT_ID ?? 'demo_merchant',


### PR DESCRIPTION
## Summary
- enforce ESLint and TypeScript checks during builds to avoid ignoring errors

## Testing
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af998efb8483218883ff1aa4a37ca8