### PR TITLE
Handle existing accounts on OAuth signup

### DIFF
--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -11,12 +11,19 @@ export default function SignupOptions() {
   const ref = typeof router.query.ref === 'string' ? router.query.ref : '';
 
   async function signUpOAuth(provider: 'apple' | 'google' | 'facebook') {
-    await supabase.auth.signInWithOAuth({
+    const { data } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: typeof window !== 'undefined' ? `${window.location.origin}/profile/setup` : undefined,
+        skipBrowserRedirect: true,
       },
     });
+
+    if (data?.linked_email) {
+      router.push(`/login?message=${encodeURIComponent('Account exists—use login.')}`);
+    } else if (data?.url) {
+      window.location.href = data.url;
+    }
   }
 
   const RightPanel = (


### PR DESCRIPTION
## Summary
- Check for `linked_email` after signing in with OAuth on the signup page
- Redirect to login with notice if an account already exists
- Continue to OAuth provider when no linked email is found

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a78816948321ab9a39ea4eb30f51