### PR TITLE
Add forgot password link after login errors

### DIFF
--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -59,7 +59,16 @@ export default function LoginWithEmail() {
 
   return (
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
-      {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
+      {err && (
+        <div className="mb-4 space-y-4">
+          <Alert variant="error" title="Error">
+            {err}
+          </Alert>
+          <Button asChild variant="secondary" className="w-full rounded-ds-xl">
+            <Link href="/forgot-password">Forgot password?</Link>
+          </Button>
+        </div>
+      )}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input label="Email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} autoComplete="email" required />
         <Input label="Password" type="password" placeholder="Your password" value={pw} onChange={(e)=>setPw(e.target.value)} autoComplete="current-password" required />

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -56,7 +56,16 @@ export default function LoginWithPassword() {
 
   return (
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
-      {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
+      {err && (
+        <div className="mb-4 space-y-4">
+          <Alert variant="error" title="Error">
+            {err}
+          </Alert>
+          <Button asChild variant="secondary" className="w-full rounded-ds-xl">
+            <Link href="/forgot-password">Forgot password?</Link>
+          </Button>
+        </div>
+      )}
       <form onSubmit={onSubmit} className="space-y-6 mt-2">
         <Input
           label="Email"


### PR DESCRIPTION
## Summary
- show an actionable "Forgot password?" link after login errors in email/password pages
- style the link as a secondary action to match existing UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a77829b083219e297de4ad935852