### PR TITLE
feat: prompt to manage sessions on login

### DIFF
--- a/components/auth/SessionDialog.tsx
+++ b/components/auth/SessionDialog.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Modal } from '@/components/design-system/Modal';
+import { Button } from '@/components/design-system/Button';
+
+export interface SessionInfo {
+  id: string;
+  user_agent: string | null;
+  created_at: string;
+  ip: string | null;
+}
+
+interface Props {
+  sessions: SessionInfo[];
+  onKeepOnlyHere: () => void;
+  onClose: () => void;
+}
+
+export default function SessionDialog({ sessions, onKeepOnlyHere, onClose }: Props) {
+  if (!sessions.length) return null;
+  return (
+    <Modal
+      open={true}
+      onClose={onClose}
+      title="Other active sessions"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Keep all sessions
+          </Button>
+          <Button onClick={onKeepOnlyHere}>Keep me signed in only here</Button>
+        </div>
+      }
+    >
+      <p className="mb-4 text-body">You have other active sessions:</p>
+      <ul className="space-y-1 text-body">
+        {sessions.map((s) => (
+          <li key={s.id}>
+            {s.user_agent || 'Unknown'}{s.ip ? ` • ${s.ip}` : ''}
+          </li>
+        ))}
+      </ul>
+    </Modal>
+  );
+}
+

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -3,9 +3,13 @@ import AuthLayout from '@/components/layouts/AuthLayout';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import SessionDialog, { SessionInfo } from '@/components/auth/SessionDialog';
+import type { User } from '@supabase/supabase-js';
 
 export default function AuthCallback() {
   const [err, setErr] = useState<string | null>(null);
+  const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -15,15 +19,40 @@ export default function AuthCallback() {
       if (error) {
         setErr(error.message);
       } else {
+        const sessionUser = data.session?.user ?? null;
+        setUser(sessionUser);
         try {
           await fetch('/api/auth/login-event', { method: 'POST' });
         } catch (err) {
           console.error(err);
         }
-        redirectByRole(data.session?.user ?? null);
+        try {
+          const r = await fetch('/api/auth/sessions');
+          const list: SessionInfo[] = await r.json();
+          if (Array.isArray(list) && list.length > 1) {
+            setSessions(list.slice(1));
+            return;
+          }
+        } catch (err) {
+          console.error(err);
+        }
+        redirectByRole(sessionUser);
       }
     })();
   }, []);
+
+  function closeSessions() {
+    redirectByRole(user);
+  }
+
+  async function keepOnlyHere() {
+    if (sessions) {
+      await Promise.all(
+        sessions.map((s) => fetch(`/api/auth/sessions/${s.id}`, { method: 'DELETE' }))
+      );
+    }
+    closeSessions();
+  }
 
   return (
     <AuthLayout title="Signing you in..." subtitle={err ? undefined : 'Please wait...'}>
@@ -31,6 +60,13 @@ export default function AuthCallback() {
         <Alert variant="error" title="Error" className="mt-4">
           {err}
         </Alert>
+      )}
+      {sessions && (
+        <SessionDialog
+          sessions={sessions}
+          onKeepOnlyHere={keepOnlyHere}
+          onClose={closeSessions}
+        />
       )}
     </AuthLayout>
   );

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -7,12 +7,16 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import SessionDialog, { SessionInfo } from '@/components/auth/SessionDialog';
+import type { User } from '@supabase/supabase-js';
 
 export default function LoginWithEmail() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
+  const [redirectUser, setRedirectUser] = useState<User | null>(null);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -32,8 +36,33 @@ export default function LoginWithEmail() {
       } catch (err) {
         console.error(err);
       }
-      redirectByRole(data.session.user);
+      const user = data.session.user;
+      setRedirectUser(user);
+      try {
+        const r = await fetch('/api/auth/sessions');
+        const list: SessionInfo[] = await r.json();
+        if (Array.isArray(list) && list.length > 1) {
+          setSessions(list.slice(1));
+          return;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+      redirectByRole(user);
     }
+  }
+
+  function closeSessions() {
+    if (redirectUser) redirectByRole(redirectUser);
+  }
+
+  async function keepOnlyHere() {
+    if (sessions) {
+      await Promise.all(
+        sessions.map((s) => fetch(`/api/auth/sessions/${s.id}`, { method: 'DELETE' }))
+      );
+    }
+    closeSessions();
   }
 
   const RightPanel = (
@@ -70,6 +99,13 @@ export default function LoginWithEmail() {
       <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
         <Link href="/login">Back to Login Options</Link>
       </Button>
+      {sessions && (
+        <SessionDialog
+          sessions={sessions}
+          onKeepOnlyHere={keepOnlyHere}
+          onClose={closeSessions}
+        />
+      )}
     </AuthLayout>
   );
 }

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
+import SessionDialog, { SessionInfo } from '@/components/auth/SessionDialog';
+import type { User } from '@supabase/supabase-js';
 
 export default function LoginWithPhone() {
   const [phone, setPhone] = useState('');
@@ -14,6 +16,8 @@ export default function LoginWithPhone() {
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
+  const [redirectUser, setRedirectUser] = useState<User | null>(null);
 
   async function requestOtp(e: React.FormEvent) {
     e.preventDefault();
@@ -45,8 +49,33 @@ export default function LoginWithPhone() {
       } catch (err) {
         console.error(err);
       }
-      redirectByRole(data.session.user);
+      const user = data.session.user;
+      setRedirectUser(user);
+      try {
+        const r = await fetch('/api/auth/sessions');
+        const list: SessionInfo[] = await r.json();
+        if (Array.isArray(list) && list.length > 1) {
+          setSessions(list.slice(1));
+          return;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+      redirectByRole(user);
     }
+  }
+
+  function closeSessions() {
+    if (redirectUser) redirectByRole(redirectUser);
+  }
+
+  async function keepOnlyHere() {
+    if (sessions) {
+      await Promise.all(
+        sessions.map((s) => fetch(`/api/auth/sessions/${s.id}`, { method: 'DELETE' }))
+      );
+    }
+    closeSessions();
   }
 
   const RightPanel = (
@@ -95,6 +124,13 @@ export default function LoginWithPhone() {
       <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
         <Link href="/login">Back to Login Options</Link>
       </Button>
+      {sessions && (
+        <SessionDialog
+          sessions={sessions}
+          onKeepOnlyHere={keepOnlyHere}
+          onClose={closeSessions}
+        />
+      )}
     </AuthLayout>
   );
 }


### PR DESCRIPTION
## Summary
- show dialog after login listing other active sessions
- allow user to revoke other sessions and stay signed in only here
- add reusable session dialog component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a79671748321a14bed6af601103a