### PR TITLE
feat: add notifications context

### DIFF
--- a/components/design-system/NotificationBell.tsx
+++ b/components/design-system/NotificationBell.tsx
@@ -1,34 +1,165 @@
-import React from 'react';
-import { useToast } from '@/components/design-system/Toast';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import clsx from 'clsx';
 import { useNotifications } from '@/components/notifications/NotificationsContext';
+import type { Notification } from '@/components/notifications/NotificationsContext';
 
-/**
- * Simple notification bell. When clicked it shows a toast
- * letting the user know they have no unread notifications.
- */
+/** Notification bell with dropdown, mark-as-read, a11y-safe. */
 export const NotificationBell: React.FC = () => {
-  const { info } = useToast();
-  const { notifications, markAllRead } = useNotifications();
-  const unread = notifications.filter((n) => !n.read).length;
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const { notifications, markAllRead, refresh } = useNotifications();
 
-  const handleClick = () => {
-    if (unread === 0) info('No new notifications');
-    else markAllRead();
+  // Close on outside click / Escape
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (buttonRef.current?.contains(t)) return;
+      if (popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const unread = useMemo(
+    () => notifications.reduce((c, n) => c + (n.read ? 0 : 1), 0),
+    [notifications],
+  );
+
+  const markAsRead = async (id: string) => {
+    try {
+      await fetch(`/api/notifications/${id}/read`, { method: 'POST' });
+      await refresh();
+    } catch {
+      /* noop */
+    }
+  };
+
+  const markAllAsRead = async () => {
+    await markAllRead();
   };
 
   return (
-    <button
-      type="button"
-      aria-label="Notifications"
-      onClick={handleClick}
-      className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-purpleVibe/10"
-    >
-      <i className="fas fa-bell" aria-hidden="true" />
-      {unread > 0 && (
-        <span className="absolute right-1 top-1 inline-flex h-2 w-2 rounded-full bg-sunsetOrange" />
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="Notifications"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls="notification-menu"
+        onClick={() => setOpen((v) => !v)}
+        className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-purpleVibe/10"
+      >
+        <i className="fas fa-bell" aria-hidden="true" />
+        {unread > 0 && (
+          <span
+            aria-live="polite"
+            className={clsx(
+              'absolute -top-1 -right-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-sunsetOrange',
+              'px-1 text-[10px] leading-none text-white',
+            )}
+          >
+            {unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          ref={popoverRef}
+          className="absolute right-0 mt-2 w-72 rounded-2xl border border-purpleVibe/20 bg-lightBg dark:bg-dark shadow-lg z-50"
+        >
+          <div className="flex items-center justify-between border-b border-purpleVibe/20 px-3 py-2">
+            <span className="text-sm font-semibold">Notifications</span>
+            {unread > 0 && (
+              <button onClick={markAllAsRead} className="text-xs text-purpleVibe hover:underline">
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          <ul id="notification-menu" role="menu" className="max-h-72 overflow-auto text-sm">
+            {notifications.length === 0 ? (
+              <li role="menuitem" className="px-3 py-3 opacity-80">
+                No notifications
+              </li>
+            ) : (
+              notifications.map((n: Notification) => {
+                const isInternal = n.url?.startsWith('/');
+                const row = (
+                  <div className={clsx('flex items-start gap-2 px-3 py-2', n.read && 'opacity-60')}>
+                    <span className="flex-1">{n.message}</span>
+                    {!n.read && (
+                      <button
+                        className="text-xs text-purpleVibe hover:underline"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          markAsRead(n.id);
+                        }}
+                      >
+                        Mark
+                      </button>
+                    )}
+                  </div>
+                );
+
+                return (
+                  <li key={n.id} role="menuitem" className="hover:bg-purpleVibe/5">
+                    {n.url ? (
+                      isInternal ? (
+                        <Link
+                          href={n.url}
+                          className="block"
+                          onClick={() => {
+                            markAsRead(n.id);
+                            setOpen(false);
+                          }}
+                        >
+                          {row}
+                        </Link>
+                      ) : (
+                        <a
+                          href={n.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block"
+                          onClick={() => {
+                            markAsRead(n.id);
+                            setOpen(false);
+                          }}
+                        >
+                          {row}
+                        </a>
+                      )
+                    ) : (
+                      <button className="block w-full text-left" onClick={() => markAsRead(n.id)}>
+                        {row}
+                      </button>
+                    )}
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
       )}
-    </button>
+    </div>
   );
 };
 
 export default NotificationBell;
+

--- a/components/design-system/NotificationBell.tsx
+++ b/components/design-system/NotificationBell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useToast } from '@/components/design-system/Toast';
+import { useNotifications } from '@/components/notifications/NotificationsContext';
 
 /**
  * Simple notification bell. When clicked it shows a toast
@@ -7,15 +8,25 @@ import { useToast } from '@/components/design-system/Toast';
  */
 export const NotificationBell: React.FC = () => {
   const { info } = useToast();
+  const { notifications, markAllRead } = useNotifications();
+  const unread = notifications.filter((n) => !n.read).length;
+
+  const handleClick = () => {
+    if (unread === 0) info('No new notifications');
+    else markAllRead();
+  };
 
   return (
     <button
       type="button"
       aria-label="Notifications"
-      onClick={() => info('No new notifications')}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-purpleVibe/10"
+      onClick={handleClick}
+      className="relative inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-purpleVibe/10"
     >
       <i className="fas fa-bell" aria-hidden="true" />
+      {unread > 0 && (
+        <span className="absolute right-1 top-1 inline-flex h-2 w-2 rounded-full bg-sunsetOrange" />
+      )}
     </button>
   );
 };

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -1,0 +1,89 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+export type Notification = {
+  id: string;
+  read: boolean;
+  [key: string]: any;
+};
+
+interface NotificationsContextValue {
+  notifications: Notification[];
+  refresh: () => Promise<void>;
+  markAllRead: () => Promise<void>;
+}
+
+const NotificationsCtx = createContext<NotificationsContextValue | null>(null);
+
+export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const fetchNotifications = useCallback(async () => {
+    const {
+      data: { user },
+    } = await supabaseBrowser.auth.getUser();
+    if (!user) {
+      setNotifications([]);
+      return;
+    }
+    const { data } = await supabaseBrowser
+      .from('notifications')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false });
+    setNotifications((data as Notification[]) ?? []);
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    const {
+      data: { user },
+    } = await supabaseBrowser.auth.getUser();
+    if (!user) return;
+    await supabaseBrowser
+      .from('notifications')
+      .update({ read: true })
+      .eq('user_id', user.id)
+      .eq('read', false);
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, []);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
+
+  useEffect(() => {
+    let channel: ReturnType<typeof supabaseBrowser.channel> | null = null;
+    (async () => {
+      const {
+        data: { user },
+      } = await supabaseBrowser.auth.getUser();
+      if (!user) return;
+      channel = supabaseBrowser
+        .channel('notifications')
+        .on(
+          'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
+          fetchNotifications,
+        )
+        .subscribe();
+    })();
+    return () => {
+      if (channel) supabaseBrowser.removeChannel(channel);
+    };
+  }, [fetchNotifications]);
+
+  const value = useMemo(
+    () => ({ notifications, refresh: fetchNotifications, markAllRead }),
+    [notifications, fetchNotifications, markAllRead],
+  );
+
+  return <NotificationsCtx.Provider value={value}>{children}</NotificationsCtx.Provider>;
+};
+
+export function useNotifications() {
+  const ctx = useContext(NotificationsCtx);
+  if (!ctx) throw new Error('useNotifications must be used within <NotificationsProvider>');
+  return ctx;
+}
+
+export default NotificationsProvider;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,6 +24,7 @@ import {
 import { PremiumThemeProvider } from '@/premium-ui/theme/PremiumThemeProvider';
 import { ImpersonationBanner } from '@/components/admin/ImpersonationBanner';
 import { SidebarAI } from '@/components/ai/SidebarAI';
+import { NotificationsProvider } from '@/components/notifications/NotificationsContext';
 
 import { Poppins, Roboto_Slab } from 'next/font/google';
 const poppins = Poppins({
@@ -210,18 +211,20 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
       <div className={`${poppins.variable} ${slab.variable} ${poppins.className} min-h-[100dvh]`}>
         <ToastProvider>
-          {showLayout ? (
-            <Layout>
-              <ImpersonationBanner />
-              {pageBody}
-            </Layout>
-          ) : (
-            <>
-              <ImpersonationBanner />
-              {pageBody}
-            </>
-          )}
-          <SidebarAI />
+          <NotificationsProvider>
+            {showLayout ? (
+              <Layout>
+                <ImpersonationBanner />
+                {pageBody}
+              </Layout>
+            ) : (
+              <>
+                <ImpersonationBanner />
+                {pageBody}
+              </>
+            )}
+            <SidebarAI />
+          </NotificationsProvider>
         </ToastProvider>
       </div>
     </ThemeProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -211,20 +211,18 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
       <div className={`${poppins.variable} ${slab.variable} ${poppins.className} min-h-[100dvh]`}>
         <ToastProvider>
-          <NotificationsProvider>
-            {showLayout ? (
-              <Layout>
-                <ImpersonationBanner />
-                {pageBody}
-              </Layout>
-            ) : (
-              <>
-                <ImpersonationBanner />
-                {pageBody}
-              </>
-            )}
-            <SidebarAI />
-          </NotificationsProvider>
+          {showLayout ? (
+            <Layout>
+              <ImpersonationBanner />
+              {pageBody}
+            </Layout>
+          ) : (
+            <>
+              <ImpersonationBanner />
+              {pageBody}
+            </>
+          )}
+          <SidebarAI />
         </ToastProvider>
       </div>
     </ThemeProvider>
@@ -234,7 +232,9 @@ function InnerApp({ Component, pageProps }: AppProps) {
 export default function App(props: AppProps) {
   return (
     <LanguageProvider>
-      <InnerApp {...props} />
+      <NotificationsProvider>
+        <InnerApp {...props} />
+      </NotificationsProvider>
     </LanguageProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add NotificationsContext with refresh and markAllRead helpers
- wrap app with NotificationsProvider
- consume notifications in NotificationBell and show unread indicator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02917fce4832197254015acbccc1b