### PR TITLE
refactor: offload premium check to serverless endpoint

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,9 @@
 // middleware.ts
-import { env } from '@/lib/env';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export async function middleware(req: NextRequest) {
-  const { pathname, search } = req.nextUrl;
+  const { pathname, search, origin } = req.nextUrl;
 
   // Only protect /premium/*
   if (!pathname.startsWith('/premium')) return NextResponse.next();
@@ -17,41 +16,19 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  const userResp = await fetch(`${env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      apikey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    },
+  const resp = await fetch(`${origin}/api/premium/status`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
 
-  if (!userResp.ok) {
+  if (!resp.ok) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
     url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
     return NextResponse.redirect(url);
   }
 
-  const user = await userResp.json();
-
-  const subResp = await fetch(
-    `${env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/subscriptions?select=id&user_id=eq.${user.id}&status=eq.active`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        apikey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      },
-    },
-  );
-
-  if (!subResp.ok) {
-    const url = req.nextUrl.clone();
-    url.pathname = '/pricing';
-    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
-    return NextResponse.redirect(url);
-  }
-
-  const subs = await subResp.json();
-  if (!Array.isArray(subs) || subs.length === 0) {
+  const { active } = await resp.json();
+  if (!active) {
     const url = req.nextUrl.clone();
     url.pathname = '/pricing';
     url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;

--- a/pages/api/premium/status.ts
+++ b/pages/api/premium/status.ts
@@ -1,0 +1,37 @@
+import { env } from '@/lib/env';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ active: boolean } | { error: string }>
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const auth = req.headers.authorization || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+
+  const supabase = createClient(
+    env.NEXT_PUBLIC_SUPABASE_URL as string,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  const user = userData?.user;
+  if (userError || !user) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { data, error } = await supabase
+    .from('subscriptions')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (error) return res.status(500).json({ error: error.message });
+
+  return res.status(200).json({ active: Boolean(data) });
+}


### PR DESCRIPTION
## Summary
- move subscription check out of edge middleware into an API route
- middleware calls new endpoint and no longer depends on `process.*`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b07a4bc3408321ba395376db7d4a22