### PR TITLE
feat: add spinner and toast helpers for async flows

### DIFF
--- a/components/design-system/Spinner.tsx
+++ b/components/design-system/Spinner.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+
+const SpinnerCtx = createContext<{ show: () => void; hide: () => void } | null>(null);
+
+export const SpinnerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [visible, setVisible] = useState(false);
+  const show = useCallback(() => setVisible(true), []);
+  const hide = useCallback(() => setVisible(false), []);
+
+  return (
+    <SpinnerCtx.Provider value={{ show, hide }}>
+      {children}
+      {visible && (
+        <div className="fixed inset-0 z-[1000] grid place-items-center bg-black/40">
+          <svg
+            className="h-10 w-10 animate-spin text-white"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+              fill="none"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+        </div>
+      )}
+    </SpinnerCtx.Provider>
+  );
+};
+
+export function useSpinner() {
+  const ctx = useContext(SpinnerCtx);
+  if (!ctx) throw new Error('useSpinner must be used within <SpinnerProvider>');
+  return ctx;
+}
+
+export const Spinner: React.FC<{ className?: string }> = ({ className = '' }) => (
+  <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" aria-hidden="true">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+  </svg>
+);

--- a/components/design-system/Toast.tsx
+++ b/components/design-system/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 type Variant = 'success' | 'info' | 'warning' | 'error';
 type ToastItem = {
@@ -10,6 +10,7 @@ type ToastItem = {
 };
 
 const ToastCtx = createContext<{ push: (t: Omit<ToastItem, 'id'>) => void } | null>(null);
+let pushRef: ((t: Omit<ToastItem, 'id'>) => void) | null = null;
 
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [items, setItems] = useState<ToastItem[]>([]);
@@ -22,6 +23,13 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, []);
 
   const ctx = useMemo(() => ({ push }), [push]);
+
+  useEffect(() => {
+    pushRef = push;
+    return () => {
+      pushRef = null;
+    };
+  }, [push]);
 
   const variants: Record<Variant, string> = {
     success: 'bg-success/10 border-success/30 text-success',
@@ -64,3 +72,14 @@ export function useToast() {
     ctx.push({ message, variant: 'error', title: opts?.title, duration: opts?.duration });
   return { success, info, warning, error };
 }
+
+export const toast = {
+  success: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'success', title: opts?.title, duration: opts?.duration }),
+  info: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'info', title: opts?.title, duration: opts?.duration }),
+  warning: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'warning', title: opts?.title, duration: opts?.duration }),
+  error: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'error', title: opts?.title, duration: opts?.duration }),
+};

--- a/components/design-system/index.ts
+++ b/components/design-system/index.ts
@@ -1,3 +1,5 @@
 export { Button } from './Button';
 export { Select } from './Select';
 export { Textarea } from './Textarea';
+export { Spinner, SpinnerProvider, useSpinner } from './Spinner';
+export { ToastProvider, useToast, toast } from './Toast';

--- a/hooks/useAsyncAction.ts
+++ b/hooks/useAsyncAction.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+import { useSpinner } from '@/components/design-system/Spinner';
+import { useToast } from '@/components/design-system/Toast';
+
+export function useAsyncAction<T extends any[], R>(
+  fn: (...args: T) => Promise<R>,
+  opts?: { success?: string; error?: string }
+) {
+  const toast = useToast();
+  const { show, hide } = useSpinner();
+  const [loading, setLoading] = useState(false);
+
+  const run = useCallback(
+    async (...args: T) => {
+      setLoading(true);
+      show();
+      try {
+        const res = await fn(...args);
+        if (opts?.success) toast.success(opts.success);
+        return res;
+      } catch (err) {
+        const message = opts?.error || (err instanceof Error ? err.message : 'Something went wrong');
+        toast.error(message);
+        return undefined as unknown as R;
+      } finally {
+        hide();
+        setLoading(false);
+      }
+    },
+    [fn, toast, show, hide, opts]
+  );
+
+  return [run, loading] as const;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import '@/styles/globals.css';
 
 import { Layout } from '@/components/Layout';
 import { ToastProvider } from '@/components/design-system/Toast';
+import { SpinnerProvider } from '@/components/design-system/Spinner';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { env } from '@/lib/env';
 import { LanguageProvider, useLocale } from '@/lib/locale';
@@ -241,7 +242,9 @@ export default function App(props: AppProps) {
   return (
     <LanguageProvider>
       <ToastProvider>
-        <InnerApp {...props} />
+        <SpinnerProvider>
+          <InnerApp {...props} />
+        </SpinnerProvider>
       </ToastProvider>
     </LanguageProvider>
   );

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -4,53 +4,44 @@ import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
 import { Button } from '@/components/design-system/Button';
-import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
 import { isValidE164Phone } from '@/utils/validation';
 import { getAuthErrorMessage } from '@/lib/authErrors';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 export default function LoginWithPhone() {
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [phoneErr, setPhoneErr] = useState<string | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [resending, setResending] = useState(false);
   const [resendAttempts, setResendAttempts] = useState(0);
 
-  async function requestOtp(e: React.FormEvent) {
+  const [requestOtp, requesting] = useAsyncAction(async (e: React.FormEvent) => {
     e.preventDefault();
-    setErr(null);
     const trimmedPhone = phone.trim();
     if (!isValidE164Phone(trimmedPhone)) {
       setPhoneErr('Enter your phone number in E.164 format, e.g. +923001234567');
       return;
     }
     setPhoneErr(null);
-    setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({
       phone: trimmedPhone,
       options: { shouldCreateUser: false },
     });
-    setLoading(false);
-    if (error) return setErr(getAuthErrorMessage(error));
+    if (error) throw new Error(getAuthErrorMessage(error));
     setResendAttempts(0);
     setStage('verify');
-  }
+  }, { error: 'Could not send code' });
 
-  async function verifyOtp(e: React.FormEvent) {
+  const [verifyOtp, verifying] = useAsyncAction(async (e: React.FormEvent) => {
     e.preventDefault();
-    setErr(null);
-    if (!code) return setErr('Enter the 6-digit code.');
+    if (!code) throw new Error('Enter the 6-digit code.');
 
     const trimmedPhone = phone.trim();
-    setLoading(true);
     // @ts-expect-error `token` is supported for verification
     const { data, error } = await supabase.auth.signInWithOtp({ phone: trimmedPhone, token: code });
-    setLoading(false);
-    if (error) return setErr(getAuthErrorMessage(error));
+    if (error) throw new Error(getAuthErrorMessage(error));
 
     if (data.session) {
       await supabase.auth.setSession({
@@ -61,25 +52,17 @@ export default function LoginWithPhone() {
       try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
       redirectByRole(data.session.user);
     }
-  }
+  }, { error: 'Could not verify code' });
 
-  async function resendOtp() {
-    setErr(null);
-    setResending(true);
-    setLoading(true);
-    try {
-      const trimmedPhone = phone.trim();
-      const { error } = await supabase.auth.signInWithOtp({
-        phone: trimmedPhone,
-        options: { shouldCreateUser: false },
-      });
-      if (error) return setErr(getAuthErrorMessage(error));
-      setResendAttempts((a) => a + 1);
-    } finally {
-      setLoading(false);
-      setResending(false);
-    }
-  }
+  const [resendOtp, resending] = useAsyncAction(async () => {
+    const trimmedPhone = phone.trim();
+    const { error } = await supabase.auth.signInWithOtp({
+      phone: trimmedPhone,
+      options: { shouldCreateUser: false },
+    });
+    if (error) throw new Error(getAuthErrorMessage(error));
+    setResendAttempts((a) => a + 1);
+  }, { error: 'Could not resend code', success: 'Code resent' });
 
   const RightPanel = (
     <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
@@ -98,8 +81,6 @@ export default function LoginWithPhone() {
 
   return (
     <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code." right={RightPanel}>
-      {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
-
       {stage === 'request' ? (
         <form onSubmit={requestOtp} className="space-y-6 mt-2">
           <Input
@@ -116,8 +97,8 @@ export default function LoginWithPhone() {
             hint="Use E.164 format, e.g. +923001234567"
             error={phoneErr ?? undefined}
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
-            {loading ? 'Sending…' : 'Send code'}
+          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={requesting}>
+            {requesting ? 'Sending…' : 'Send code'}
           </Button>
         </form>
       ) : (
@@ -134,18 +115,18 @@ export default function LoginWithPhone() {
             type="submit"
             variant="primary"
             className="w-full rounded-ds-xl"
-            disabled={loading && !resending}
+            disabled={verifying}
           >
-            {loading && !resending ? 'Verifying…' : 'Verify & Continue'}
+            {verifying ? 'Verifying…' : 'Verify & Continue'}
           </Button>
           <Button
             type="button"
             variant="secondary"
             className="w-full rounded-ds-xl"
             onClick={resendOtp}
-            disabled={loading}
+            disabled={resending}
           >
-            {loading && resending ? 'Resending…' : `Resend code${resendAttempts ? ` (${resendAttempts})` : ''}`}
+            {resending ? 'Resending…' : `Resend code${resendAttempts ? ` (${resendAttempts})` : ''}`}
           </Button>
         </form>
       )}

--- a/pages/update-password.tsx
+++ b/pages/update-password.tsx
@@ -1,52 +1,31 @@
 import React, { useState } from 'react';
-import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Input } from '@/components/design-system/Input';
 import { Button } from '@/components/design-system/Button';
-import { Alert } from '@/components/design-system/Alert';
 import { supabase } from '@/lib/supabaseClient';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 export default function UpdatePassword() {
   const router = useRouter();
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false), [err, setErr] = useState<React.ReactNode>(null);
-  const [ok, setOk] = useState(false);
-
-  const submit = async (e: React.FormEvent) => {
+  const [submit, loading] = useAsyncAction(async (e: React.FormEvent) => {
     e.preventDefault();
-    setErr(null);
-    if (!password) return setErr('Please enter a new password.');
-    setLoading(true);
+    if (!password) throw new Error('Please enter a new password.');
     const { data: reused, error: rpcError } = await supabase.rpc('password_is_reused', { new_password: password });
-    if (rpcError) {
-      setLoading(false);
-      return setErr(rpcError.message);
-    }
-    if (reused) {
-      setLoading(false);
-      return setErr('Cannot reuse old password.');
-    }
+    if (rpcError) throw new Error(rpcError.message);
+    if (reused) throw new Error('Cannot reuse old password.');
     const { error } = await supabase.auth.updateUser({ password });
-    setLoading(false);
     if (error) {
       if (error.code === 'token_expired') {
-        return setErr(
-          <>
-            Link expired.{' '}
-            <Link href="/forgot-password" className="text-primary underline">
-              Request a new reset
-            </Link>
-          </>
-        );
+        throw new Error('Link expired. Request a new reset.');
       }
-      return setErr(error.message);
+      throw new Error(error.message);
     }
-    setOk(true);
     setTimeout(() => router.push('/login'), 800);
-  };
+  }, { success: 'Password updated', error: 'Could not update password' });
 
   return (
     <section className="min-h-[100svh] bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
@@ -60,9 +39,6 @@ export default function UpdatePassword() {
 
             <h1 className="font-slab text-h1 mb-2 text-primary dark:text-electricBlue">Set a new password</h1>
             <p className="text-grayish dark:text-white/75 mb-6">Enter your new password to continue.</p>
-
-            {err && <Alert variant="error" title="Couldn’t update" className="mb-4">{err}</Alert>}
-            {ok && <Alert variant="success" title="Updated" className="mb-4">Redirecting to login…</Alert>}
 
             <form onSubmit={submit} className="space-y-4">
               <Input label="New password" type="password" placeholder="••••••••"


### PR DESCRIPTION
## Summary
- add SpinnerProvider and toast helpers to design system
- introduce useAsyncAction hook that shows spinner + toast
- refactor auth and profile flows to use toasts instead of alerts

## Testing
- `npm test` *(fails: supa.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a1d71008321a9f1017f4b2f766d