### PR TITLE
refactor: normalize control sizing and typography

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,15 @@ module.exports = {
     '@next/next/no-img-element': 'warn',
     '@next/next/no-css-tags': 'warn',
     'react-hooks/exhaustive-deps': 'warn',
+    'no-restricted-syntax': [
+      'warn',
+      {
+        selector:
+          "JSXAttribute[name.name='className'] Literal[value=/\\btext-(?:caption|tiny|micro)\\b/]",
+        message:
+          'Avoid undersized typography classes (text-caption, text-tiny, text-micro). Use text-small or text-body instead.',
+      },
+    ],
   },
   overrides: [
     // API routes & tests: loosen typing during sprint

--- a/components/ai/MessageList.tsx
+++ b/components/ai/MessageList.tsx
@@ -55,14 +55,14 @@ export function MessageList({
           <div className="mt-3 flex items-center justify-center gap-2">
             <button
               onClick={newChat}
-              className="text-caption rounded-full px-3 py-1 bg-card border border-border hover:bg-accent"
+              className="form-control rounded-full px-3 bg-card border border-border hover:bg-accent text-small"
             >
               New chat
             </button>
             <button
               onClick={toggleVoice}
               disabled={!voiceSupported || voiceDenied}
-              className="text-caption rounded-full px-3 py-1 border border-border bg-card hover:bg-accent disabled:opacity-50"
+              className="form-control rounded-full px-3 border border-border bg-card hover:bg-accent disabled:opacity-50 text-small"
               title={
                 voiceSupported
                   ? voiceDenied
@@ -76,7 +76,7 @@ export function MessageList({
               🎙 {listening ? 'Stop' : 'Speak'}
             </button>
           </div>
-          <div className="mt-2 text-tiny text-muted-foreground/80">Tip: Alt+A toggles anywhere.</div>
+          <div className="mt-2 text-small text-muted-foreground/80">Tip: Alt+A toggles anywhere.</div>
         </div>
       )}
 
@@ -90,7 +90,7 @@ export function MessageList({
           }`}
           aria-live={m.id === streamingId ? 'polite' : undefined}
         >
-          <div className="text-micro uppercase tracking-wider text-muted-foreground mb-1">
+          <div className="text-small uppercase tracking-wider text-muted-foreground mb-1">
             {m.role === 'user' ? 'You' : 'GramorX AI'}
           </div>
           <div className="prose prose-sm dark:prose-invert max-w-none">
@@ -100,7 +100,7 @@ export function MessageList({
       ))}
 
       {loading && (
-        <div className="text-caption text-muted-foreground animate-pulse">Thinking…</div>
+        <div className="text-small text-muted-foreground animate-pulse">Thinking…</div>
       )}
     </div>
   );

--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -59,7 +59,7 @@ export const Button: React.FC<ButtonProps> = ({
   ...rest
 }) => {
   const base =
-    'btn focus:outline-none focus-visible:ring-2 focus-visible:ring-electricBlue/40 disabled:opacity-60 disabled:cursor-not-allowed';
+    'form-control btn focus:outline-none focus-visible:ring-2 focus-visible:ring-electricBlue/40 disabled:opacity-60 disabled:cursor-not-allowed';
   const fx = animated ? 'btn--fx' : ''; // apply shine/lift only when animated
 
   const cls = [

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -23,7 +23,7 @@ export const Input: React.FC<InputProps> = ({
   const describedBy =
     error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'form-control w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'disabled:opacity-60',
     'dark:bg-dark/50 dark:text-white dark:placeholder-white/40',

--- a/components/design-system/Select.tsx
+++ b/components/design-system/Select.tsx
@@ -10,7 +10,7 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
 
 export const Select: React.FC<SelectProps> = ({ label, hint, error, options = [], className = '', children, ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText',
+    'form-control w-full rounded-ds border bg-white text-lightText',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'dark:bg-dark/50 dark:text-white dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');

--- a/components/design-system/Textarea.tsx
+++ b/components/design-system/Textarea.tsx
@@ -8,7 +8,7 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 
 export const Textarea: React.FC<TextareaProps> = ({ label, hint, error, className = '', ...props }) => {
   const base = [
-    'w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
+    'form-control w-full rounded-ds border bg-white text-lightText placeholder-gray-500',
     'focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
     'dark:bg-dark/50 dark:text-white dark:placeholder-white/40 dark:border-purpleVibe/30 dark:focus:ring-electricBlue dark:focus:border-electricBlue',
   ].join(' ');

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,12 +184,18 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 /* Dark section helper (hero/modules/pricing/waitlist) */
 .section-dark { @apply bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90; }
 
+@layer utilities {
+  .form-control {
+    @apply min-h-[44px];
+  }
+}
+
 /* AI sidebar helpers (theme aware, token-only) */
 .ai-icon-btn{
-  @apply h-8 w-8 grid place-items-center rounded-md border border-border bg-card text-card-foreground hover:bg-accent hover:text-card-foreground disabled:opacity-50;
+  @apply form-control w-11 grid place-items-center rounded-md border border-border bg-card text-card-foreground hover:bg-accent hover:text-card-foreground disabled:opacity-50;
 }
 .ai-tab{
-  @apply h-8 px-3 rounded-md border border-border bg-card text-caption text-card-foreground hover:bg-accent hover:text-foreground;
+  @apply form-control px-3 rounded-md border border-border bg-card text-small text-card-foreground hover:bg-accent hover:text-foreground;
 }
 .ai-tab.is-active{
   @apply bg-primary text-primary-foreground;


### PR DESCRIPTION
## Summary
- replace legacy caption/tiny/micro text classes in interactive elements with `text-small`
- introduce `form-control` utility enforcing 44px min-height and apply to buttons & inputs
- add ESLint rule flagging undersized typography utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2088c38948321a26808dc4fe36498