### PR TITLE
feat: add bottom navigation for mobile

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
 import { useStreak } from '@/hooks/useStreak';
 import { Breadcrumbs, type Crumb } from '@/components/design-system/Breadcrumbs';
+import { BottomNav } from '@/components/navigation/BottomNav';
 
 export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { current } = useStreak();
@@ -27,6 +28,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
         {children}
       </main>
       <Footer />
+      <BottomNav />
     </>
   );
 };

--- a/components/navigation/BottomNav.tsx
+++ b/components/navigation/BottomNav.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { NavLink } from '@/components/design-system/NavLink';
+
+const NAV_ITEMS = [
+  { href: '/', label: 'Home', icon: 'fa-home', exact: true },
+  { href: '/learning', label: 'Courses', icon: 'fa-book' },
+  { href: '/mock-tests', label: 'Tests', icon: 'fa-pencil-alt' },
+  { href: '/profile', label: 'Profile', icon: 'fa-user' },
+];
+
+export const BottomNav: React.FC = () => {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-200 bg-white dark:bg-dark md:hidden">
+      <ul className="flex justify-around">
+        {NAV_ITEMS.map(({ href, label, icon, exact }) => (
+          <li key={href} className="flex-1">
+            <NavLink
+              href={href}
+              exact={exact}
+              variant="plain"
+              className="flex flex-col items-center gap-1 py-2 text-xs text-gray-600 dark:text-grayish [&.is-active]:text-vibrantPurple"
+            >
+              <i className={`fas ${icon} text-lg`} aria-hidden />
+              <span>{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default BottomNav;


### PR DESCRIPTION
## Summary
- add mobile bottom nav with quick links to core sections
- render bottom nav in main layout for small screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20889a2bc832196abe425a6959452