### PR TITLE
feat(env): allow skipping env validation during tests

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -80,19 +80,45 @@ const raw = {
   NODE_ENV: process.env.NODE_ENV as any,
 };
 
+const skipValidation =
+  process.env.SKIP_ENV_VALIDATION === 'true' || raw.NODE_ENV === 'test';
+
 const parsed = envSchema.safeParse(raw);
 
 if (!parsed.success && typeof window === 'undefined') {
-  const errors = parsed.error.issues
-    .map((i) => `${i.path.join('.')}: ${i.message}`)
-    .join('\n');
-  console.error('Invalid environment variables:\n' + errors);
-  throw new Error('Invalid environment variables');
+  if (skipValidation) {
+    const warnings = parsed.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    console.warn(
+      'Skipping environment variable validation. Falling back to safe defaults:\n' +
+        warnings,
+    );
+  } else {
+    const errors = parsed.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    console.error('Invalid environment variables:\n' + errors);
+    throw new Error('Invalid environment variables');
+  }
 }
+
+const defaults = {
+  NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon_key',
+  SUPABASE_URL: 'http://localhost:54321',
+  SUPABASE_SERVICE_KEY: 'service_key',
+  SUPABASE_SERVICE_ROLE_KEY: 'service_role_key',
+  TWILIO_ACCOUNT_SID: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  TWILIO_AUTH_TOKEN: 'auth_token',
+  TWILIO_VERIFY_SERVICE_SID: 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  TWILIO_WHATSAPP_FROM: 'whatsapp:+10000000000',
+};
 
 export const env = (parsed.success
   ? parsed.data
   : {
+      ...defaults,
       ...raw,
       NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES: Number(
         raw.NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES ?? 30,


### PR DESCRIPTION
## Summary
- allow skipping environment validation with `SKIP_ENV_VALIDATION` or when `NODE_ENV` is `test`
- log warnings and provide safe defaults when validation is skipped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0839cf3f88321bca7fdba2e06a3fc