### PR TITLE
Handle invalid_grant auth errors

### DIFF
--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -21,7 +21,18 @@ export default function LoginWithEmail() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) {
+      const msg = error.message?.toLowerCase() ?? '';
+      if (
+        error.code === 'invalid_grant' &&
+        (msg.includes('weak_password') || (msg.includes('password') && msg.includes('undefined')))
+      ) {
+        setErr('Use your Google/Facebook/Apple account to sign in');
+      } else {
+        setErr(error.message);
+      }
+      return;
+    }
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -22,7 +22,18 @@ export default function LoginWithPassword() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) {
+      const msg = error.message?.toLowerCase() ?? '';
+      if (
+        error.code === 'invalid_grant' &&
+        (msg.includes('weak_password') || (msg.includes('password') && msg.includes('undefined')))
+      ) {
+        setErr('Use your Google/Facebook/Apple account to sign in');
+      } else {
+        setErr(error.message);
+      }
+      return;
+    }
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,


### PR DESCRIPTION
## Summary
- Detect Supabase `invalid_grant` errors caused by weak or missing passwords and show a social-login hint
- Guide users to use Google, Facebook, or Apple when password sign-in isn't available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a78255748321ba7ade06f5bc024e