### PR TITLE
refactor: type-safe error handling in ChallengeScore

### DIFF
--- a/components/review/ChallengeScore.tsx
+++ b/components/review/ChallengeScore.tsx
@@ -26,8 +26,12 @@ export const ChallengeScore: React.FC<ChallengeProps> = ({ attemptId, type }) =>
       }
       const data = await res.json();
       setResult(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
       setResult(null);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- use `unknown` in ChallengeScore error handler
- safely derive error message using `instanceof Error`

## Testing
- `npm test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and related lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aff5b6ecd08321a3dc8120cf39633e