### PR TITLE
feat: show signup link for missing accounts

### DIFF
--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -11,7 +11,7 @@ import { redirectByRole } from '@/lib/routeAccess';
 export default function LoginWithEmail() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
-  const [err, setErr] = useState<string | null>(null);
+  const [err, setErr] = useState<React.ReactNode>(null);
   const [loading, setLoading] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
@@ -21,7 +21,20 @@ export default function LoginWithEmail() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) {
+      if (error.code === 'user_not_found') {
+        return setErr(
+          <span>
+            Account not found. Try{' '}
+            <Link href="/signup" className="underline text-primaryDark">
+              signing up
+            </Link>
+            .
+          </span>
+        );
+      }
+      return setErr(error.message);
+    }
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -12,7 +12,7 @@ import { redirectByRole } from '@/lib/routeAccess';
 export default function LoginWithPassword() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
-  const [err, setErr] = useState<string | null>(null);
+  const [err, setErr] = useState<React.ReactNode>(null);
   const [loading, setLoading] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
@@ -22,7 +22,20 @@ export default function LoginWithPassword() {
     setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) {
+      if (error.code === 'user_not_found') {
+        return setErr(
+          <span>
+            Account not found. Try{' '}
+            <Link href="/signup" className="underline text-primary">
+              signing up
+            </Link>
+            .
+          </span>
+        );
+      }
+      return setErr(error.message);
+    }
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,


### PR DESCRIPTION
## Summary
- show custom message when Supabase returns `user_not_found` during email/password login
- include signup link in error display

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a7760dfc8321a5ae9bfee085d10e