### PR TITLE
feat: add card color token

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -186,10 +186,10 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 
 /* AI sidebar helpers (theme aware, token-only) */
 .ai-icon-btn{
-  @apply h-8 w-8 grid place-items-center rounded-md border border-border bg-card text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50;
+  @apply h-8 w-8 grid place-items-center rounded-md border border-border bg-card text-card-foreground hover:bg-accent hover:text-foreground disabled:opacity-50;
 }
 .ai-tab{
-  @apply h-8 px-3 rounded-md border border-border bg-card text-caption text-muted-foreground hover:bg-accent hover:text-foreground;
+  @apply h-8 px-3 rounded-md border border-border bg-card text-caption text-card-foreground hover:bg-accent hover:text-foreground;
 }
 .ai-tab.is-active{
   @apply bg-primary text-primary-foreground;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,10 @@ module.exports = {
         lightBorder:   'rgb(var(--color-lightBorder) / <alpha-value>)',
         border:        'rgb(var(--color-border) / <alpha-value>)',
         mutedText:     'rgb(var(--color-mutedText) / <alpha-value>)',
+        card: {
+          DEFAULT: 'rgb(var(--color-lightCard) / <alpha-value>)',
+          foreground: 'rgb(var(--color-lightText) / <alpha-value>)',
+        },
       },
 
       borderRadius: {


### PR DESCRIPTION
## Summary
- add `card` color token and foreground mapping for Tailwind
- point AI icon and tab helpers at the new `card` color

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/file-type)*
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9984e7bc83218fadec3c87217823