### PR TITLE
feat: block repeated login attempts

### DIFF
--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,61 @@
+interface SimpleRedis {
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<number>;
+  get(key: string): Promise<string | null>;
+  del(key: string): Promise<number>;
+}
+
+class MemoryRedis implements SimpleRedis {
+  private store = new Map<string, { value: number; expire?: number }>();
+
+  async incr(key: string): Promise<number> {
+    const now = Date.now();
+    const entry = this.store.get(key);
+    if (entry && entry.expire && entry.expire < now) {
+      this.store.delete(key);
+      return this.incr(key);
+    }
+    const val = (entry?.value ?? 0) + 1;
+    this.store.set(key, { value: val, expire: entry?.expire });
+    return val;
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    const entry = this.store.get(key);
+    if (!entry) return 0;
+    entry.expire = Date.now() + seconds * 1000;
+    this.store.set(key, entry);
+    return 1;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expire && entry.expire < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return String(entry.value);
+    }
+
+  async del(key: string): Promise<number> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+}
+
+let client: SimpleRedis;
+
+if (process.env.REDIS_URL) {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const Redis = require('ioredis');
+    client = new Redis(process.env.REDIS_URL);
+  } catch {
+    console.warn('ioredis not installed; falling back to in-memory store');
+    client = new MemoryRedis();
+  }
+} else {
+  client = new MemoryRedis();
+}
+
+export const redis = client;

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { redis } from '@/lib/redis';
+
+const MAX_ATTEMPTS = 5;
+const BLOCK_TIME_SEC = 60 * 15; // 15 minutes
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password are required.' });
+  }
+
+  const ipRaw = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
+  const ip = Array.isArray(ipRaw) ? ipRaw[0] : ipRaw.split(',')[0];
+  const key = `login:fail:${ip}`;
+
+  const attemptsStr = await redis.get(key);
+  const attempts = attemptsStr ? parseInt(attemptsStr, 10) : 0;
+  if (attempts >= MAX_ATTEMPTS) {
+    return res.status(429).json({ error: 'Too many failed login attempts. Please try again later.' });
+  }
+
+  const { data, error } = await supabaseAdmin.auth.signInWithPassword({ email, password });
+  if (error || !data.session) {
+    await redis.incr(key);
+    await redis.expire(key, BLOCK_TIME_SEC);
+    return res.status(401).json({ error: 'Invalid email or password.' });
+  }
+
+  await redis.del(key);
+  return res.status(200).json({ session: data.session });
+}

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -20,20 +20,30 @@ export default function LoginWithPassword() {
     setErr(null);
     if (!email || !pw) return setErr('Please fill in all fields.');
     setLoading(true);
-    const { error, data } = await supabase.auth.signInWithPassword({ email, password: pw });
-    setLoading(false);
-    if (error) return setErr(error.message);
-    if (data.session) {
-      await supabase.auth.setSession({
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: pw }),
       });
-      try {
-        await fetch('/api/auth/login-event', { method: 'POST' });
-      } catch (err) {
-        console.error(err);
+      const data = await res.json();
+      setLoading(false);
+      if (!res.ok) return setErr(data.error || 'Login failed');
+      if (data.session) {
+        await supabase.auth.setSession({
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token,
+        });
+        try {
+          await fetch('/api/auth/login-event', { method: 'POST' });
+        } catch (err) {
+          console.error(err);
+        }
+        redirectByRole(data.session.user);
       }
-      redirectByRole(data.session.user);
+    } catch (_err) {
+      setLoading(false);
+      setErr('Login failed');
     }
   }
 


### PR DESCRIPTION
## Summary
- add API to limit repeated failed logins using Redis or in-memory store
- add simple Redis wrapper with optional fallback
- route login forms through server-side check before authenticating

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a792a1e88321bd1475da72b2ee60