### PR TITLE
feat: add trust signals section

### DIFF
--- a/components/sections/TrustSignals.tsx
+++ b/components/sections/TrustSignals.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Image from 'next/image';
+import { Container } from '@/components/design-system/Container';
+
+const partners = [
+  {
+    name: 'British Council',
+    logo: '/brand/british-council.svg',
+    width: 120,
+    height: 40,
+  },
+  {
+    name: 'IDP',
+    logo: '/brand/idp.svg',
+    width: 80,
+    height: 40,
+  },
+  {
+    name: 'Cambridge',
+    logo: '/brand/cambridge.svg',
+    width: 120,
+    height: 40,
+  },
+];
+
+export const TrustSignals: React.FC = () => {
+  return (
+    <section id="trust" className="section-light py-24">
+      <Container>
+        <div className="text-center mb-14">
+          <h2 className="font-slab uppercase tracking-tight text-h2 md:text-display text-gradient-primary">
+            Trusted By
+          </h2>
+          <p className="mt-3 text-grayish">
+            Official partnerships and certifications
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-10 opacity-80">
+          {partners.map((p) => (
+            <Image key={p.name} src={p.logo} alt={`${p.name} logo`} width={p.width} height={p.height} />
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+};
+
+export default TrustSignals;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,11 +17,13 @@ const Hero = dynamic(
 
 // Robust static imports for the rest (default OR named export)
 import * as ModulesMod from '@/components/sections/Modules';
+import * as TrustMod from '@/components/sections/TrustSignals';
 import * as TestimonialsMod from '@/components/sections/Testimonials';
 import * as PricingMod from '@/components/sections/Pricing';
 import * as WaitlistMod from '@/components/sections/Waitlist';
 
 type ModulesModule = typeof import('@/components/sections/Modules');
+type TrustModule = typeof import('@/components/sections/TrustSignals');
 type TestimonialsModule = typeof import('@/components/sections/Testimonials');
 type PricingModule = typeof import('@/components/sections/Pricing');
 type WaitlistModule = typeof import('@/components/sections/Waitlist') & {
@@ -29,11 +31,13 @@ type WaitlistModule = typeof import('@/components/sections/Waitlist') & {
 };
 
 const ModulesModTyped = ModulesMod as ModulesModule;
+const TrustModTyped = TrustMod as TrustModule;
 const TestimonialsModTyped = TestimonialsMod as TestimonialsModule;
 const PricingModTyped = PricingMod as PricingModule;
 const WaitlistModTyped = WaitlistMod as WaitlistModule;
 
 const Modules = ModulesModTyped.Modules ?? ModulesModTyped.default;
+const Trust = TrustModTyped.TrustSignals ?? TrustModTyped.default;
 const Testimonials =
   TestimonialsModTyped.Testimonials ?? TestimonialsModTyped.default;
 const Pricing = PricingModTyped.Pricing ?? PricingModTyped.default;
@@ -80,6 +84,13 @@ export default function HomePage() {
         className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90"
       >
         <Modules />
+      </section>
+
+      <section
+        id="trust"
+        className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90"
+      >
+        <Trust />
       </section>
 
       <section

--- a/public/brand/british-council.svg
+++ b/public/brand/british-council.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="5" fill="#0d6efd"/>
+  <text x="60" y="25" font-size="14" text-anchor="middle" fill="#fff">British Council</text>
+</svg>

--- a/public/brand/cambridge.svg
+++ b/public/brand/cambridge.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="5" fill="#4caf50"/>
+  <text x="60" y="25" font-size="16" text-anchor="middle" fill="#fff">Cambridge</text>
+</svg>

--- a/public/brand/idp.svg
+++ b/public/brand/idp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="5" fill="#ff5722"/>
+  <text x="60" y="25" font-size="18" text-anchor="middle" fill="#fff">IDP</text>
+</svg>


### PR DESCRIPTION
## Summary
- add TrustSignals section showing partner logos
- render Trust section on home page

## Testing
- `npm test` *(fails: supa.from is not a function)*
- `CI=1 npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b141d21de88321b9a33eddcf6ac9dc