### PR TITLE
Handle existing Supabase accounts during signup

### DIFF
--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -49,7 +49,11 @@ export default function SignupWithPassword() {
       setLoading(false);
 
       if (error) {
-        setErr(error.message);
+        if (error.code === 'user_exists') {
+          setErr('user_exists');
+        } else {
+          setErr(error.message);
+        }
         return;
       }
 
@@ -102,7 +106,17 @@ export default function SignupWithPassword() {
     >
       {err && (
         <Alert variant="error" title="Error" className="mb-4">
-          {err}
+          {err === 'user_exists' ? (
+            <>
+              Account already exists. Try{' '}
+              <Link href="/login" className="underline">
+                logging in
+              </Link>
+              .
+            </>
+          ) : (
+            err
+          )}
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary
- Detect Supabase `user_exists` error when signing up with email
- Show "Account already exists" message with link to `/login`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a783e7648321b637fef6b4e08c85