### PR TITLE
feat: add referral system

### DIFF
--- a/pages/account/referrals.tsx
+++ b/pages/account/referrals.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+
+interface Invite {
+  referred_id: string | null;
+  reward_credits: number;
+  reward_issued: boolean;
+  created_at: string;
+}
+
+export default function ReferralsPage() {
+  const [code, setCode] = useState<string>('');
+  const [invites, setInvites] = useState<Invite[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        router.replace('/login');
+        return;
+      }
+      try {
+        const res = await fetch('/api/referrals', {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        setCode(data.code);
+        setInvites(data.invites || []);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    })();
+  }, [router]);
+
+  const copyCode = () => {
+    if (!code) return;
+    navigator.clipboard.writeText(code).catch(() => {});
+  };
+
+  return (
+    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+      <Container>
+        <div className="max-w-xl mx-auto space-y-6">
+          <Card className="p-6 rounded-ds-2xl">
+            <h1 className="font-slab text-display mb-4">Referrals</h1>
+            {code ? (
+              <div className="mb-6">
+                <p className="mb-2">Your referral code:</p>
+                <div className="flex items-center gap-3">
+                  <code className="px-3 py-2 bg-gray-100 dark:bg-dark/40 rounded-ds">{code}</code>
+                  <Button variant="secondary" onClick={copyCode} className="rounded-ds">Copy</Button>
+                </div>
+              </div>
+            ) : (
+              <p className="mb-6">Loading…</p>
+            )}
+
+            <h2 className="font-slab text-h4 mb-2">Invite history</h2>
+            {invites.length === 0 && <p>No invites yet.</p>}
+            <ul className="space-y-2">
+              {invites.map((inv) => (
+                <li key={inv.referred_id} className="text-small flex justify-between">
+                  <span>{inv.referred_id ?? 'Unknown'}</span>
+                  <span>
+                    {inv.reward_issued ? `${inv.reward_credits} credits` : 'pending'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/pages/api/referrals.ts
+++ b/pages/api/referrals.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabaseFromRequest } from '@/lib/apiAuth';
+import { supabaseService } from '@/lib/supabaseService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const authed = supabaseFromRequest(req);
+    const { data: userData, error: userErr } = await authed.auth.getUser();
+    if (userErr || !userData?.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userId = userData.user.id;
+
+    // Ensure referral code exists
+    let { data: codeData } = await supabaseService
+      .from('referral_codes')
+      .select('code')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (!codeData) {
+      let code: string;
+      do {
+        code = Math.random().toString(36).slice(2, 8).toUpperCase();
+        const { data: exists } = await supabaseService
+          .from('referral_codes')
+          .select('user_id')
+          .eq('code', code)
+          .maybeSingle();
+        if (!exists) break;
+      } while (true);
+      const { data: inserted, error: insertErr } = await supabaseService
+        .from('referral_codes')
+        .insert({ user_id: userId, code })
+        .select('code')
+        .single();
+      if (insertErr) return res.status(500).json({ error: 'Could not create code' });
+      codeData = inserted;
+    }
+
+    const { data: invites } = await supabaseService
+      .from('referral_signups')
+      .select('referred_id, reward_credits, reward_issued, created_at')
+      .eq('referrer_id', userId)
+      .order('created_at', { ascending: false });
+
+    return res.status(200).json({ code: codeData.code, invites: invites || [] });
+  }
+
+  if (req.method === 'POST') {
+    const { code } = (req.body || {}) as { code?: string };
+    if (!code) return res.status(400).json({ error: 'Missing code' });
+
+    const authed = supabaseFromRequest(req);
+    const { data: userData, error: userErr } = await authed.auth.getUser();
+    if (userErr || !userData?.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const userId = userData.user.id;
+
+    const { data: ref } = await supabaseService
+      .from('referral_codes')
+      .select('user_id')
+      .eq('code', code)
+      .maybeSingle();
+
+    if (!ref?.user_id || ref.user_id === userId) {
+      return res.status(400).json({ error: 'Invalid code' });
+    }
+
+    const { error: insertErr } = await supabaseService
+      .from('referral_signups')
+      .insert({ referrer_id: ref.user_id, referred_id: userId, reward_credits: 50 });
+
+    if (insertErr) {
+      return res.status(500).json({ error: 'Could not record referral' });
+    }
+
+    return res.status(200).json({ ok: true });
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Button } from '@/components/design-system/Button';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 
 export default function SignupOptions() {
+  const router = useRouter();
+  const ref = typeof router.query.ref === 'string' ? router.query.ref : '';
+
   async function signUpOAuth(provider: 'apple' | 'google' | 'facebook') {
     await supabase.auth.signInWithOAuth({
       provider,
@@ -50,12 +54,12 @@ export default function SignupOptions() {
           <span className="inline-flex items-center gap-3"><i className="fab fa-facebook-f text-xl" aria-hidden /> Sign up with Facebook</span>
         </Button>
         <Button asChild variant="secondary" className="rounded-ds-xl w-full">
-          <Link href="/signup/password">
+          <Link href={`/signup/password${ref ? `?ref=${ref}` : ''}`}>
             <span className="inline-flex items-center gap-3"><i className="fas fa-envelope text-xl" aria-hidden /> Sign up with Email</span>
           </Link>
         </Button>
         <Button asChild variant="secondary" className="rounded-ds-xl w-full">
-          <Link href="/signup/phone">
+          <Link href={`/signup/phone${ref ? `?ref=${ref}` : ''}`}>
             <span className="inline-flex items-center gap-3"><i className="fas fa-sms text-xl" aria-hidden /> Sign up with Phone</span>
           </Link>
         </Button>

--- a/supabase/migrations/20250923_referrals.sql
+++ b/supabase/migrations/20250923_referrals.sql
@@ -1,0 +1,36 @@
+-- referrals tables
+-- Table to store unique referral code per user
+create table if not exists public.referral_codes (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  code text unique not null,
+  created_at timestamptz default now()
+);
+
+alter table public.referral_codes enable row level security;
+
+create policy "users can view own referral code"
+  on public.referral_codes for select
+  using (auth.uid() = user_id);
+
+create policy "users can insert own referral code"
+  on public.referral_codes for insert
+  with check (auth.uid() = user_id);
+
+-- Table to track signups using referral codes
+create table if not exists public.referral_signups (
+  id bigserial primary key,
+  referrer_id uuid references auth.users(id) on delete set null,
+  referred_id uuid references auth.users(id) on delete set null,
+  reward_credits integer default 0,
+  reward_issued boolean default false,
+  created_at timestamptz default now()
+);
+
+alter table public.referral_signups enable row level security;
+
+create policy "users can view own referrals"
+  on public.referral_signups for select
+  using (auth.uid() = referrer_id or auth.uid() = referred_id);
+
+create index if not exists referral_signups_referrer_idx on public.referral_signups(referrer_id);
+create index if not exists referral_signups_referred_idx on public.referral_signups(referred_id);


### PR DESCRIPTION
## Summary
- add referral tables and API endpoints
- expose referral page with invite history
- collect referral codes during signup and record rewards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04dc102588321af9e2e51e7713a4f