### PR TITLE
refactor: standardize interactive text sizes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,14 @@ module.exports = {
     '@next/next/no-img-element': 'warn',
     '@next/next/no-css-tags': 'warn',
     'react-hooks/exhaustive-deps': 'warn',
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "Literal[value=/\\btext-(?:caption|tiny|micro)\\b/]",
+        message:
+          'Avoid undersized typography classes (text-caption/text-tiny/text-micro). Use text-small or text-body instead.',
+      },
+    ],
   },
   overrides: [
     // API routes & tests: loosen typing during sprint

--- a/components/ai/MessageList.tsx
+++ b/components/ai/MessageList.tsx
@@ -55,14 +55,14 @@ export function MessageList({
           <div className="mt-3 flex items-center justify-center gap-2">
             <button
               onClick={newChat}
-              className="text-caption rounded-full px-3 py-1 bg-card border border-border hover:bg-accent"
+              className="form-control text-small rounded-full px-3 bg-card border border-border hover:bg-accent"
             >
               New chat
             </button>
             <button
               onClick={toggleVoice}
               disabled={!voiceSupported || voiceDenied}
-              className="text-caption rounded-full px-3 py-1 border border-border bg-card hover:bg-accent disabled:opacity-50"
+              className="form-control text-small rounded-full px-3 border border-border bg-card hover:bg-accent disabled:opacity-50"
               title={
                 voiceSupported
                   ? voiceDenied
@@ -76,7 +76,7 @@ export function MessageList({
               🎙 {listening ? 'Stop' : 'Speak'}
             </button>
           </div>
-          <div className="mt-2 text-tiny text-muted-foreground/80">Tip: Alt+A toggles anywhere.</div>
+          <div className="mt-2 text-small text-muted-foreground/80">Tip: Alt+A toggles anywhere.</div>
         </div>
       )}
 
@@ -90,7 +90,7 @@ export function MessageList({
           }`}
           aria-live={m.id === streamingId ? 'polite' : undefined}
         >
-          <div className="text-micro uppercase tracking-wider text-muted-foreground mb-1">
+          <div className="text-small uppercase tracking-wider text-muted-foreground mb-1">
             {m.role === 'user' ? 'You' : 'GramorX AI'}
           </div>
           <div className="prose prose-sm dark:prose-invert max-w-none">
@@ -100,7 +100,7 @@ export function MessageList({
       ))}
 
       {loading && (
-        <div className="text-caption text-muted-foreground animate-pulse">Thinking…</div>
+        <div className="text-small text-muted-foreground animate-pulse">Thinking…</div>
       )}
     </div>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -185,11 +185,14 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 .section-dark { @apply bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90; }
 
 /* AI sidebar helpers (theme aware, token-only) */
+.form-control{
+  @apply min-h-11;
+}
 .ai-icon-btn{
-  @apply h-8 w-8 grid place-items-center rounded-md border border-border bg-card text-card-foreground hover:bg-accent hover:text-card-foreground disabled:opacity-50;
+  @apply form-control w-11 grid place-items-center rounded-md border border-border bg-card text-card-foreground hover:bg-accent hover:text-card-foreground disabled:opacity-50;
 }
 .ai-tab{
-  @apply h-8 px-3 rounded-md border border-border bg-card text-caption text-card-foreground hover:bg-accent hover:text-foreground;
+  @apply form-control px-3 rounded-md border border-border bg-card text-small text-card-foreground hover:bg-accent hover:text-foreground;
 }
 .ai-tab.is-active{
   @apply bg-primary text-primary-foreground;


### PR DESCRIPTION
## Summary
- replace tiny caption classes in AI message list with text-small and shared form-control height
- add form-control utility for consistent 44px control height and update AI sidebar helpers
- add ESLint rule to disallow undersized text utilities

## Testing
- `npm run lint`
- `npm test` *(fails: supa.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a1d7cd483219a679f59c81f3b30