### PR TITLE
Fix SidebarAI import in _app

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,7 @@ import {
 
 import { PremiumThemeProvider } from '@/premium-ui/theme/PremiumThemeProvider';
 import { ImpersonationBanner } from '@/components/admin/ImpersonationBanner';
-import { SidebarAI } from '@/components/ai/SidebarAI';
+import SidebarAI from '@/components/ai/SidebarAI';
 
 import { Poppins, Roboto_Slab } from 'next/font/google';
 const poppins = Poppins({


### PR DESCRIPTION
## Summary
- use default import for `SidebarAI` in the main app component

## Testing
- `npm test`
- `npx tsx -e "import React from 'react'; import SidebarAI from './components/ai/SidebarAI'; import { renderToString } from 'react-dom/server'; console.log('Rendered:', renderToString(React.createElement(SidebarAI)));"`


------
https://chatgpt.com/codex/tasks/task_e_68b02f247ee483219b94726d4a205789