### PR TITLE
feat: allow resending phone login code

### DIFF
--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -14,6 +14,8 @@ export default function LoginWithPhone() {
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [resendAttempts, setResendAttempts] = useState(0);
 
   async function requestOtp(e: React.FormEvent) {
     e.preventDefault();
@@ -23,6 +25,7 @@ export default function LoginWithPhone() {
     const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: false } });
     setLoading(false);
     if (error) return setErr(error.message);
+    setResendAttempts(0);
     setStage('verify');
   }
 
@@ -47,6 +50,17 @@ export default function LoginWithPhone() {
       }
       redirectByRole(data.session.user);
     }
+  }
+
+  async function resendOtp() {
+    setErr(null);
+    setLoading(true);
+    setResending(true);
+    const { error } = await supabase.auth.signInWithOtp({ phone, options: { shouldCreateUser: false } });
+    setLoading(false);
+    setResending(false);
+    if (error) return setErr(error.message);
+    setResendAttempts((a) => a + 1);
   }
 
   const RightPanel = (
@@ -87,7 +101,10 @@ export default function LoginWithPhone() {
         <form onSubmit={verifyOtp} className="space-y-6 mt-2">
           <Input label="Verification code" inputMode="numeric" placeholder="123456" value={code} onChange={(e)=>setCode(e.target.value)} required />
           <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
-            {loading ? 'Verifying…' : 'Verify & Continue'}
+            {loading && !resending ? 'Verifying…' : 'Verify & Continue'}
+          </Button>
+          <Button type="button" variant="secondary" className="w-full rounded-ds-xl" onClick={resendOtp} disabled={loading}>
+            {loading && resending ? 'Resending…' : `Resend code${resendAttempts ? ` (${resendAttempts})` : ''}`}
           </Button>
         </form>
       )}


### PR DESCRIPTION
## Summary
- track resend attempts during phone verification
- add "Resend code" button that calls `signInWithOtp` again

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a77e016483218225c3bd5b0e7447