### PR TITLE
Use Next.js Link for speaking attempts navigation

### DIFF
--- a/pages/speaking/simulator/part2.tsx
+++ b/pages/speaking/simulator/part2.tsx
@@ -1,6 +1,7 @@
 // pages/speaking/simulator/part2.tsx
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
 import Recorder from '@/components/speaking/Recorder';
@@ -419,7 +420,9 @@ export default function SpeakingPart2() {
                     </button>
                   </div>
                   <div className="mt-3">
-                    <a href="/speaking/attempts" className="text-sm underline">View all attempts</a>
+                    <Link href="/speaking/attempts/" className="text-sm underline">
+                      View all attempts
+                    </Link>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace raw anchor with `Link` in part2 simulator
- import `Link` from `next/link`

## Testing
- `npx next lint pages/speaking/simulator/part2.tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68afefce24a48321a930c93ca3de15d3