### PR TITLE
refactor: use token utilities for colors

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -24,14 +24,14 @@ const QUICK = [
 // Named export to match Layout import style
 export const Footer: React.FC = () => {
   return (
-    <footer className="py-16 border-t border-gray-200 dark:border-purpleVibe/20">
+    <footer className="py-16 border-t border-lightBorder dark:border-purpleVibe/20">
       <Container>
         {/* 1 col on mobile -> 2 on small -> 4 on md (mobile-friendly, nothing else changed) */}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-10 mb-10">
           {/* Brand + Socials */}
           <div>
             <h3 className="text-xl font-semibold mb-4">IELTS MasterPortal</h3>
-            <p className="text-lightText dark:text-white">
+            <p className="text-body dark:text-white">
               The most advanced IELTS preparation platform powered by AI technology and expert
               teaching methodologies.
             </p>
@@ -51,7 +51,7 @@ export const Footer: React.FC = () => {
             </h3>
             <ul className="space-y-2">
               {RESOURCES.map((x) => (
-                <li key={x.label} className="text-gray-600 dark:text-grayish">
+                <li key={x.label} className="text-mutedText dark:text-grayish">
                   <NavLink href={x.href} label={x.label} className="!px-0 !py-1" />
                 </li>
               ))}
@@ -65,7 +65,7 @@ export const Footer: React.FC = () => {
             </h3>
             <ul className="space-y-2">
               {QUICK.map((x) => (
-                <li key={x.label} className="text-gray-600 dark:text-grayish">
+                <li key={x.label} className="text-mutedText dark:text-grayish">
                   <NavLink href={x.href} label={x.label} className="!px-0 !py-1" />
                 </li>
               ))}
@@ -77,7 +77,7 @@ export const Footer: React.FC = () => {
             <h3 className="text-xl font-semibold mb-4 relative after:absolute after:-bottom-2 after:left-0 after:w-12 after:h-[3px] after:bg-primary dark:after:bg-neonGreen">
               Contact Us
             </h3>
-            <ul className="space-y-3 text-gray-600 dark:text-grayish">
+            <ul className="space-y-3 text-mutedText dark:text-grayish">
               <li>
                 <i className="fas fa-envelope mr-2" />
                 <a href="mailto:info@solvioadvisors.com" className="hover:underline">
@@ -100,7 +100,7 @@ export const Footer: React.FC = () => {
           </div>
         </div>
 
-        <div className="text-center pt-8 border-t border-gray-200 dark:border-purpleVibe/20 text-sm text-gray-600 dark:text-grayish">
+        <div className="text-center pt-8 border-t border-lightBorder dark:border-purpleVibe/20 text-sm text-mutedText dark:text-grayish">
           &copy; {new Date().getFullYear()} IELTS MasterPortal. All rights reserved. Launching soon!
         </div>
       </Container>

--- a/components/dashboard/SavedItems.tsx
+++ b/components/dashboard/SavedItems.tsx
@@ -41,8 +41,8 @@ export function SavedItems() {
   if (loading) {
     return (
       <Card className="p-6 rounded-ds-2xl">
-        <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
-        <div className="mt-4 animate-pulse h-4 w-64 bg-gray-200 dark:bg-white/10 rounded" />
+        <div className="animate-pulse h-5 w-40 bg-lightBorder dark:bg-white/10 rounded" />
+        <div className="mt-4 animate-pulse h-4 w-64 bg-lightBorder dark:bg-white/10 rounded" />
       </Card>
     );
   }
@@ -52,7 +52,7 @@ export function SavedItems() {
       <Card className="p-6 rounded-ds-2xl flex items-center justify-between">
         <div>
           <div className="font-semibold mb-1">Saved items</div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Sign in to access your bookmarks.</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Sign in to access your bookmarks.</div>
         </div>
         <Button href="/login" variant="primary" className="rounded-ds-xl">Sign in</Button>
       </Card>
@@ -85,7 +85,7 @@ export function SavedItems() {
         </select>
       </div>
       {items.filter((b) => filter === 'all' || b.category === filter).length === 0 ? (
-        <div className="text-sm text-gray-600 dark:text-grayish">No saved items yet.</div>
+        <div className="text-sm text-mutedText dark:text-grayish">No saved items yet.</div>
       ) : (
         <ul className="grid gap-2">
           {items
@@ -95,7 +95,7 @@ export function SavedItems() {
                 <Link href={linkFor(b)} className="underline">
                   {b.category}: {b.resource_id}
                 </Link>
-                <span className="text-sm text-gray-600 dark:text-grayish">
+                <span className="text-sm text-mutedText dark:text-grayish">
                   {new Date(b.created_at).toLocaleDateString()}
                 </span>
               </li>

--- a/components/dashboard/WhatsAppOptIn.tsx
+++ b/components/dashboard/WhatsAppOptIn.tsx
@@ -35,7 +35,7 @@ export function WhatsAppOptIn() {
     <Card className="p-6 rounded-ds-2xl">
       <h2 className="font-slab text-h2 mb-4">WhatsApp updates</h2>
       {status === "success" ? (
-        <p className="text-sm text-gray-600 dark:text-grayish">
+        <p className="text-sm text-mutedText dark:text-grayish">
           You&apos;re subscribed to WhatsApp reminders.
         </p>
       ) : (

--- a/components/design-system/Badge.tsx
+++ b/components/design-system/Badge.tsx
@@ -14,7 +14,7 @@ export const Badge: React.FC<{
     md: 'text-body px-3.5 py-1.5 rounded-ds',
   };
   const variants: Record<Variant, string> = {
-    neutral: 'bg-gray-200 text-lightText dark:bg-white/10 dark:text-white',
+    neutral: 'bg-lightBorder text-body dark:bg-white/10 dark:text-white',
     success: 'bg-success/15 text-success border border-success/30',
     warning: 'bg-goldenYellow/15 text-goldenYellow border border-goldenYellow/30',
     danger: 'bg-sunsetOrange/15 text-sunsetOrange border border-sunsetOrange/30',

--- a/components/design-system/Breadcrumbs.tsx
+++ b/components/design-system/Breadcrumbs.tsx
@@ -5,15 +5,15 @@ export type Crumb = { label: string; href?: string };
 export const Breadcrumbs: React.FC<{ items: Crumb[]; className?: string }> = ({ items, className='' }) => {
   return (
     <nav aria-label="Breadcrumb" className={`text-small ${className}`}>
-      <ol className="flex items-center gap-2 text-gray-600 dark:text-grayish">
+      <ol className="flex items-center gap-2 text-mutedText dark:text-grayish">
         {items.map((c, i) => (
           <li key={`${c.label}-${i}`} className="flex items-center gap-2">
             {c.href ? (
-              <Link href={c.href} className="hover:text-lightText dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-primary rounded-ds px-1">
+              <Link href={c.href} className="hover:text-body dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-primary rounded-ds px-1">
                 {c.label}
               </Link>
             ) : (
-              <span className="text-lightText dark:text-white">{c.label}</span>
+              <span className="text-body dark:text-white">{c.label}</span>
             )}
             {i < items.length - 1 && <span className="opacity-60"><i className="fas fa-chevron-right" aria-hidden="true" /></span>}
           </li>

--- a/components/design-system/Checkbox.tsx
+++ b/components/design-system/Checkbox.tsx
@@ -15,7 +15,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({ label, hint, error, classNam
           'mt-1 h-5 w-5 rounded-ds border',
           'text-primary focus:ring-2 focus:ring-primary focus:outline-none',
           'dark:bg-dark/50 dark:border-purpleVibe/30 dark:focus:ring-electricBlue',
-          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-gray-300'
+          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-lightBorder'
         ].join(' ')}
         {...props}
       />
@@ -24,7 +24,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({ label, hint, error, classNam
         {error ? (
           <div className="text-small text-sunsetOrange">{error}</div>
         ) : hint ? (
-          <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>
+          <div className="text-small text-mutedText dark:text-grayish">{hint}</div>
         ) : null}
       </div>
     </label>

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -23,7 +23,7 @@ export const Input: React.FC<InputProps> = ({
   const describedBy =
     error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'w-full rounded-ds border bg-card text-body placeholder-mutedText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'disabled:opacity-60',
     'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',
@@ -36,13 +36,13 @@ export const Input: React.FC<InputProps> = ({
   return (
     <label className={`block ${className}`}>
       {label && (
-        <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">
+        <span className="mb-1.5 inline-block text-small text-mutedText dark:text-grayish">
           {label}
         </span>
       )}
       <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
         {iconLeft && (
-          <span className="absolute left-3 text-gray-500 dark:text-white/50">
+          <span className="absolute left-3 text-mutedText dark:text-white/50">
             {iconLeft}
           </span>
         )}
@@ -55,7 +55,7 @@ export const Input: React.FC<InputProps> = ({
           {...props}
         />
         {iconRight && (
-          <span className="absolute right-3 text-gray-500 dark:text-white/50">
+          <span className="absolute right-3 text-mutedText dark:text-white/50">
             {iconRight}
           </span>
         )}
@@ -65,7 +65,7 @@ export const Input: React.FC<InputProps> = ({
           {error}
         </span>
       ) : hint ? (
-        <span id={`${inputId}-hint`} className="mt-1 block text-small text-gray-600 dark:text-grayish">
+        <span id={`${inputId}-hint`} className="mt-1 block text-small text-mutedText dark:text-grayish">
           {hint}
         </span>
       ) : null}

--- a/components/design-system/ProgressBar.tsx
+++ b/components/design-system/ProgressBar.tsx
@@ -10,8 +10,8 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({ value, label, classNam
   const v = Math.max(0, Math.min(100, value));
   return (
     <div className={`w-full ${className}`}>
-      {label && <div className="mb-1 text-small text-gray-600 dark:text-grayish">{label}</div>}
-      <div className="h-2 w-full rounded-ds bg-gray-200 dark:bg-white/10 overflow-hidden">
+      {label && <div className="mb-1 text-small text-mutedText dark:text-grayish">{label}</div>}
+      <div className="h-2 w-full rounded-ds bg-lightBorder dark:bg-white/10 overflow-hidden">
         <div
           className="h-full rounded-ds bg-primary dark:bg-electricBlue transition-[width] duration-300"
           style={{ width: `${v}%` }}

--- a/components/design-system/QuestionItem.tsx
+++ b/components/design-system/QuestionItem.tsx
@@ -8,7 +8,7 @@ type BaseProps = {
 };
 
 const statusRing: Record<NonNullable<BaseProps['status']>, string> = {
-  default: 'border-gray-200 dark:border-white/10',
+  default: 'border-lightBorder dark:border-white/10',
   answered: 'border-success/60',
   flagged: 'border-goldenYellow/60',
   review: 'border-electricBlue/60'
@@ -49,7 +49,7 @@ export const QuestionMCQ: React.FC<{
         <legend className="sr-only">Question {number}</legend>
         <div className="grid gap-2">
           {options.map(opt => (
-            <label key={opt.key} className="flex items-center gap-3 p-2 rounded-ds hover:bg-gray-50 dark:hover:bg-white/5">
+            <label key={opt.key} className="flex items-center gap-3 p-2 rounded-ds hover:bg-lightBg dark:hover:bg-white/5">
               <input
                 type="radio"
                 name={group}
@@ -86,8 +86,8 @@ export const QuestionTFNG: React.FC<{
             type="button"
             onClick={() => onChange?.(o.k)}
             className={`px-3 py-2 rounded-ds border text-small
-              ${value === o.k ? 'bg-primary text-white dark:bg-electricBlue' : 'bg-white dark:bg-dark/40 text-lightText dark:text-white'}
-              border-gray-200 dark:border-white/10`}
+              ${value === o.k ? 'bg-primary text-white dark:bg-electricBlue' : 'bg-card dark:bg-dark/40 text-body dark:text-white'}
+              border-lightBorder dark:border-white/10`}
             aria-pressed={value === o.k}
           >
             {o.l}
@@ -111,7 +111,7 @@ export const QuestionGapFill: React.FC<{
     <QuestionShell number={number} status={status} className={className}>
       <input
         type="text"
-        className="w-full rounded-ds border bg-white text-lightText placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue px-3 py-2"
+        className="w-full rounded-ds border bg-card text-body placeholder-mutedText focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue px-3 py-2"
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
         placeholder={placeholder}

--- a/components/design-system/Radio.tsx
+++ b/components/design-system/Radio.tsx
@@ -15,7 +15,7 @@ export const Radio: React.FC<RadioProps> = ({ label, hint, error, className = ''
           'mt-1 h-5 w-5 border rounded-full',
           'text-primary focus:ring-2 focus:ring-primary focus:outline-none',
           'dark:bg-dark/50 dark:border-purpleVibe/30 dark:focus:ring-electricBlue',
-          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-gray-300'
+          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-lightBorder'
         ].join(' ')}
         {...props}
       />
@@ -24,7 +24,7 @@ export const Radio: React.FC<RadioProps> = ({ label, hint, error, className = ''
         {error ? (
           <div className="text-small text-sunsetOrange">{error}</div>
         ) : hint ? (
-          <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>
+          <div className="text-small text-mutedText dark:text-grayish">{hint}</div>
         ) : null}
       </div>
     </label>

--- a/components/design-system/ScoreCard.tsx
+++ b/components/design-system/ScoreCard.tsx
@@ -30,7 +30,7 @@ export const ScoreCard: React.FC<ScoreCardProps> = ({ overall, subscores, title=
         <div className="relative h-24 w-24" aria-hidden="true">
           <svg viewBox="0 0 36 36" className="h-full w-full">
             <path
-              className="text-gray-200 dark:text-white/10"
+              className="text-lightBorder dark:text-white/10"
               stroke="currentColor"
               strokeWidth="3"
               fill="none"
@@ -51,7 +51,7 @@ export const ScoreCard: React.FC<ScoreCardProps> = ({ overall, subscores, title=
           </div>
         </div>
         <div>
-          <div className="text-small text-gray-600 dark:text-grayish">{title}</div>
+          <div className="text-small text-mutedText dark:text-grayish">{title}</div>
           <div className="text-h2 font-slab">Overall {band.toFixed(1)}</div>
           {subscores && (
             <div className="mt-3 grid grid-cols-2 gap-2 text-small">

--- a/components/design-system/Select.tsx
+++ b/components/design-system/Select.tsx
@@ -10,7 +10,7 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
 
 export const Select: React.FC<SelectProps> = ({ label, hint, error, options = [], className = '', children, ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText',
+    'w-full rounded-ds border bg-card text-body',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'dark:bg-dark/50 dark:text-white dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
@@ -18,7 +18,7 @@ export const Select: React.FC<SelectProps> = ({ label, hint, error, options = []
 
   return (
     <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
+      {label && <span className="mb-1.5 inline-block text-small text-mutedText dark:text-grayish">{label}</span>}
       <div className="relative">
         <select className={`${base} ${invalid} appearance-none pl-4 pr-10 py-3`} {...props}>
           {options.map(opt => (
@@ -33,7 +33,7 @@ export const Select: React.FC<SelectProps> = ({ label, hint, error, options = []
       {error ? (
         <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
       ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span className="mt-1 block text-small text-mutedText dark:text-grayish">{hint}</span>
       ) : null}
     </label>
   );

--- a/components/design-system/Tabs.tsx
+++ b/components/design-system/Tabs.tsx
@@ -11,13 +11,13 @@ export type TabsProps = {
 export const Tabs: React.FC<TabsProps> = ({ tabs, value, onChange, className='' }) => {
   return (
     <div className={`w-full ${className}`}>
-      <div className="flex flex-wrap gap-2 border-b border-gray-200 dark:border-white/10">
+      <div className="flex flex-wrap gap-2 border-b border-lightBorder dark:border-white/10">
         {tabs.map(t => {
           const active = value === t.key;
           const base = 'px-4 py-2 rounded-ds-t font-medium';
           const styles = active
             ? 'text-primary border-b-2 border-primary dark:text-electricBlue dark:border-electricBlue'
-            : 'text-gray-600 dark:text-grayish hover:text-lightText dark:hover:text-white';
+            : 'text-mutedText dark:text-grayish hover:text-body dark:hover:text-white';
           return (
             <button
               key={t.key}

--- a/components/design-system/Textarea.tsx
+++ b/components/design-system/Textarea.tsx
@@ -8,7 +8,7 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 
 export const Textarea: React.FC<TextareaProps> = ({ label, hint, error, className = '', ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'w-full rounded-ds border bg-card text-body placeholder-mutedText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
@@ -16,12 +16,12 @@ export const Textarea: React.FC<TextareaProps> = ({ label, hint, error, classNam
 
   return (
     <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
+      {label && <span className="mb-1.5 inline-block text-small text-mutedText dark:text-grayish">{label}</span>}
       <textarea className={`${base} ${invalid} p-4 min-h-[140px]`} {...props} />
       {error ? (
         <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
       ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span className="mt-1 block text-small text-mutedText dark:text-grayish">{hint}</span>
       ) : null}
     </label>
   );

--- a/components/design-system/Toaster.tsx
+++ b/components/design-system/Toaster.tsx
@@ -44,10 +44,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           <div
             key={t.id}
             className={`rounded-ds-2xl p-4 shadow-lg border
-              ${t.intent === 'success' ? 'bg-emerald-50 border-emerald-200 text-emerald-900 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-200'
-              : t.intent === 'error' ? 'bg-rose-50 border-rose-200 text-rose-900 dark:bg-rose-900/20 dark:border-rose-700 dark:text-rose-200'
-              : t.intent === 'warning' ? 'bg-amber-50 border-amber-200 text-amber-900 dark:bg-amber-900/20 dark:border-amber-700 dark:text-amber-200'
-              : 'bg-black/80 border-white/10 text-white'}`}
+              ${t.intent === 'success' ? 'bg-success/15 border-success/30 text-success dark:bg-success/20 dark:border-success/40 dark:text-success'
+              : t.intent === 'error' ? 'bg-error/15 border-error/30 text-error dark:bg-error/20 dark:border-error/40 dark:text-error'
+              : t.intent === 'warning' ? 'bg-goldenYellow/15 border-goldenYellow/30 text-goldenYellow dark:bg-goldenYellow/20 dark:border-goldenYellow/40 dark:text-goldenYellow'
+              : 'bg-dark/80 border-border text-body dark:border-border/50 dark:text-white'}`}
           >
             <div className="font-semibold">{t.title}</div>
             {t.desc && <div className="text-sm opacity-90 mt-1">{t.desc}</div>}

--- a/components/design-system/Toggle.tsx
+++ b/components/design-system/Toggle.tsx
@@ -20,21 +20,21 @@ export const Toggle: React.FC<ToggleProps> = ({ checked=false, onChange, label, 
         onClick={() => !disabled && onChange?.(!checked)}
         className={[
           'relative inline-flex h-6 w-11 items-center rounded-ds transition',
-          checked ? 'bg-primary dark:bg-electricBlue' : 'bg-gray-300 dark:bg-white/20',
+          checked ? 'bg-primary dark:bg-electricBlue' : 'bg-lightBorder dark:bg-white/20',
           disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer',
           'focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-electricBlue'
         ].join(' ')}
       >
         <span
           className={[
-            'inline-block h-5 w-5 transform rounded-ds bg-white dark:bg-dark transition',
+            'inline-block h-5 w-5 transform rounded-ds bg-card dark:bg-dark transition',
             checked ? 'translate-x-5' : 'translate-x-1'
           ].join(' ')}
         />
       </button>
       <div>
         {label && <div className="text-body">{label}</div>}
-        {hint && <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>}
+        {hint && <div className="text-small text-mutedText dark:text-grayish">{hint}</div>}
       </div>
     </label>
   );

--- a/components/design-system/UserMenu.tsx
+++ b/components/design-system/UserMenu.tsx
@@ -140,7 +140,7 @@ export const UserMenu: React.FC<{
           className="absolute right-0 mt-2 w-64 rounded-2xl border border-vibrantPurple/20 bg-lightBg dark:bg-dark shadow-lg overflow-hidden"
         >
           {showEmail && (email || name) && (
-            <div className="px-4 py-3 text-small text-grayish dark:text-white/70 border-b border-vibrantPurple/15">
+            <div className="px-4 py-3 text-small text-grayish dark:text-body/70 border-b border-vibrantPurple/15">
               <div className="flex items-center gap-3">
                 <div className="h-9 w-9 rounded-full bg-vibrantPurple/15 flex items-center justify-center overflow-hidden">
                   {localAvatar ? (
@@ -151,7 +151,7 @@ export const UserMenu: React.FC<{
                   )}
                 </div>
                 <div>
-                  <div className="font-medium text-lightText dark:text-white">{name ?? email}</div>
+                  <div className="font-medium text-body dark:text-white">{name ?? email}</div>
                   {email && name && <div className="opacity-80">{email}</div>}
                 </div>
               </div>

--- a/components/layouts/AuthLayout.tsx
+++ b/components/layouts/AuthLayout.tsx
@@ -36,7 +36,7 @@ export default function AuthLayout({
       <div className="flex flex-col justify-center w-full md:w-1/2 px-8 py-12">
         <div className="flex justify-between items-center mb-8">
           <span className="font-slab text-h2 md:text-display text-gradient-primary">GramorX</span>
-          <span className="text-small text-grayish dark:text-gray-400">IELTS Portal</span>
+          <span className="text-small text-grayish dark:text-grayish">IELTS Portal</span>
         </div>
 
         <Container className="max-w-md w-full">

--- a/components/layouts/ExamLayout.tsx
+++ b/components/layouts/ExamLayout.tsx
@@ -47,7 +47,7 @@ export default function ExamLayout({
             <div className="flex items-center gap-4">
               <div className="leading-tight">
                 {attemptId && (
-                  <div className="text-small text-grayish dark:text-gray-400">Attempt {attemptId}</div>
+                  <div className="text-small text-grayish dark:text-grayish">Attempt {attemptId}</div>
                 )}
                 <h1 className="font-semibold">{title}</h1>
               </div>

--- a/components/mistakes/MistakeCard.tsx
+++ b/components/mistakes/MistakeCard.tsx
@@ -25,11 +25,11 @@ export const MistakeCard: React.FC<MistakeCardProps> = ({ mistake, onReview }) =
     <Card className="p-4 rounded-ds-2xl">
       <div className="font-medium">{mistake.mistake}</div>
       {mistake.correction && (
-        <div className="text-sm text-gray-600 dark:text-grayish mt-1">
+        <div className="text-sm text-mutedText dark:text-grayish mt-1">
           Correct: {mistake.correction}
         </div>
       )}
-      <div className="text-xs text-gray-600 dark:text-grayish mt-2">
+      <div className="text-xs text-mutedText dark:text-grayish mt-2">
         Next review: {next}
       </div>
       <Button

--- a/components/reading/QuestionNav.tsx
+++ b/components/reading/QuestionNav.tsx
@@ -45,7 +45,7 @@ export const QuestionNav: React.FC<{
     .sort((a, b) => a.qNo - b.qNo);
 
   return (
-    <aside className={`card-surface p-4 rounded-ds border border-gray-200 dark:border-white/10 sticky top-24 ${className}`}>
+    <aside className={`card-surface p-4 rounded-ds border border-lightBorder dark:border-white/10 sticky top-24 ${className}`}>
       <div className="flex items-center justify-between gap-2">
         <h3 className="text-h3 font-semibold">Questions</h3>
         <Badge variant="info" size="sm">{counts.answered}/{counts.total} done</Badge>
@@ -90,7 +90,7 @@ export const QuestionNav: React.FC<{
             ? 'bg-success/15 text-success border-success/30'
             : flagged
               ? 'bg-goldenYellow/15 text-goldenYellow border-goldenYellow/30'
-              : 'bg-gray-200/40 dark:bg-white/10 text-lightText dark:text-white border-gray-200/60 dark:border-white/10';
+              : 'bg-lightBorder/40 dark:bg-white/10 text-body dark:text-white border-lightBorder/60 dark:border-white/10';
 
           return (
             <button

--- a/components/reading/ReadingStatsCard.tsx
+++ b/components/reading/ReadingStatsCard.tsx
@@ -67,8 +67,8 @@ export function ReadingStatsCard() {
   if (loading) {
     return (
       <Card className="p-6">
-        <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded mb-3" />
-        <div className="animate-pulse h-4 w-64 bg-gray-200 dark:bg-white/10 rounded" />
+        <div className="animate-pulse h-5 w-40 bg-lightBorder dark:bg-white/10 rounded mb-3" />
+        <div className="animate-pulse h-4 w-64 bg-lightBorder dark:bg-white/10 rounded" />
       </Card>
     );
   }
@@ -78,7 +78,7 @@ export function ReadingStatsCard() {
       <Card className="p-6 flex items-center justify-between">
         <div>
           <div className="font-semibold mb-1">Reading progress</div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Sign in to track your attempts and accuracy.</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Sign in to track your attempts and accuracy.</div>
         </div>
         <Button href="/login" variant="primary" className="rounded-ds-xl">Sign in</Button>
       </Card>
@@ -96,21 +96,21 @@ export function ReadingStatsCard() {
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Attempts</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Attempts</div>
           <div className="text-xl font-semibold">{stat?.attempts ?? 0}</div>
         </div>
         <div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Points</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Points</div>
           <div className="text-xl font-semibold">{stat?.total_score ?? 0}/{stat?.total_max ?? 0}</div>
         </div>
         <div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Avg. duration</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Avg. duration</div>
           <div className="text-xl font-semibold">
             {stat?.avg_duration_ms ? Math.round((stat.avg_duration_ms/1000)/60) + ' min' : '—'}
           </div>
         </div>
         <div>
-          <div className="text-sm text-gray-600 dark:text-grayish">Last attempt</div>
+          <div className="text-sm text-mutedText dark:text-grayish">Last attempt</div>
           <div className="text-xl font-semibold">
             {stat?.last_attempt_at ? new Date(stat.last_attempt_at).toLocaleDateString() : '—'}
           </div>
@@ -119,7 +119,7 @@ export function ReadingStatsCard() {
 
       <div className="mb-3 font-medium">Recent attempts</div>
       {recent.length === 0 ? (
-        <div className="text-sm text-gray-600 dark:text-grayish">No attempts yet. Try a passage to see your stats.</div>
+        <div className="text-sm text-mutedText dark:text-grayish">No attempts yet. Try a passage to see your stats.</div>
       ) : (
         <ul className="grid gap-2">
           {recent.map(a => (
@@ -128,7 +128,7 @@ export function ReadingStatsCard() {
                 <Link href={`/reading/review/${a.id}`} className="underline">
                   {a.passage_slug}
                 </Link>
-                <span className="ml-2 text-sm text-gray-600 dark:text-grayish">
+                <span className="ml-2 text-sm text-mutedText dark:text-grayish">
                   {new Date(a.created_at).toLocaleString()}
                 </span>
               </div>

--- a/components/sections/Specialties.tsx
+++ b/components/sections/Specialties.tsx
@@ -38,7 +38,7 @@ export const Specialties: React.FC<{ id?: string; className?: string }> = ({ id 
                 </span>
                 <div>
                   <h3 className="text-h3 font-semibold mb-1">{it.title}</h3>
-                  <p className="text-body text-gray-600 dark:text-grayish">{it.desc}</p>
+                  <p className="text-body text-mutedText dark:text-grayish">{it.desc}</p>
                 </div>
               </div>
             </Card>

--- a/components/speaking/AccentMirror.tsx
+++ b/components/speaking/AccentMirror.tsx
@@ -36,7 +36,7 @@ export const AccentMirror: React.FC<{ accent: Accent }> = ({ accent }) => {
   }, [accent]);
 
   if (loading) return <p>Loading prompts...</p>;
-  if (error) return <p className="text-red-600">{error}</p>;
+  if (error) return <p className="text-error">{error}</p>;
   if (!data) return null;
 
   return (

--- a/components/study-plan/TargetSummary.tsx
+++ b/components/study-plan/TargetSummary.tsx
@@ -12,16 +12,16 @@ export const TargetSummary: React.FC<Props> = ({ daily, weekly, eta }) => (
     <h3 className="font-slab text-h3 mb-4">Your Targets</h3>
     <div className="grid grid-cols-2 gap-4 mb-4">
       <div>
-        <div className="text-sm text-gray-600 dark:text-grayish">Daily</div>
+        <div className="text-sm text-mutedText dark:text-grayish">Daily</div>
         <div className="text-xl font-semibold">{daily}</div>
       </div>
       <div>
-        <div className="text-sm text-gray-600 dark:text-grayish">Weekly</div>
+        <div className="text-sm text-mutedText dark:text-grayish">Weekly</div>
         <div className="text-xl font-semibold">{weekly}</div>
       </div>
     </div>
     {eta && (
-      <p className="text-sm text-gray-600 dark:text-grayish">
+      <p className="text-sm text-mutedText dark:text-grayish">
         ETA to goal: {new Date(eta).toLocaleDateString()}
       </p>
     )}

--- a/components/writing/ReevalPanel.tsx
+++ b/components/writing/ReevalPanel.tsx
@@ -63,9 +63,9 @@ export const ReevalPanel: React.FC<{
 
       <div className="mt-4">
         <label className="block">
-          <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">Mode</span>
+          <span className="mb-1.5 inline-block text-small text-mutedText dark:text-grayish">Mode</span>
           <select
-            className="w-full p-3.5 rounded-ds border border-gray-200 dark:border-white/10 bg-white dark:bg-dark"
+            className="w-full p-3.5 rounded-ds border border-lightBorder dark:border-white/10 bg-card dark:bg-dark"
             value={mode}
             onChange={(e)=>setMode(e.target.value as any)}
           >
@@ -82,7 +82,7 @@ export const ReevalPanel: React.FC<{
             key={k}
             type="button"
             onClick={()=>toggleFocus(k)}
-            className={`p-3.5 rounded-ds border border-gray-200 dark:border-white/10 ${focus.includes(k)?'bg-electricBlue/10 text-electricBlue border-electricBlue/30':''}`}
+            className={`p-3.5 rounded-ds border border-lightBorder dark:border-white/10 ${focus.includes(k)?'bg-electricBlue/10 text-electricBlue border-electricBlue/30':''}`}
           >
             {k}
           </button>
@@ -99,7 +99,7 @@ export const ReevalPanel: React.FC<{
 
       {result && (
         <div className="mt-6 grid gap-4">
-          <div className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10">
+          <div className="p-3.5 rounded-ds border border-lightBorder dark:border-white/10">
             <div className="flex items-center gap-3">
               <Badge variant="neutral" size="sm">Original: {original.bandOverall}</Badge>
               <Badge
@@ -113,7 +113,7 @@ export const ReevalPanel: React.FC<{
 
           <div className="grid sm:grid-cols-2 gap-3">
             {(['task','coherence','lexical','grammar'] as const).map(k => (
-              <div key={k} className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10">
+              <div key={k} className="p-3.5 rounded-ds border border-lightBorder dark:border-white/10">
                 <div className="flex items-center justify-between">
                   <span className="capitalize">{k}</span>
                   <Badge

--- a/design-system/tokens/colors.js
+++ b/design-system/tokens/colors.js
@@ -25,4 +25,6 @@ module.exports = {
   // Generic border token (alias of lightBorder)
   border: '#e0e0e0',
   mutedText: '#d0d0e0',     // subtle text color
+  body: '#1a1a2e',          // default body text
+  error: '#ff4d4d',         // alias of sunsetRed
 };

--- a/doc/ui-guidelines.md
+++ b/doc/ui-guidelines.md
@@ -1,0 +1,22 @@
+# UI Guidelines
+
+This project uses design tokens to ensure visual consistency across all components.
+
+## Color and typography utilities
+- **Avoid raw Tailwind color classes** (e.g. `text-gray-600`, `text-red-600`).
+- Use tokenized utilities instead:
+  - `text-body` for default copy
+  - `text-mutedText` for subdued text
+  - `text-primary`, `text-secondary`, etc. for brand colors
+  - `text-error` for error states
+- Background and border colors follow the same pattern (`bg-primary`, `border-lightBorder`, ...).
+
+## Tokens outside Tailwind
+Color variables are exported in [`styles/tokens.css`](../styles/tokens.css). Import this file or its
+variables in non‑Tailwind contexts to access the same palette.
+
+```html
+<link rel="stylesheet" href="/styles/tokens.css" />
+```
+
+These CSS variables power both the Tailwind utilities and any external stylesheets.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,5 @@
+@import './tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -5,41 +7,9 @@
 /* Ensure full-height layout */
 html, body, #__next { height: 100%; }
 
-/* =========================
-   Color tokens → RGB triplets
-   (must match design-system/tokens/colors.js)
-   ========================= */
-:root{
-  --color-primary:        67 97 238;   /* #4361ee */
-  --color-primaryDark:    58 86 212;   /* #3a56d4 */
-  --color-secondary:     247 37 133;   /* #f72585 */
-  --color-accent:         76 201 240;  /* #4cc9f0 */
-  --color-success:        46 196 182;  /* #2ec4b6 */
-
-  --color-purpleVibe:    157 78 221;   /* #9d4edd */
-  --color-vibrantPurple: 157 78 221;   /* alias */
-  --color-electricBlue:    0 187 249;  /* #00bbf9 */
-  --color-neonGreen:     128 255 219;  /* #80ffdb */
-  --color-sunsetOrange:  255 107 107;  /* #ff6b6b */
-  --color-sunsetRed:     255  77  77;  /* #ff4d4d */
-  --color-goldenYellow:  255 209 102;  /* #ffd166 */
-
-  --color-dark:           15  15  27;  /* #0f0f1b */
-  --color-darker:          7   7  16;  /* #070710 */
-  --color-lightBg:       240 242 245;  /* #f0f2f5 */
-  --color-lightText:      26  26  46;  /* #1a1a2e */
-  /* darker gray for accessible body text on light backgrounds */
-  --color-grayish:       106 106 134;  /* #6a6a86 */
-
-  --color-lightCard:     255 255 255;  /* #ffffff */
-  --color-lightBorder:   224 224 224;  /* #e0e0e0 */
-  --color-border:        224 224 224;  /* #e0e0e0 */
-  --color-mutedText:     208 208 224;  /* #d0d0e0 */
-}
-
 /* Light = default; Dark via .dark on <html> (next-themes) */
-body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
-.dark body { @apply text-white bg-gradient-to-br from-darker to-dark; }
+body { @apply font-sans text-body bg-lightBg overflow-x-hidden relative; }
+.dark body { @apply text-body bg-gradient-to-br from-darker to-dark; }
 
 /* =========================
    Headings → Roboto Slab (no circular apply)

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,37 @@
+/* Shared design tokens for non-Tailwind contexts */
+:root {
+  --color-primary:        67 97 238;   /* #4361ee */
+  --color-primaryDark:    58 86 212;   /* #3a56d4 */
+  --color-secondary:     247 37 133;   /* #f72585 */
+  --color-accent:         76 201 240;  /* #4cc9f0 */
+  --color-success:        46 196 182;  /* #2ec4b6 */
+
+  --color-purpleVibe:    157 78 221;   /* #9d4edd */
+  --color-vibrantPurple: 157 78 221;   /* alias */
+  --color-electricBlue:    0 187 249;  /* #00bbf9 */
+  --color-neonGreen:     128 255 219;  /* #80ffdb */
+  --color-sunsetOrange:  255 107 107;  /* #ff6b6b */
+  --color-sunsetRed:     255  77  77;  /* #ff4d4d */
+  --color-goldenYellow:  255 209 102;  /* #ffd166 */
+
+  --color-dark:           15  15  27;  /* #0f0f1b */
+  --color-darker:          7   7  16;  /* #070710 */
+  --color-lightBg:       240 242 245;  /* #f0f2f5 */
+  --color-lightText:      26  26  46;  /* #1a1a2e */
+  /* darker gray for accessible body text on light backgrounds */
+  --color-grayish:       106 106 134;  /* #6a6a86 */
+
+  --color-lightCard:     255 255 255;  /* #ffffff */
+  --color-lightBorder:   224 224 224;  /* #e0e0e0 */
+  --color-border:        224 224 224;  /* #e0e0e0 */
+  --color-mutedText:     208 208 224;  /* #d0d0e0 */
+
+  /* aliases */
+  --color-body:          26  26  46;  /* same as lightText */
+  --color-error:        255  77  77;  /* alias of sunsetRed */
+}
+
+/* Dark mode overrides */
+.dark {
+  --color-body: 255 255 255;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,9 @@ module.exports = {
         lightBorder: 'rgb(var(--color-lightBorder) / <alpha-value>)',
         mutedText:   'rgb(var(--color-mutedText) / <alpha-value>)',
 
+        body:        'rgb(var(--color-body) / <alpha-value>)',
+        error:       'rgb(var(--color-error) / <alpha-value>)',
+
         // Components
         card: {
           DEFAULT:    'rgb(var(--color-lightCard) / <alpha-value>)',


### PR DESCRIPTION
## Summary
- replace raw Tailwind color classes with tokenized utilities across UI components
- export shared design variables via `styles/tokens.css` for non-Tailwind usage
- document token usage in `doc/ui-guidelines.md`

## Testing
- `npm test` *(fails: supa.from is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b14a1f8ae08321b6aee808785fa40c