### PR TITLE
feat: prevent password reuse

### DIFF
--- a/pages/update-password.tsx
+++ b/pages/update-password.tsx
@@ -19,6 +19,15 @@ export default function UpdatePassword() {
     setErr(null);
     if (!password) return setErr('Please enter a new password.');
     setLoading(true);
+    const { data: reused, error: rpcError } = await supabase.rpc('password_is_reused', { new_password: password });
+    if (rpcError) {
+      setLoading(false);
+      return setErr(rpcError.message);
+    }
+    if (reused) {
+      setLoading(false);
+      return setErr('Cannot reuse old password.');
+    }
     const { error } = await supabase.auth.updateUser({ password });
     setLoading(false);
     if (error) return setErr(error.message);

--- a/supabase/migrations/20250924_password_reuse_check.sql
+++ b/supabase/migrations/20250924_password_reuse_check.sql
@@ -1,0 +1,22 @@
+-- function to detect password reuse
+create or replace function public.password_is_reused(new_password text)
+returns boolean
+language plpgsql
+security definer
+as $$
+declare
+  stored text;
+begin
+  select encrypted_password into stored
+  from auth.users
+  where id = auth.uid();
+
+  if stored is null then
+    return false;
+  end if;
+
+  return stored = crypt(new_password, stored);
+end;
+$$;
+
+grant execute on function public.password_is_reused(text) to authenticated;


### PR DESCRIPTION
## Summary
- check new passwords against previous via `password_is_reused` RPC
- add SQL function to detect reused passwords

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a790fe448321a382ca413730b098