### PR TITLE
refactor: replace explicit any types

### DIFF
--- a/lib/requireRole.ts
+++ b/lib/requireRole.ts
@@ -36,9 +36,13 @@ export async function requireRole(
   if (error || !data?.user) throw new Error('unauthorized');
   const user = data.user;
 
+  interface RoleMetadata {
+    role?: AppRole;
+  }
+
   let role =
-    ((user.app_metadata as any)?.role as AppRole | undefined) ??
-    ((user.user_metadata as any)?.role as AppRole | undefined) ??
+    (user.app_metadata as RoleMetadata).role ??
+    (user.user_metadata as RoleMetadata).role ??
     null;
 
   if (!role) {

--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -10,9 +10,12 @@ export type AppRole = 'admin' | 'teacher' | 'student';
 // user has no recognized role.
 export function extractRole(user: User | null | undefined): AppRole | null {
   if (!user) return null;
+  interface RoleMetadata {
+    role?: unknown;
+  }
   const r =
-    (user.app_metadata as any)?.role ??
-    (user.user_metadata as any)?.role ??
+    (user.app_metadata as RoleMetadata).role ??
+    (user.user_metadata as RoleMetadata).role ??
     null;
   const v = r ? String(r).toLowerCase() : null;
   return v === 'admin' || v === 'teacher' || v === 'student' ? (v as AppRole) : null;

--- a/lib/speaking/saveJsonToStorage.ts
+++ b/lib/speaking/saveJsonToStorage.ts
@@ -5,7 +5,7 @@ type SaveOptions = {
   attemptId: string;
   ctx: 'p1' | 'p2' | 'p3' | 'chat';
   filename: string; // e.g. "q1.feedback.json"
-  data: any;
+  data: unknown;
 };
 
 /**

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -33,7 +33,7 @@ export type StreakData = {
   next_restart_date: string | null;
 };
 
-const normalize = (json: any): StreakData => ({
+const normalize = (json: Partial<StreakData> | null | undefined): StreakData => ({
   current_streak: json?.current_streak ?? 0,
   last_activity_date: json?.last_activity_date ?? null,
   shields: json?.shields ?? 0,
@@ -41,14 +41,17 @@ const normalize = (json: any): StreakData => ({
 });
 
 const handle = async (res: Response, fallbackMsg: string): Promise<StreakData> => {
-  let json: any = null;
+  let json: unknown = null;
   try {
     json = await res.json();
   } catch {
     // ignore
   }
-  if (!res.ok) throw new Error(json?.error || fallbackMsg);
-  return normalize(json);
+  if (!res.ok) {
+    const msg = (json as { error?: string })?.error;
+    throw new Error(msg || fallbackMsg);
+  }
+  return normalize(json as Partial<StreakData> | null | undefined);
 };
 
 /**

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -2,7 +2,7 @@ import { env } from './env';
 // lib/supabaseBrowser.ts
 import { createClient } from '@supabase/supabase-js';
 
-const url  = env.NEXT_PUBLIC_SUPABASE_URL;
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
 const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 // HMR-safe singleton in dev to avoid multiple GoTrueClient instances
@@ -17,12 +17,19 @@ const getClient = () =>
     },
   });
 
+declare global {
+  interface Window {
+    __supa?: ReturnType<typeof getClient>;
+    supa?: ReturnType<typeof getClient>;
+  }
+}
+
 export const supabaseBrowser =
-  (typeof window !== 'undefined'
-    ? ((window as any).__supa ?? ((window as any).__supa = getClient()))
-    : getClient());
+  typeof window !== 'undefined'
+    ? window.__supa ?? (window.__supa = getClient())
+    : getClient();
 
 // OPTIONAL: expose for console debugging in dev
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  (window as any).supa = supabaseBrowser;
+  window.supa = supabaseBrowser;
 }


### PR DESCRIPTION
## Summary
- replace explicit `any` casts in role helpers with typed metadata
- allow saving arbitrary JSON to storage using `unknown`
- tighten streak and Supabase client utilities with safer types

## Testing
- `npx eslint lib/requireRole.ts lib/roles.ts lib/speaking/saveJsonToStorage.ts lib/streak.ts lib/supabaseBrowser.ts -f json`
- `node --loader ts-node/esm tools/run-tests.ts` *(fails: Cannot require() ES Module ... in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68aff7e4ffc08321a6dbe2d56f09eb08