### PR TITLE
Use Supabase auth helpers for cookies and middleware

### DIFF
--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,21 +1,10 @@
-import { env } from './env';
 // lib/supabaseBrowser.ts
-import { createClient } from '@supabase/supabase-js';
-
-const url = env.NEXT_PUBLIC_SUPABASE_URL;
-const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// Use @supabase/auth-helpers-nextjs so that auth tokens are also
+// synchronised to cookies (sb-access-token / sb-refresh-token).
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 // HMR-safe singleton in dev to avoid multiple GoTrueClient instances
-const getClient = () =>
-  createClient(url, anon, {
-    auth: {
-      // Persist the auth session so that verification links
-      // and page reloads keep the user logged in.
-      persistSession: true,
-      autoRefreshToken: true,
-      // keep default storageKey (sb-<project>-auth-token)
-    },
-  });
+const getClient = () => createClientComponentClient();
 
 declare global {
   interface Window {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 // middleware.ts
-import { env } from '@/lib/env';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
 
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
@@ -9,56 +9,33 @@ export async function middleware(req: NextRequest) {
   // Only protect /premium/*
   if (!pathname.startsWith('/premium')) return NextResponse.next();
 
-  const token = req.cookies.get('sb-access-token')?.value;
-  if (!token) {
+  const res = NextResponse.next();
+  const supabase = createMiddlewareClient({ req, res });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
     url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
     return NextResponse.redirect(url);
   }
 
-  const userResp = await fetch(`${env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      apikey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    },
-  });
+  const { data: subs, error } = await supabase
+    .from('subscriptions')
+    .select('id')
+    .eq('user_id', session.user.id)
+    .eq('status', 'active');
 
-  if (!userResp.ok) {
-    const url = req.nextUrl.clone();
-    url.pathname = '/login';
-    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
-    return NextResponse.redirect(url);
-  }
-
-  const user = await userResp.json();
-
-  const subResp = await fetch(
-    `${env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/subscriptions?select=id&user_id=eq.${user.id}&status=eq.active`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        apikey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      },
-    },
-  );
-
-  if (!subResp.ok) {
+  if (error || !subs || subs.length === 0) {
     const url = req.nextUrl.clone();
     url.pathname = '/pricing';
     url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
     return NextResponse.redirect(url);
   }
 
-  const subs = await subResp.json();
-  if (!Array.isArray(subs) || subs.length === 0) {
-    const url = req.nextUrl.clone();
-    url.pathname = '/pricing';
-    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
-    return NextResponse.redirect(url);
-  }
-
-  return NextResponse.next();
+  return res;
 }
 
 export const config = { matcher: ['/premium/:path*'] };


### PR DESCRIPTION
## Summary
- create a browser Supabase client via `@supabase/auth-helpers-nextjs` so login writes sb-access-token cookies
- replace manual token checks in middleware with `createMiddlewareClient` and Supabase queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b078b4111483219b8c6b4a683cd785