### PR TITLE
feat: validate password strength before signup

### DIFF
--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -33,6 +33,12 @@ export default function SignupWithPassword() {
       return;
     }
 
+    const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+    if (!pwRegex.test(pw)) {
+      setErr('Use a stronger password');
+      return;
+    }
+
     try {
       setLoading(true);
       const { error } = await supabase.auth.signUp({


### PR DESCRIPTION
## Summary
- validate password with regex before calling Supabase sign up
- show a stronger password warning when validation fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a7892a0c8321bbdddb223c389809