### PR TITLE
chore: remove unused Link import

### DIFF
--- a/components/sections/Learning/CourseCatalog.tsx
+++ b/components/sections/Learning/CourseCatalog.tsx
@@ -1,6 +1,5 @@
 import { env } from "@/lib/env";
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
 import { createClient } from '@supabase/supabase-js';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';


### PR DESCRIPTION
## Summary
- clean up CourseCatalog component by removing unused `Link` import

## Testing
- `npm test` (fails: Unknown file extension ".ts" for tools/run-tests.ts)
- `npm run lint` (fails: numerous existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68aff5b8d3e48321814285d0613b794a