### PR TITLE
refactor: use env helpers in Twilio webhook

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -38,6 +38,7 @@ const envSchema = z.object({
   LOCAL_ADMIN_TOKEN: z.string().optional(),
   ADMIN_API_TOKEN: z.string().optional(),
   SITE_URL: z.string().url().optional(),
+  PORT: z.coerce.number().optional(),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 });
 
@@ -77,6 +78,7 @@ const raw = {
   LOCAL_ADMIN_TOKEN: process.env.LOCAL_ADMIN_TOKEN,
   ADMIN_API_TOKEN: process.env.ADMIN_API_TOKEN,
   SITE_URL: process.env.SITE_URL,
+  PORT: process.env.PORT,
   NODE_ENV: process.env.NODE_ENV as any,
 };
 


### PR DESCRIPTION
## Summary
- centralize Twilio webhook env handling via `lib/env`
- reuse existing `supabaseService` client and drop direct `createClient`
- expose optional `PORT` in env schema

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0839cbf2c832195d0672c502639f3