### PR TITLE
enforce verification before granting session

### DIFF
--- a/lib/routeAccess.test.ts
+++ b/lib/routeAccess.test.ts
@@ -6,6 +6,7 @@ import {
   requiredRolesFor,
   isPublicRoute,
   isGuestOnlyRoute,
+  redirectByRole,
 } from './routeAccess';
 
 test('canAccess respects role gates', () => {
@@ -25,4 +26,17 @@ test('requiredRolesFor returns the correct roles', () => {
 test('signup flow paths bypass auth guards', () => {
   assert.strictEqual(isPublicRoute('/signup/phone'), true);
   assert.strictEqual(isGuestOnlyRoute('/signup/phone'), true);
+});
+
+test('redirectByRole sends unverified users to verification', () => {
+  const user: any = {
+    email_confirmed_at: null,
+    phone_confirmed_at: null,
+    app_metadata: { role: 'student' },
+  };
+  assert.strictEqual(redirectByRole(user), '/auth/verify');
+});
+
+test('verification page is considered public', () => {
+  assert.strictEqual(isPublicRoute('/auth/verify'), true);
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -103,6 +103,17 @@ function InnerApp({ Component, pageProps }: AppProps) {
         const r: AppRole | null = getUserRole(user);
         if (!active) return;
 
+        if (
+          user &&
+          !user.email_confirmed_at &&
+          !user.phone_confirmed_at &&
+          pathname !== '/auth/verify'
+        ) {
+          await supabaseBrowser.auth.signOut();
+          router.replace('/auth/verify');
+          return;
+        }
+
         // ⬇️ removed: setRole(r);
 
         if (user) {


### PR DESCRIPTION
## Summary
- redirect unverified users to `/auth/verify` and clear their session
- allow `/auth/verify` as a public route
- guard app initialization to sign out and reroute unverified sessions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a79595b48321a186f644efea46f8