### PR TITLE
fix: escape apostrophe in WhatsApp opt-in message

### DIFF
--- a/components/dashboard/WhatsAppOptIn.tsx
+++ b/components/dashboard/WhatsAppOptIn.tsx
@@ -36,7 +36,7 @@ export function WhatsAppOptIn() {
       <h2 className="font-slab text-h2 mb-4">WhatsApp updates</h2>
       {status === "success" ? (
         <p className="text-sm text-gray-600 dark:text-grayish">
-          You're subscribed to WhatsApp reminders.
+          You&apos;re subscribed to WhatsApp reminders.
         </p>
       ) : (
         <form onSubmit={onSubmit} className="grid gap-4 sm:flex sm:items-end">


### PR DESCRIPTION
## Summary
- escape apostrophe in WhatsApp opt-in success message to satisfy JSX lint

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afefd2266c832182563022a4d26615