### PR TITLE
fix: restore check-otp API

### DIFF
--- a/__tests__/login-success.test.ts
+++ b/__tests__/login-success.test.ts
@@ -32,6 +32,7 @@ const supabaseClient = {
               id: 'user1',
               app_metadata: { role: 'student' },
               user_metadata: {},
+              email_confirmed_at: '2024-01-01T00:00:00Z',
             },
             access_token: 'tok',
             refresh_token: 'ref',
@@ -41,6 +42,7 @@ const supabaseClient = {
       };
     },
     setSession: async () => {},
+    signOut: async () => {},
   },
 };
 require.cache[require.resolve('@supabase/supabase-js')] = {


### PR DESCRIPTION
## Summary
- restore Twilio+Supabase implementation of check-otp API
- ensure non-POST requests throw and add validation/error handling

## Testing
- `npm test` *(fails: import_supabaseBrowser.supabaseBrowser.auth.signOut is not a function)*
- `npx tsx __tests__/check-otp.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b204e0d0b88321a11de13834633ebe