### PR TITLE
Handle expired reset link in password update flow

### DIFF
--- a/pages/update-password.tsx
+++ b/pages/update-password.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
@@ -11,7 +12,7 @@ import { supabase } from '@/lib/supabaseClient';
 export default function UpdatePassword() {
   const router = useRouter();
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false), [err, setErr] = useState<string|null>(null);
+  const [loading, setLoading] = useState(false), [err, setErr] = useState<React.ReactNode>(null);
   const [ok, setOk] = useState(false);
 
   const submit = async (e: React.FormEvent) => {
@@ -21,7 +22,19 @@ export default function UpdatePassword() {
     setLoading(true);
     const { error } = await supabase.auth.updateUser({ password });
     setLoading(false);
-    if (error) return setErr(error.message);
+    if (error) {
+      if (error.code === 'token_expired') {
+        return setErr(
+          <>
+            Link expired.{' '}
+            <Link href="/forgot-password" className="text-primary underline">
+              Request a new reset
+            </Link>
+          </>
+        );
+      }
+      return setErr(error.message);
+    }
     setOk(true);
     setTimeout(() => router.push('/login'), 800);
   };


### PR DESCRIPTION
## Summary
- detect `token_expired` errors during password update and guide users to request a new reset link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a78fa88c8321b7f6971d57dd7f07