### PR TITLE
Hydrate Supabase session in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,10 +13,14 @@ export async function middleware(req: NextRequest) {
   const supabase = createMiddlewareClient({ req, res });
 
   const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) {
+  if (!session) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
     url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
@@ -26,7 +30,7 @@ export async function middleware(req: NextRequest) {
   const { data: sub } = await supabase
     .from('subscriptions')
     .select('id')
-    .eq('user_id', user.id)
+    .eq('user_id', user!.id)
     .eq('status', 'active')
     .maybeSingle();
 


### PR DESCRIPTION
## Summary
- hydrate Supabase session cookies in middleware and skip login redirect when session exists

## Testing
- `npm test` *(fails: tsx not found)*
- `node --loader ts-node/esm tools/run-tests.ts` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b005fd17188321a2acea3e8f292630