### PR TITLE
feat: type groq transcription response

### DIFF
--- a/lib/ai/evaluateSpeaking.ts
+++ b/lib/ai/evaluateSpeaking.ts
@@ -1,6 +1,7 @@
 import { env } from "@/lib/env";
 // /lib/ai/evaluateSpeaking.ts
 import Groq from 'groq-sdk';
+import type { GroqTranscription } from '@/types/groq';
 
 export type Feedback = {
   band?: number;
@@ -87,15 +88,14 @@ export async function transcribeWithGroq(audioBytes: Buffer, filename = 'audio.w
   const groq = new Groq({ apiKey });
   // The Groq SDK expects a File (Web API). In Node 18+, File exists globally.
   const file = new File([audioBytes], filename, { type: 'audio/webm' });
-  const r = await groq.audio.transcriptions.create({
+  const r: GroqTranscription = await groq.audio.transcriptions.create({
     file,
     model: 'whisper-large-v3',
     response_format: 'verbose_json',
     temperature: 0.0
   });
-  // @ts-ignore types: r.text exists in verbose_json
-  const text: string | undefined = (r as any)?.text || (r as any)?.segments?.map((s: any) => s.text).join(' ');
-  return text?.trim() || null;
+  const text = r.text ?? r.segments?.map((s) => s.text).join(' ');
+  return text ? text.trim() : null;
 }
 
 // ---------- Fallback (never blocks UI) ----------

--- a/pages/api/speaking/score-audio-groq.ts
+++ b/pages/api/speaking/score-audio-groq.ts
@@ -2,6 +2,7 @@ import { env } from "@/lib/env";
 // pages/api/speaking/score-audio-groq.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Groq from 'groq-sdk';
+import type { GroqTranscription } from '@/types/groq';
 import { z } from 'zod';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -60,7 +61,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     fs.writeFileSync(tmpFile, buf);
 
     // Transcribe (Groq Whisper)
-    const transcription = await (groq as any).audio.transcriptions.create({
+    const transcription: GroqTranscription = await groq.audio.transcriptions.create({
       file: fs.createReadStream(tmpFile),
       model: 'whisper-large-v3',
       // language: 'en',
@@ -69,7 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     const transcript: string =
-      transcription?.text || transcription?.segments?.map((s: any) => s.text).join(' ').trim() || '';
+      transcription.text || transcription.segments?.map((s) => s.text).join(' ').trim() || '';
 
     // Score (Llama 3.3 70B)
     const systemPrompt = `

--- a/types/groq.ts
+++ b/types/groq.ts
@@ -1,0 +1,10 @@
+export interface GroqTranscriptionSegment {
+  text: string;
+  start?: number;
+  end?: number;
+}
+
+export interface GroqTranscription {
+  text?: string;
+  segments?: GroqTranscriptionSegment[];
+}


### PR DESCRIPTION
## Summary
- add GroqTranscription interfaces for text and segment data
- use new types for Groq transcription results and remove any/@ts-ignore

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af998aad648321b4aa9c2b7001f9c7