### PR TITLE
Handle banned user error in login pages

### DIFF
--- a/lib/authErrors.ts
+++ b/lib/authErrors.ts
@@ -1,0 +1,5 @@
+export function getAuthErrorMessage(error: { code?: string; message: string } | null): string {
+  if (!error) return '';
+  if (error.code === 'user_banned') return 'Account disabled. Contact support.';
+  return error.message;
+}

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import { getAuthErrorMessage } from '@/lib/authErrors';
 
 export default function LoginWithEmail() {
   const [email, setEmail] = useState('');
@@ -21,7 +22,7 @@ export default function LoginWithEmail() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) return setErr(getAuthErrorMessage(error));
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import { getAuthErrorMessage } from '@/lib/authErrors';
 
 export default function LoginWithPassword() {
   const [email, setEmail] = useState('');
@@ -22,7 +23,7 @@ export default function LoginWithPassword() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) return setErr(getAuthErrorMessage(error));
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import { getAuthErrorMessage } from '@/lib/authErrors';
 
 export default function LoginWithPhone() {
   const [phone, setPhone] = useState('');
@@ -22,7 +23,7 @@ export default function LoginWithPhone() {
     setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: false } });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) return setErr(getAuthErrorMessage(error));
     setStage('verify');
   }
 
@@ -34,7 +35,7 @@ export default function LoginWithPhone() {
     // @ts-expect-error `token` is supported for verification
     const { data, error } = await supabase.auth.signInWithOtp({ phone, token: code });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) return setErr(getAuthErrorMessage(error));
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,


### PR DESCRIPTION
## Summary
- centralize auth error message mapping for Supabase user bans
- display "Account disabled. Contact support." on email, password, and phone login flows when user is banned

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a77faffc8321a1bd824fdd745358