### PR TITLE
chore: remove unused catch param

### DIFF
--- a/components/sections/Learning/DrillGenerator.tsx
+++ b/components/sections/Learning/DrillGenerator.tsx
@@ -20,7 +20,7 @@ export const DrillGenerator: React.FC = () => {
       });
       const data = await res.json();
       setResult(data.text ?? 'No content produced.');
-    } catch (e) {
+    } catch {
       setResult('Error generating drill. Try again.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- avoid unused error variable in `DrillGenerator` by using bare catch block

## Testing
- `node -r ts-node/register tools/run-tests.ts` *(fails: Unknown file extension ".ts" for tools/run-tests.ts)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aff5b9b96083219f0be36df473dee7