### PR TITLE
refactor: tokenized design system styling

### DIFF
--- a/components/design-system/AudioBar.tsx
+++ b/components/design-system/AudioBar.tsx
@@ -146,7 +146,7 @@ export const AudioBar: React.FC<AudioBarProps> = (props) => {
 
       <div className="flex-1">
         <div
-          className="h-2 w-full rounded-ds bg-gray-200 dark:bg-white/10 overflow-hidden"
+          className="h-2 w-full rounded-ds bg-border dark:bg-border/20 overflow-hidden"
           role="slider"
           aria-valuemin={0}
           aria-valuemax={100}

--- a/components/design-system/AudioRecordButton.tsx
+++ b/components/design-system/AudioRecordButton.tsx
@@ -39,7 +39,7 @@ export const AudioRecordButton: React.FC<AudioRecordButtonProps> = ({ onStop, cl
 
   if (!supported) {
     return (
-      <button type="button" disabled className={`px-4 py-2 rounded-ds bg-gray-200 dark:bg-white/10 text-small ${className}`}>
+      <button type="button" disabled className={`px-4 py-2 rounded-ds bg-border dark:bg-border/20 text-small ${className}`}>
         Recording not supported
       </button>
     );
@@ -50,9 +50,9 @@ export const AudioRecordButton: React.FC<AudioRecordButtonProps> = ({ onStop, cl
       type="button"
       onClick={recording ? stop : start}
       disabled={disabled}
-      className={`inline-flex items-center gap-2 px-4 py-2 rounded-ds border border-gray-200 dark:border-white/10
-        ${recording ? 'bg-sunsetOrange/20 text-sunsetOrange' : 'bg-white dark:bg-dark/40 text-lightText dark:text-white'}
-        hover:bg-gray-50 dark:hover:bg-white/10 ${className}`}
+      className={`inline-flex items-center gap-2 px-4 py-2 rounded-ds border border-border dark:border-border/20
+        ${recording ? 'bg-sunsetOrange/20 text-sunsetOrange' : 'bg-card dark:bg-dark/40 text-lightText dark:text-foreground'}
+        hover:bg-border/20 dark:hover:bg-border/20 ${className}`}
       aria-pressed={recording}
       aria-label={recording ? 'Stop recording' : 'Start recording'}
     >

--- a/components/design-system/AvatarUploader.tsx
+++ b/components/design-system/AvatarUploader.tsx
@@ -87,7 +87,7 @@ export const AvatarUploader: React.FC<Props> = ({
         }}
         className={`
           border-2 border-dashed rounded-ds p-6 text-center cursor-pointer
-          ${drag ? 'border-primary bg-primary/5' : 'border-gray-300 dark:border-white/10'}
+          ${drag ? 'border-primary bg-primary/5' : 'border-border dark:border-vibrantPurple/20'}
         `}
         onClick={() => inputRef.current?.click()}
       >

--- a/components/design-system/Badge.tsx
+++ b/components/design-system/Badge.tsx
@@ -14,7 +14,7 @@ export const Badge: React.FC<{
     md: 'text-body px-3.5 py-1.5 rounded-ds',
   };
   const variants: Record<Variant, string> = {
-    neutral: 'bg-gray-200 text-lightText dark:bg-white/10 dark:text-white',
+    neutral: 'bg-border text-lightText dark:bg-border/20 dark:text-foreground',
     success: 'bg-success/15 text-success border border-success/30',
     warning: 'bg-goldenYellow/15 text-goldenYellow border border-goldenYellow/30',
     danger: 'bg-sunsetOrange/15 text-sunsetOrange border border-sunsetOrange/30',

--- a/components/design-system/Breadcrumbs.tsx
+++ b/components/design-system/Breadcrumbs.tsx
@@ -5,15 +5,15 @@ export type Crumb = { label: string; href?: string };
 export const Breadcrumbs: React.FC<{ items: Crumb[]; className?: string }> = ({ items, className='' }) => {
   return (
     <nav aria-label="Breadcrumb" className={`text-small ${className}`}>
-      <ol className="flex items-center gap-2 text-gray-600 dark:text-grayish">
+      <ol className="flex items-center gap-2 text-mutedText">
         {items.map((c, i) => (
           <li key={`${c.label}-${i}`} className="flex items-center gap-2">
             {c.href ? (
-              <Link href={c.href} className="hover:text-lightText dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-primary rounded-ds px-1">
+              <Link href={c.href} className="hover:text-lightText dark:hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary rounded-ds px-1">
                 {c.label}
               </Link>
             ) : (
-              <span className="text-lightText dark:text-white">{c.label}</span>
+              <span className="text-lightText dark:text-foreground">{c.label}</span>
             )}
             {i < items.length - 1 && <span className="opacity-60"><i className="fas fa-chevron-right" aria-hidden="true" /></span>}
           </li>

--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -38,7 +38,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 const Spinner: React.FC = () => (
   <span
     aria-hidden
-    className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/60 border-t-white mr-2"
+    className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-foreground/60 border-t-foreground mr-2"
   />
 );
 

--- a/components/design-system/Checkbox.tsx
+++ b/components/design-system/Checkbox.tsx
@@ -15,7 +15,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({ label, hint, error, classNam
           'mt-1 h-5 w-5 rounded-ds border',
           'text-primary focus:ring-2 focus:ring-primary focus:outline-none',
           'dark:bg-dark/50 dark:border-purpleVibe/30 dark:focus:ring-electricBlue',
-          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-gray-300'
+          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-border'
         ].join(' ')}
         {...props}
       />
@@ -24,7 +24,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({ label, hint, error, classNam
         {error ? (
           <div className="text-small text-sunsetOrange">{error}</div>
         ) : hint ? (
-          <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>
+          <div className="text-small text-mutedText">{hint}</div>
         ) : null}
       </div>
     </label>

--- a/components/design-system/Drawer.tsx
+++ b/components/design-system/Drawer.tsx
@@ -26,11 +26,11 @@ export const Drawer: React.FC<DrawerProps> = ({ open, onClose, side='right', tit
 
   return (
     <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-black/30 dark:bg-black/60" onClick={onClose} aria-hidden="true" />
+      <div className="absolute inset-0 bg-dark/30 dark:bg-dark/60" onClick={onClose} aria-hidden="true" />
       <div className={`absolute ${pos} ${size} card-surface shadow-xl ${className}`} role="dialog" aria-modal="true">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-white/10">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border dark:border-vibrantPurple/20">
           <div className="font-semibold">{title}</div>
-          <button onClick={onClose} className="rounded-ds p-2 hover:bg-gray-100 dark:hover:bg-white/10" aria-label="Close">
+          <button onClick={onClose} className="rounded-ds p-2 hover:bg-border/20 dark:hover:bg-border/20" aria-label="Close">
             <i className="fas fa-times" aria-hidden="true" />
           </button>
         </div>

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -23,10 +23,10 @@ export const Input: React.FC<InputProps> = ({
   const describedBy =
     error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'w-full rounded-ds border border-border bg-card text-lightText placeholder-mutedText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'disabled:opacity-60',
-    'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',
+    'dark:bg-dark/50 dark:text-foreground dark:placeholder-mutedText/40',
     'dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
   const invalid = error
@@ -36,13 +36,13 @@ export const Input: React.FC<InputProps> = ({
   return (
     <label className={`block ${className}`}>
       {label && (
-        <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">
+        <span className="mb-1.5 inline-block text-small text-mutedText">
           {label}
         </span>
       )}
       <div className={`relative flex items-center ${error ? 'text-sunsetOrange' : ''}`}>
         {iconLeft && (
-          <span className="absolute left-3 text-gray-500 dark:text-white/50">
+          <span className="absolute left-3 text-mutedText opacity-60 dark:text-mutedText">
             {iconLeft}
           </span>
         )}
@@ -55,7 +55,7 @@ export const Input: React.FC<InputProps> = ({
           {...props}
         />
         {iconRight && (
-          <span className="absolute right-3 text-gray-500 dark:text-white/50">
+          <span className="absolute right-3 text-mutedText opacity-60 dark:text-mutedText">
             {iconRight}
           </span>
         )}
@@ -65,7 +65,7 @@ export const Input: React.FC<InputProps> = ({
           {error}
         </span>
       ) : hint ? (
-        <span id={`${inputId}-hint`} className="mt-1 block text-small text-gray-600 dark:text-grayish">
+        <span id={`${inputId}-hint`} className="mt-1 block text-small text-mutedText">
           {hint}
         </span>
       ) : null}

--- a/components/design-system/Modal.tsx
+++ b/components/design-system/Modal.tsx
@@ -19,12 +19,12 @@ export const Modal: React.FC<ModalProps> = ({ open, onClose, title, children, fo
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/30 dark:bg-black/60" onClick={onClose} aria-hidden="true" />
+      <div className="absolute inset-0 bg-dark/30 dark:bg-dark/60" onClick={onClose} aria-hidden="true" />
       <div role="dialog" aria-modal="true" className={`card-surface rounded-ds-2xl w-full max-w-lg shadow-xl relative ${className}`}>
-        {title && <div className="px-6 pt-5 pb-3 border-b border-gray-200 dark:border-white/10 text-h3 font-semibold">{title}</div>}
+        {title && <div className="px-6 pt-5 pb-3 border-b border-border dark:border-vibrantPurple/20 text-h3 font-semibold">{title}</div>}
         <div className="px-6 py-5">{children}</div>
-        {footer && <div className="px-6 pt-3 pb-5 border-t border-gray-200 dark:border-white/10">{footer}</div>}
-        <button onClick={onClose} className="absolute top-3 right-3 rounded-ds p-2 hover:bg-gray-100 dark:hover:bg-white/10" aria-label="Close">
+        {footer && <div className="px-6 pt-3 pb-5 border-t border-border dark:border-vibrantPurple/20">{footer}</div>}
+        <button onClick={onClose} className="absolute top-3 right-3 rounded-ds p-2 hover:bg-border/20 dark:hover:bg-border/20" aria-label="Close">
           <i className="fas fa-times" aria-hidden="true" />
         </button>
       </div>

--- a/components/design-system/NotificationBell.tsx
+++ b/components/design-system/NotificationBell.tsx
@@ -100,7 +100,7 @@ export const NotificationBell: React.FC = () => {
         {unread > 0 && (
           <span
             aria-live="polite"
-            className="absolute -top-1 -right-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-sunsetOrange px-1 text-[10px] leading-none text-white"
+            className="absolute -top-1 -right-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-sunsetOrange px-1 text-[10px] leading-none text-foreground"
           >
             {unread}
           </span>

--- a/components/design-system/ProgressBar.tsx
+++ b/components/design-system/ProgressBar.tsx
@@ -10,8 +10,8 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({ value, label, classNam
   const v = Math.max(0, Math.min(100, value));
   return (
     <div className={`w-full ${className}`}>
-      {label && <div className="mb-1 text-small text-gray-600 dark:text-grayish">{label}</div>}
-      <div className="h-2 w-full rounded-ds bg-gray-200 dark:bg-white/10 overflow-hidden">
+      {label && <div className="mb-1 text-small text-mutedText">{label}</div>}
+      <div className="h-2 w-full rounded-ds bg-border dark:bg-border/20 overflow-hidden">
         <div
           className="h-full rounded-ds bg-primary dark:bg-electricBlue transition-[width] duration-300"
           style={{ width: `${v}%` }}

--- a/components/design-system/QuestionItem.tsx
+++ b/components/design-system/QuestionItem.tsx
@@ -8,7 +8,7 @@ type BaseProps = {
 };
 
 const statusRing: Record<NonNullable<BaseProps['status']>, string> = {
-  default: 'border-gray-200 dark:border-white/10',
+  default: 'border-border dark:border-border/20',
   answered: 'border-success/60',
   flagged: 'border-goldenYellow/60',
   review: 'border-electricBlue/60'
@@ -49,7 +49,7 @@ export const QuestionMCQ: React.FC<{
         <legend className="sr-only">Question {number}</legend>
         <div className="grid gap-2">
           {options.map(opt => (
-            <label key={opt.key} className="flex items-center gap-3 p-2 rounded-ds hover:bg-gray-50 dark:hover:bg-white/5">
+            <label key={opt.key} className="flex items-center gap-3 p-2 rounded-ds hover:bg-border/20 dark:hover:bg-foreground/5">
               <input
                 type="radio"
                 name={group}
@@ -86,8 +86,8 @@ export const QuestionTFNG: React.FC<{
             type="button"
             onClick={() => onChange?.(o.k)}
             className={`px-3 py-2 rounded-ds border text-small
-              ${value === o.k ? 'bg-primary text-white dark:bg-electricBlue' : 'bg-white dark:bg-dark/40 text-lightText dark:text-white'}
-              border-gray-200 dark:border-white/10`}
+              ${value === o.k ? 'bg-primary text-primary-foreground dark:bg-electricBlue' : 'bg-card dark:bg-dark/40 text-lightText dark:text-foreground'}
+              border-border dark:border-border/20`}
             aria-pressed={value === o.k}
           >
             {o.l}
@@ -111,7 +111,7 @@ export const QuestionGapFill: React.FC<{
     <QuestionShell number={number} status={status} className={className}>
       <input
         type="text"
-        className="w-full rounded-ds border bg-white text-lightText placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue px-3 py-2"
+        className="w-full rounded-ds border border-border bg-card text-lightText placeholder-mutedText focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary dark:bg-dark/50 dark:text-foreground dark:placeholder-mutedText/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue px-3 py-2"
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
         placeholder={placeholder}

--- a/components/design-system/Radio.tsx
+++ b/components/design-system/Radio.tsx
@@ -15,7 +15,7 @@ export const Radio: React.FC<RadioProps> = ({ label, hint, error, className = ''
           'mt-1 h-5 w-5 border rounded-full',
           'text-primary focus:ring-2 focus:ring-primary focus:outline-none',
           'dark:bg-dark/50 dark:border-purpleVibe/30 dark:focus:ring-electricBlue',
-          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-gray-300'
+          error ? 'border-sunsetOrange focus:ring-sunsetOrange' : 'border-border'
         ].join(' ')}
         {...props}
       />
@@ -24,7 +24,7 @@ export const Radio: React.FC<RadioProps> = ({ label, hint, error, className = ''
         {error ? (
           <div className="text-small text-sunsetOrange">{error}</div>
         ) : hint ? (
-          <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>
+          <div className="text-small text-mutedText">{hint}</div>
         ) : null}
       </div>
     </label>

--- a/components/design-system/Ribbon.tsx
+++ b/components/design-system/Ribbon.tsx
@@ -27,7 +27,7 @@ export const Ribbon: React.FC<{
       aria-hidden="true"
     >
       <span
-        className={`inline-block py-1 px-8 text-xs font-bold tracking-wide text-white bg-gradient-to-r ${variantCls[variant]} shadow-glow rounded-ds`}
+        className={`inline-block py-1 px-8 text-xs font-bold tracking-wide text-primary-foreground bg-gradient-to-r ${variantCls[variant]} shadow-glow rounded-ds`}
       >
         {label}
       </span>

--- a/components/design-system/ScoreCard.tsx
+++ b/components/design-system/ScoreCard.tsx
@@ -30,7 +30,7 @@ export const ScoreCard: React.FC<ScoreCardProps> = ({ overall, subscores, title=
         <div className="relative h-24 w-24" aria-hidden="true">
           <svg viewBox="0 0 36 36" className="h-full w-full">
             <path
-              className="text-gray-200 dark:text-white/10"
+              className="text-border dark:text-border/20"
               stroke="currentColor"
               strokeWidth="3"
               fill="none"
@@ -51,13 +51,13 @@ export const ScoreCard: React.FC<ScoreCardProps> = ({ overall, subscores, title=
           </div>
         </div>
         <div>
-          <div className="text-small text-gray-600 dark:text-grayish">{title}</div>
+          <div className="text-small text-mutedText">{title}</div>
           <div className="text-h2 font-slab">Overall {band.toFixed(1)}</div>
           {subscores && (
             <div className="mt-3 grid grid-cols-2 gap-2 text-small">
               {Object.entries(subscores).map(([k, v]) => (
                 v != null && (
-                  <div key={k} className="flex items-center justify-between rounded-ds px-2.5 py-1.5 bg-purpleVibe/10 text-lightText dark:text-white">
+                  <div key={k} className="flex items-center justify-between rounded-ds px-2.5 py-1.5 bg-purpleVibe/10 text-lightText dark:text-foreground">
                     <span className="capitalize">{k.replace(/([A-Z])/g, ' $1')}</span>
                     <span className="font-semibold tabular-nums">{clampBand(v).toFixed(1)}</span>
                   </div>

--- a/components/design-system/Select.tsx
+++ b/components/design-system/Select.tsx
@@ -10,15 +10,15 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
 
 export const Select: React.FC<SelectProps> = ({ label, hint, error, options = [], className = '', children, ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText',
+    'w-full rounded-ds border border-border bg-card text-lightText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
-    'dark:bg-dark/50 dark:text-white dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
+    'dark:bg-dark/50 dark:text-foreground dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
   const invalid = error ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange' : '';
 
   return (
     <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
+      {label && <span className="mb-1.5 inline-block text-small text-mutedText">{label}</span>}
       <div className="relative">
         <select className={`${base} ${invalid} appearance-none pl-4 pr-10 py-3`} {...props}>
           {options.map(opt => (
@@ -33,7 +33,7 @@ export const Select: React.FC<SelectProps> = ({ label, hint, error, options = []
       {error ? (
         <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
       ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span className="mt-1 block text-small text-mutedText">{hint}</span>
       ) : null}
     </label>
   );

--- a/components/design-system/Skeleton.tsx
+++ b/components/design-system/Skeleton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const Skeleton: React.FC<{ className?: string }> = ({ className = '' }) => {
-  return <div className={`animate-pulse bg-gray-200 dark:bg-white/10 rounded ${className}`} />;
+  return <div className={`animate-pulse bg-border dark:bg-border/20 rounded ${className}`} />;
 };

--- a/components/design-system/Tabs.tsx
+++ b/components/design-system/Tabs.tsx
@@ -11,13 +11,13 @@ export type TabsProps = {
 export const Tabs: React.FC<TabsProps> = ({ tabs, value, onChange, className='' }) => {
   return (
     <div className={`w-full ${className}`}>
-      <div className="flex flex-wrap gap-2 border-b border-gray-200 dark:border-white/10">
+      <div className="flex flex-wrap gap-2 border-b border-border dark:border-vibrantPurple/20">
         {tabs.map(t => {
           const active = value === t.key;
           const base = 'px-4 py-2 rounded-ds-t font-medium';
           const styles = active
             ? 'text-primary border-b-2 border-primary dark:text-electricBlue dark:border-electricBlue'
-            : 'text-gray-600 dark:text-grayish hover:text-lightText dark:hover:text-white';
+            : 'text-mutedText hover:text-lightText dark:hover:text-foreground';
           return (
             <button
               key={t.key}

--- a/components/design-system/Textarea.tsx
+++ b/components/design-system/Textarea.tsx
@@ -8,20 +8,20 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 
 export const Textarea: React.FC<TextareaProps> = ({ label, hint, error, className = '', ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'w-full rounded-ds border border-border bg-card text-lightText placeholder-mutedText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
-    'dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
+    'dark:bg-dark/50 dark:text-foreground dark:placeholder-mutedText/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');
   const invalid = error ? 'border-sunsetOrange focus:ring-sunsetOrange focus:border-sunsetOrange' : '';
 
   return (
     <label className={`block ${className}`}>
-      {label && <span className="mb-1.5 inline-block text-small text-gray-600 dark:text-grayish">{label}</span>}
+      {label && <span className="mb-1.5 inline-block text-small text-mutedText">{label}</span>}
       <textarea className={`${base} ${invalid} p-4 min-h-[140px]`} {...props} />
       {error ? (
         <span className="mt-1 block text-small text-sunsetOrange">{error}</span>
       ) : hint ? (
-        <span className="mt-1 block text-small text-gray-600 dark:text-grayish">{hint}</span>
+        <span className="mt-1 block text-small text-mutedText">{hint}</span>
       ) : null}
     </label>
   );

--- a/components/design-system/ThemeToggle.tsx
+++ b/components/design-system/ThemeToggle.tsx
@@ -10,8 +10,8 @@ export function ThemeToggle() {
       type="button"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
       className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm hover:shadow-sm
-                 bg-white/70 dark:bg-white/10 backdrop-blur
-                 border-black/10 dark:border-white/15"
+                 bg-card/70 dark:bg-card/10 backdrop-blur
+                 border-border dark:border-border/20"
       aria-label="Toggle color theme"
       title="Toggle theme"
     >

--- a/components/design-system/Timer.tsx
+++ b/components/design-system/Timer.tsx
@@ -62,14 +62,14 @@ export const Timer: React.FC<TimerProps> = ({
 
   const label = useMemo(() => format(seconds), [seconds]);
 
-  const intent = mode === 'countdown' && seconds <= 60 ? 'text-sunsetOrange' : 'text-lightText dark:text-white';
+  const intent = mode === 'countdown' && seconds <= 60 ? 'text-sunsetOrange' : 'text-lightText dark:text-foreground';
 
   return (
     <div
       role="timer"
       aria-live="polite"
       aria-label={ariaLabel}
-      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-ds border border-gray-200 dark:border-white/10 ${className}`}
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-ds border border-border dark:border-vibrantPurple/20 ${className}`}
     >
       <i className={`fas fa-clock ${intent}`} aria-hidden="true" />
       <span className={`tabular-nums font-semibold ${intent}`}>{label}</span>

--- a/components/design-system/Toaster.tsx
+++ b/components/design-system/Toaster.tsx
@@ -44,10 +44,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           <div
             key={t.id}
             className={`rounded-ds-2xl p-4 shadow-lg border
-              ${t.intent === 'success' ? 'bg-emerald-50 border-emerald-200 text-emerald-900 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-200'
-              : t.intent === 'error' ? 'bg-rose-50 border-rose-200 text-rose-900 dark:bg-rose-900/20 dark:border-rose-700 dark:text-rose-200'
-              : t.intent === 'warning' ? 'bg-amber-50 border-amber-200 text-amber-900 dark:bg-amber-900/20 dark:border-amber-700 dark:text-amber-200'
-              : 'bg-black/80 border-white/10 text-white'}`}
+              ${t.intent === 'success' ? 'bg-success/10 border-success/20 text-success'
+              : t.intent === 'error' ? 'bg-sunsetRed/10 border-sunsetRed/20 text-sunsetRed'
+              : t.intent === 'warning' ? 'bg-goldenYellow/10 border-goldenYellow/20 text-goldenYellow'
+              : 'bg-dark/80 border-border text-foreground'}`}
           >
             <div className="font-semibold">{t.title}</div>
             {t.desc && <div className="text-sm opacity-90 mt-1">{t.desc}</div>}

--- a/components/design-system/Toggle.tsx
+++ b/components/design-system/Toggle.tsx
@@ -20,21 +20,21 @@ export const Toggle: React.FC<ToggleProps> = ({ checked=false, onChange, label, 
         onClick={() => !disabled && onChange?.(!checked)}
         className={[
           'relative inline-flex h-6 w-11 items-center rounded-ds transition',
-          checked ? 'bg-primary dark:bg-electricBlue' : 'bg-gray-300 dark:bg-white/20',
+          checked ? 'bg-primary dark:bg-electricBlue' : 'bg-border dark:bg-border/20',
           disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer',
           'focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-electricBlue'
         ].join(' ')}
       >
         <span
           className={[
-            'inline-block h-5 w-5 transform rounded-ds bg-white dark:bg-dark transition',
+            'inline-block h-5 w-5 transform rounded-ds bg-card dark:bg-dark transition',
             checked ? 'translate-x-5' : 'translate-x-1'
           ].join(' ')}
         />
       </button>
       <div>
         {label && <div className="text-body">{label}</div>}
-        {hint && <div className="text-small text-gray-600 dark:text-grayish">{hint}</div>}
+        {hint && <div className="text-small text-mutedText">{hint}</div>}
       </div>
     </label>
   );

--- a/components/design-system/UserMenu.tsx
+++ b/components/design-system/UserMenu.tsx
@@ -140,7 +140,7 @@ export const UserMenu: React.FC<{
           className="absolute right-0 mt-2 w-64 rounded-2xl border border-vibrantPurple/20 bg-lightBg dark:bg-dark shadow-lg overflow-hidden"
         >
           {showEmail && (email || name) && (
-            <div className="px-4 py-3 text-small text-grayish dark:text-white/70 border-b border-vibrantPurple/15">
+            <div className="px-4 py-3 text-small text-grayish dark:text-foreground/70 border-b border-vibrantPurple/15">
               <div className="flex items-center gap-3">
                 <div className="h-9 w-9 rounded-full bg-vibrantPurple/15 flex items-center justify-center overflow-hidden">
                   {localAvatar ? (
@@ -151,7 +151,7 @@ export const UserMenu: React.FC<{
                   )}
                 </div>
                 <div>
-                  <div className="font-medium text-lightText dark:text-white">{name ?? email}</div>
+                  <div className="font-medium text-lightText dark:text-foreground">{name ?? email}</div>
                   {email && name && <div className="opacity-80">{email}</div>}
                 </div>
               </div>

--- a/doc/ui-guidelines.md
+++ b/doc/ui-guidelines.md
@@ -1,0 +1,17 @@
+# UI Guidelines
+
+## Design tokens
+- Use tokenized Tailwind utilities for color and typography (e.g., `text-primary`, `text-mutedText`, `bg-card`).
+- Avoid raw color names like `text-gray-600` or `bg-white`; tokens ensure theme parity.
+
+## Shared tokens for non-Tailwind usage
+- CSS variables for tokens live in `styles/tokens.css`.
+- Import this file in non-Tailwind contexts:
+  ```css
+  @import '../styles/tokens.css';
+  ```
+- Dark mode is toggled by adding the `.dark` class to the root element; variables update automatically.
+
+## Components
+- All design-system components rely on tokens. When extending components, prefer token utilities over raw colors.
+- For background and border colors use utilities like `bg-card`, `bg-primary`, `border-border`.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,4 @@
+@import './tokens.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -5,41 +6,9 @@
 /* Ensure full-height layout */
 html, body, #__next { height: 100%; }
 
-/* =========================
-   Color tokens → RGB triplets
-   (must match design-system/tokens/colors.js)
-   ========================= */
-:root{
-  --color-primary:        67 97 238;   /* #4361ee */
-  --color-primaryDark:    58 86 212;   /* #3a56d4 */
-  --color-secondary:     247 37 133;   /* #f72585 */
-  --color-accent:         76 201 240;  /* #4cc9f0 */
-  --color-success:        46 196 182;  /* #2ec4b6 */
-
-  --color-purpleVibe:    157 78 221;   /* #9d4edd */
-  --color-vibrantPurple: 157 78 221;   /* alias */
-  --color-electricBlue:    0 187 249;  /* #00bbf9 */
-  --color-neonGreen:     128 255 219;  /* #80ffdb */
-  --color-sunsetOrange:  255 107 107;  /* #ff6b6b */
-  --color-sunsetRed:     255  77  77;  /* #ff4d4d */
-  --color-goldenYellow:  255 209 102;  /* #ffd166 */
-
-  --color-dark:           15  15  27;  /* #0f0f1b */
-  --color-darker:          7   7  16;  /* #070710 */
-  --color-lightBg:       240 242 245;  /* #f0f2f5 */
-  --color-lightText:      26  26  46;  /* #1a1a2e */
-  /* darker gray for accessible body text on light backgrounds */
-  --color-grayish:       106 106 134;  /* #6a6a86 */
-
-  --color-lightCard:     255 255 255;  /* #ffffff */
-  --color-lightBorder:   224 224 224;  /* #e0e0e0 */
-  --color-border:        224 224 224;  /* #e0e0e0 */
-  --color-mutedText:     208 208 224;  /* #d0d0e0 */
-}
-
 /* Light = default; Dark via .dark on <html> (next-themes) */
 body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
-.dark body { @apply text-white bg-gradient-to-br from-darker to-dark; }
+.dark body { @apply text-foreground bg-gradient-to-br from-darker to-dark; }
 
 /* =========================
    Headings → Roboto Slab (no circular apply)
@@ -52,10 +21,10 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
    Header / Nav (GLOBAL)
    ========================= */
 .header-glass {
-  @apply text-lightText bg-white/90 backdrop-blur-md border-b border-gray-200;
+  @apply text-lightText bg-white/90 backdrop-blur-md border-b border-border;
 }
 .dark .header-glass {
-  @apply text-white bg-dark/95 border-vibrantPurple/20;
+  @apply text-foreground bg-dark/95 border-vibrantPurple/20;
 }
 
 /* Navigation pill with underline (active & hover) */
@@ -67,7 +36,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 }
 .dark .nav-pill{
   /* Dark theme text */
-  @apply text-white/90 hover:text-white;
+  @apply text-foreground/90 hover:text-foreground;
 }
 
 /* underline */
@@ -81,7 +50,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 
 /* active pill background (light vs dark) */
 .nav-pill.is-active{ @apply bg-vibrantPurple/10; }
-.dark .nav-pill.is-active{ @apply bg-white/5; }
+.dark .nav-pill.is-active{ @apply bg-foreground/5; }
 .nav-pill.is-active::after{ opacity:1; }
 
 /* Container utility */
@@ -117,7 +86,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 .btn-primary:hover, .btn-accent:hover { background-position: 100% 50%; }
 
 /* Variants */
-.btn-primary  { @apply text-white bg-gradient-to-br from-purpleVibe to-electricBlue shadow-glow; }
+.btn-primary  { @apply text-foreground bg-gradient-to-br from-purpleVibe to-electricBlue shadow-glow; }
 .btn-primary:hover {
   background-image: linear-gradient(135deg,
     rgb(var(--color-electricBlue)),
@@ -128,7 +97,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 .btn-secondary{ @apply border-2 border-primary text-primary bg-transparent; }
 .dark .btn-secondary { @apply border-neonGreen text-neonGreen; }
 
-.btn-accent   { @apply text-white bg-gradient-to-br from-sunsetOrange to-sunsetRed shadow-glow; }
+.btn-accent   { @apply text-foreground bg-gradient-to-br from-sunsetOrange to-sunsetRed shadow-glow; }
 .btn-accent:hover {
   background-image: linear-gradient(135deg,
     rgb(var(--color-sunsetRed)),
@@ -146,7 +115,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
    Card surfaces
    ========================= */
 .card-surface { @apply rounded-ds-2xl border bg-lightCard border-lightBorder text-lightText; }
-.dark .card-surface { @apply border-vibrantPurple/20 backdrop-blur-md bg-purpleVibe/10 text-white; }
+.dark .card-surface { @apply border-vibrantPurple/20 backdrop-blur-md bg-purpleVibe/10 text-foreground; }
 
 /* Glass card variant (used by waitlist/testimonials etc.) */
 .card-glass {
@@ -154,7 +123,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
   @apply bg-white/70 text-lightText border-lightBorder;
 }
 .dark .card-glass {
-  @apply bg-purpleVibe/10 text-white border-vibrantPurple/20;
+  @apply bg-purpleVibe/10 text-foreground border-vibrantPurple/20;
 }
 
 /* =========================
@@ -200,7 +169,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
   @apply bg-lightCard border border-lightBorder text-lightText/80;
 }
 .dark .ai-code-block{
-  @apply bg-purpleVibe/10 border-vibrantPurple/20 text-white/80;
+  @apply bg-purpleVibe/10 border-vibrantPurple/20 text-foreground/80;
 }
 
 /* AI sidebar split view */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,38 @@
+/* Design tokens → CSS variables
+   (must match design-system/tokens/colors.js) */
+:root {
+  --color-primary:        67 97 238;   /* #4361ee */
+  --color-primaryDark:    58 86 212;   /* #3a56d4 */
+  --color-secondary:     247 37 133;  /* #f72585 */
+  --color-accent:         76 201 240;  /* #4cc9f0 */
+  --color-success:        46 196 182;  /* #2ec4b6 */
+
+  --color-purpleVibe:    157 78 221;   /* #9d4edd */
+  --color-vibrantPurple: 157 78 221;   /* alias */
+  --color-electricBlue:    0 187 249;  /* #00bbf9 */
+  --color-neonGreen:     128 255 219;  /* #80ffdb */
+  --color-sunsetOrange:  255 107 107;  /* #ff6b6b */
+  --color-sunsetRed:     255  77  77;  /* #ff4d4d */
+  --color-goldenYellow:  255 209 102;  /* #ffd166 */
+
+  --color-dark:           15  15  27;  /* #0f0f1b */
+  --color-darker:          7   7  16;  /* #070710 */
+  --color-lightBg:       240 242 245;  /* #f0f2f5 */
+  --color-lightText:      26  26  46;  /* #1a1a2e */
+  /* darker gray for accessible body text on light backgrounds */
+  --color-grayish:       106 106 134;  /* #6a6a86 */
+
+  --color-lightCard:     255 255 255;  /* #ffffff */
+  --color-lightBorder:   224 224 224;  /* #e0e0e0 */
+  --color-border:        224 224 224;  /* #e0e0e0 */
+  --color-mutedText:     208 208 224;  /* #d0d0e0 */
+
+  /* Generic tokens */
+  --color-background: var(--color-lightBg);
+  --color-foreground: var(--color-lightText);
+}
+
+.dark {
+  --color-background: var(--color-darker);
+  --color-foreground: 255 255 255;
+}


### PR DESCRIPTION
## Summary
- replace hardcoded design-system colors with token utilities
- expose CSS variables via `styles/tokens.css` and import from globals
- document token usage and theming in `doc/ui-guidelines.md`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2088a74a08321bb45ea0e8bce6571