### PR TITLE
docs: document all environment variables

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -2,28 +2,54 @@
 
 The application relies on the following environment variables. Provide these values in your `.env` files or in your Vercel project settings.
 
-| Key | Description |
-| --- | --- |
-| `NEXT_PUBLIC_SUPABASE_URL` | URL of the Supabase instance. |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key for Supabase. |
-| `SUPABASE_URL` | Server-side URL of the Supabase instance. |
-| `SUPABASE_SERVICE_KEY` | Supabase service key for server-side tasks. |
-| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for server-side tasks. |
-| `NEXT_PUBLIC_BASE_URL` | Base URL for building absolute links. |
-| `ADMIN_EMAILS` | Comma separated list of admin emails. |
-| `GOOGLE_GENERATIVE_AI_API_KEY` | Google Generative AI API key. |
-| `GROQ_API_KEY` | Groq API key. |
-| `GROQ_MODEL` | Groq model identifier. |
-| `OPENAI_API_KEY` | OpenAI API key. |
-| `GEMINI_API_KEY` | Gemini API key. |
-| `PREMIUM_MASTER_PIN` | Master PIN for premium feature access. |
-| `SPEAKING_DAILY_LIMIT` | Daily limit for speaking attempts. |
-| `SPEAKING_BUCKET` | Storage bucket name for speaking uploads. |
-| `TWILIO_ACCOUNT_SID` | Twilio account SID for messaging. |
-| `TWILIO_AUTH_TOKEN` | Twilio authentication token. |
-| `TWILIO_VERIFY_SERVICE_SID` | Twilio Verify service SID. |
-| `TWILIO_WHATSAPP_FROM` | Phone number used for WhatsApp messages. |
-| `NEXT_PUBLIC_DEBUG` | Enables debug features when set. |
+## Public Variables
+
+| Key | Description | Required |
+| --- | --- | :---: |
+| `NEXT_PUBLIC_SUPABASE_URL` | URL of the Supabase instance. | Yes |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key for Supabase. | Yes |
+
+## Server-only Variables
+
+| Key | Description | Required |
+| --- | --- | :---: |
+| `SUPABASE_URL` | Server-side URL of the Supabase instance. | Yes |
+| `SUPABASE_SERVICE_KEY` | Supabase service key for server-side tasks. | Yes |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for server-side tasks. | Yes |
+| `TWILIO_ACCOUNT_SID` | Twilio account SID for messaging. | Yes |
+| `TWILIO_AUTH_TOKEN` | Twilio authentication token. | Yes |
+| `TWILIO_VERIFY_SERVICE_SID` | Twilio Verify service SID. | Yes |
+| `TWILIO_WHATSAPP_FROM` | Phone number used for WhatsApp messages. | Yes |
+
+## Optional Variables
+
+| Key | Description | Scope | Required |
+| --- | --- | --- | :---: |
+| `NEXT_PUBLIC_BASE_URL` | Base URL for building absolute links. | Public | No |
+| `NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES` | Client idle timeout in minutes (default 30). | Public | No |
+| `NEXT_PUBLIC_DEBUG` | Enables debug features when set. | Public | No |
+| `NEXT_PUBLIC_SITE_URL` | Public site URL override. | Public | No |
+| `ADMIN_EMAILS` | Comma separated list of admin emails. | Server | No |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Google Generative AI API key. | Server | No |
+| `GROQ_API_KEY` | Groq API key. | Server | No |
+| `GROQ_MODEL` | Groq model identifier. | Server | No |
+| `OPENAI_API_KEY` | OpenAI API key. | Server | No |
+| `OPENAI_MODEL` | OpenAI model identifier. | Server | No |
+| `GEMINI_API_KEY` | Gemini API key. | Server | No |
+| `GEMINI_MODEL` | Gemini model identifier. | Server | No |
+| `GX_AI_PROVIDER` | Default AI provider selection. | Server | No |
+| `PREMIUM_MASTER_PIN` | Master PIN for premium feature access. | Server | No |
+| `PREMIUM_PIN_HASH` | Hashed value for premium PIN. | Server | No |
+| `PREMIUM_PIN_SALT` | Salt used to hash the premium PIN. | Server | No |
+| `PREMIUM_PIN_RATE` | Rate limit for PIN attempts. | Server | No |
+| `PREMIUM_PIN_WINDOW_SEC` | Time window in seconds for PIN rate limiting. | Server | No |
+| `STRIPE_SECRET_KEY` | Stripe secret key. | Server | No |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret. | Server | No |
+| `SPEAKING_DAILY_LIMIT` | Daily limit for speaking attempts. | Server | No |
+| `SPEAKING_BUCKET` | Storage bucket name for speaking uploads. | Server | No |
+| `LOCAL_ADMIN_TOKEN` | Local development admin token. | Server | No |
+| `ADMIN_API_TOKEN` | Token for admin API access. | Server | No |
+| `SITE_URL` | Server-side site URL override. | Server | No |
+| `NODE_ENV` | Node environment (`development`, `production`, or `test`). | Server | No |
 
 These variables are validated at runtime in [`lib/env.ts`](../lib/env.ts).
-


### PR DESCRIPTION
## Summary
- categorize environment variables into public, server-only, and optional sections
- add missing env var descriptions and mark whether each is required

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0839ca584832195c47d4d6de9434d