### PR TITLE
feat: add spinner and toast helpers

### DIFF
--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -1,6 +1,7 @@
 // components/design-system/Button.tsx
 import * as React from 'react';
 import Link from 'next/link';
+import { Spinner } from './Spinner';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'accent' | 'ghost' | 'link';
 export type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -34,13 +35,6 @@ const variantClasses: Record<ButtonVariant, string> = {
     'bg-transparent text-electricBlue border border-electricBlue/30 hover:bg-electricBlue/10 dark:border-electricBlue/30',
   link: 'bg-transparent text-electricBlue underline underline-offset-4 hover:opacity-90',
 };
-
-const Spinner: React.FC = () => (
-  <span
-    aria-hidden
-    className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/60 border-t-white mr-2"
-  />
-);
 
 export const Button: React.FC<ButtonProps> = ({
   variant = 'primary',
@@ -76,7 +70,9 @@ export const Button: React.FC<ButtonProps> = ({
 
   const content = (
     <>
-      {loading && <Spinner />}
+      {loading && (
+        <Spinner className="mr-2 h-4 w-4 border-white/60 border-t-white" size={16} />
+      )}
       {!loading && leadingIcon ? <span className="mr-2 inline-flex">{leadingIcon}</span> : null}
       <span>{loading ? 'Please wait…' : children}</span>
       {!loading && trailingIcon ? <span className="ml-2 inline-flex">{trailingIcon}</span> : null}

--- a/components/design-system/Spinner.tsx
+++ b/components/design-system/Spinner.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type SpinnerProps = {
+  size?: number;
+  className?: string;
+};
+
+export const Spinner: React.FC<SpinnerProps> = ({ size = 16, className = '' }) => (
+  <span
+    aria-hidden
+    className={`inline-block animate-spin rounded-full border-2 border-current border-t-transparent ${className}`}
+    style={{ width: size, height: size }}
+  />
+);
+
+export default Spinner;

--- a/components/design-system/Toast.tsx
+++ b/components/design-system/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 type Variant = 'success' | 'info' | 'warning' | 'error';
 type ToastItem = {
@@ -10,6 +10,7 @@ type ToastItem = {
 };
 
 const ToastCtx = createContext<{ push: (t: Omit<ToastItem, 'id'>) => void } | null>(null);
+let pushRef: ((t: Omit<ToastItem, 'id'>) => void) | null = null;
 
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [items, setItems] = useState<ToastItem[]>([]);
@@ -22,6 +23,13 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, []);
 
   const ctx = useMemo(() => ({ push }), [push]);
+
+  useEffect(() => {
+    pushRef = push;
+    return () => {
+      pushRef = null;
+    };
+  }, [push]);
 
   const variants: Record<Variant, string> = {
     success: 'bg-success/10 border-success/30 text-success',
@@ -49,6 +57,17 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       </div>
     </ToastCtx.Provider>
   );
+};
+
+export const toast = {
+  success: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'success', title: opts?.title, duration: opts?.duration }),
+  info: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'info', title: opts?.title, duration: opts?.duration }),
+  warning: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'warning', title: opts?.title, duration: opts?.duration }),
+  error: (message: string, opts?: { title?: string; duration?: number }) =>
+    pushRef?.({ message, variant: 'error', title: opts?.title, duration: opts?.duration }),
 };
 
 export function useToast() {

--- a/components/design-system/index.ts
+++ b/components/design-system/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './Button';
 export { Select } from './Select';
 export { Textarea } from './Textarea';
+export { Spinner } from './Spinner';

--- a/hooks/useAsyncAction.ts
+++ b/hooks/useAsyncAction.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+import { useToast } from '@/components/design-system/Toast';
+
+export function useAsyncAction<T extends (...args: any[]) => Promise<any>>(
+  fn: T,
+  opts: { successMessage?: string; errorMessage?: string } = {}
+) {
+  const { success, error } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  const run = useCallback(
+    async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>> | undefined> => {
+      setLoading(true);
+      try {
+        const result = await fn(...args);
+        if (opts.successMessage) success(opts.successMessage);
+        return result as Awaited<ReturnType<T>>;
+      } catch (e: any) {
+        const msg = opts.errorMessage || e?.message || 'Something went wrong';
+        error(msg);
+        return undefined;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fn, success, error, opts.successMessage, opts.errorMessage]
+  );
+
+  return { run, loading } as const;
+}

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -5,7 +5,7 @@ import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
 import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
-import { Alert } from '@/components/design-system/Alert';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
 import { isValidEmail } from '@/utils/validation';
@@ -15,37 +15,24 @@ export default function LoginWithPassword() {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
   const [emailErr, setEmailErr] = useState<string | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  // MFA state
   const [otp, setOtp] = useState('');
   const [otpSent, setOtpSent] = useState(false);
   const [factorId, setFactorId] = useState<string | null>(null);
   const [challengeId, setChallengeId] = useState<string | null>(null);
-  const [verifying, setVerifying] = useState(false);
 
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
-
+  const { run: submit, loading } = useAsyncAction(async () => {
     const trimmedEmail = email.trim();
-    if (!trimmedEmail || !pw) {
-      setErr('Please fill in all fields.');
-      return;
-    }
+    if (!trimmedEmail || !pw) throw new Error('Please fill in all fields.');
     if (!isValidEmail(trimmedEmail)) {
       setEmailErr('Enter a valid email address.');
-      return;
+      throw new Error('Enter a valid email address.');
     }
     setEmailErr(null);
 
-    setLoading(true);
     const { error, data } = await supabase.auth.signInWithPassword({
       email: trimmedEmail,
       password: pw,
     });
-    setLoading(false);
 
     if (error) {
       const msg = error.message?.toLowerCase() ?? '';
@@ -53,11 +40,9 @@ export default function LoginWithPassword() {
         error.code === 'invalid_grant' &&
         (msg.includes('weak_password') || (msg.includes('password') && msg.includes('undefined')))
       ) {
-        setErr('Use your Google/Facebook/Apple account to sign in');
-      } else {
-        setErr(getAuthErrorMessage(error));
+        throw new Error('Use your Google/Facebook/Apple account to sign in');
       }
-      return;
+      throw new Error(getAuthErrorMessage(error));
     }
 
     if (data.session) {
@@ -71,7 +56,7 @@ export default function LoginWithPassword() {
       if (factors.length) {
         const f = factors[0];
         const { data: challenge, error: cErr } = await supabase.auth.mfa.challenge({ factorId: f.id });
-        if (cErr) return setErr(getAuthErrorMessage(cErr));
+        if (cErr) throw new Error(getAuthErrorMessage(cErr));
         setFactorId(f.id);
         setChallengeId(challenge?.id ?? null);
         setOtpSent(true);
@@ -81,21 +66,16 @@ export default function LoginWithPassword() {
       try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
       redirectByRole(data.session.user);
     }
-  }
+  });
 
-  async function verifyOtp(e: React.FormEvent) {
-    e.preventDefault();
+  const { run: verify, loading: verifying } = useAsyncAction(async () => {
     if (!factorId || !challengeId) return;
-
-    setVerifying(true);
     const { error } = await supabase.auth.mfa.verify({ factorId, challengeId, code: otp });
-    setVerifying(false);
-    if (error) return setErr(getAuthErrorMessage(error));
-
+    if (error) throw new Error(getAuthErrorMessage(error));
     try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
     const { data: { user } } = await supabase.auth.getUser();
     if (user) redirectByRole(user);
-  }
+  });
 
   const RightPanel = (
     <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
@@ -116,10 +96,14 @@ export default function LoginWithPassword() {
 
   return (
     <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
-      {err && <Alert variant="error" title="Error">{err}</Alert>}
-
       {!otpSent ? (
-        <form onSubmit={onSubmit} className="space-y-6 mt-2">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+          className="space-y-6 mt-2"
+        >
           <Input
             label="Email"
             type="email"
@@ -142,18 +126,34 @@ export default function LoginWithPassword() {
             autoComplete="current-password"
             required
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
-            {loading ? 'Signing in…' : 'Continue'}
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full rounded-ds-xl"
+            loading={loading}
+          >
+            Continue
           </Button>
           <Button asChild variant="secondary" className="mt-4 w-full rounded-ds-xl">
             <Link href="/forgot-password">Forgot password?</Link>
           </Button>
         </form>
       ) : (
-        <form onSubmit={verifyOtp} className="space-y-6 mt-2 max-w-xs">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            verify();
+          }}
+          className="space-y-6 mt-2 max-w-xs"
+        >
           <Input label="Enter OTP" value={otp} onChange={e => setOtp(e.target.value)} autoComplete="one-time-code" placeholder="6-digit code" required />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={verifying}>
-            {verifying ? 'Verifying…' : 'Verify'}
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full rounded-ds-xl"
+            loading={verifying}
+          >
+            Verify
           </Button>
         </form>
       )}

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
 import { Button } from '@/components/design-system/Button';
-import { Alert } from '@/components/design-system/Alert';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { redirectByRole } from '@/lib/routeAccess';
 import { isValidE164Phone } from '@/utils/validation';
@@ -15,43 +15,30 @@ export default function LoginWithPhone() {
   const [code, setCode] = useState('');
   const [stage, setStage] = useState<'request' | 'verify'>('request');
   const [phoneErr, setPhoneErr] = useState<string | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [resending, setResending] = useState(false);
   const [resendAttempts, setResendAttempts] = useState(0);
 
-  async function requestOtp(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
+  const { run: requestOtp, loading: requesting } = useAsyncAction(async () => {
     const trimmedPhone = phone.trim();
     if (!isValidE164Phone(trimmedPhone)) {
       setPhoneErr('Enter your phone number in E.164 format, e.g. +923001234567');
-      return;
+      throw new Error('Enter your phone number in E.164 format, e.g. +923001234567');
     }
     setPhoneErr(null);
-    setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({
       phone: trimmedPhone,
       options: { shouldCreateUser: false },
     });
-    setLoading(false);
-    if (error) return setErr(getAuthErrorMessage(error));
+    if (error) throw new Error(getAuthErrorMessage(error));
     setResendAttempts(0);
     setStage('verify');
-  }
+  });
 
-  async function verifyOtp(e: React.FormEvent) {
-    e.preventDefault();
-    setErr(null);
-    if (!code) return setErr('Enter the 6-digit code.');
-
+  const { run: verifyOtp, loading: verifying } = useAsyncAction(async () => {
+    if (!code) throw new Error('Enter the 6-digit code.');
     const trimmedPhone = phone.trim();
-    setLoading(true);
     // @ts-expect-error `token` is supported for verification
     const { data, error } = await supabase.auth.signInWithOtp({ phone: trimmedPhone, token: code });
-    setLoading(false);
-    if (error) return setErr(getAuthErrorMessage(error));
-
+    if (error) throw new Error(getAuthErrorMessage(error));
     if (data.session) {
       await supabase.auth.setSession({
         access_token: data.session.access_token,
@@ -61,25 +48,17 @@ export default function LoginWithPhone() {
       try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
       redirectByRole(data.session.user);
     }
-  }
+  });
 
-  async function resendOtp() {
-    setErr(null);
-    setResending(true);
-    setLoading(true);
-    try {
-      const trimmedPhone = phone.trim();
-      const { error } = await supabase.auth.signInWithOtp({
-        phone: trimmedPhone,
-        options: { shouldCreateUser: false },
-      });
-      if (error) return setErr(getAuthErrorMessage(error));
-      setResendAttempts((a) => a + 1);
-    } finally {
-      setLoading(false);
-      setResending(false);
-    }
-  }
+  const { run: resendOtp, loading: resending } = useAsyncAction(async () => {
+    const trimmedPhone = phone.trim();
+    const { error } = await supabase.auth.signInWithOtp({
+      phone: trimmedPhone,
+      options: { shouldCreateUser: false },
+    });
+    if (error) throw new Error(getAuthErrorMessage(error));
+    setResendAttempts((a) => a + 1);
+  });
 
   const RightPanel = (
     <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
@@ -98,10 +77,14 @@ export default function LoginWithPhone() {
 
   return (
     <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code." right={RightPanel}>
-      {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
-
       {stage === 'request' ? (
-        <form onSubmit={requestOtp} className="space-y-6 mt-2">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            requestOtp();
+          }}
+          className="space-y-6 mt-2"
+        >
           <Input
             label="Phone number"
             type="tel"
@@ -116,12 +99,23 @@ export default function LoginWithPhone() {
             hint="Use E.164 format, e.g. +923001234567"
             error={phoneErr ?? undefined}
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
-            {loading ? 'Sending…' : 'Send code'}
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full rounded-ds-xl"
+            loading={requesting}
+          >
+            Send code
           </Button>
         </form>
       ) : (
-        <form onSubmit={verifyOtp} className="space-y-6 mt-2">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            verifyOtp();
+          }}
+          className="space-y-6 mt-2"
+        >
           <Input
             label="Verification code"
             inputMode="numeric"
@@ -134,18 +128,19 @@ export default function LoginWithPhone() {
             type="submit"
             variant="primary"
             className="w-full rounded-ds-xl"
-            disabled={loading && !resending}
+            loading={verifying}
+            disabled={verifying || resending}
           >
-            {loading && !resending ? 'Verifying…' : 'Verify & Continue'}
+            Verify & Continue
           </Button>
           <Button
             type="button"
             variant="secondary"
             className="w-full rounded-ds-xl"
-            onClick={resendOtp}
-            disabled={loading}
+            onClick={() => resendOtp()}
+            loading={resending}
           >
-            {loading && resending ? 'Resending…' : `Resend code${resendAttempts ? ` (${resendAttempts})` : ''}`}
+            {`Resend code${resendAttempts ? ` (${resendAttempts})` : ''}`}
           </Button>
         </form>
       )}


### PR DESCRIPTION
## Summary
- add reusable Spinner component and export in design system
- expose global toast helpers and async action hook for loading + notifications
- switch login flows to use toasts and spinner instead of inline alerts

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError: createContext is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b2088d97f08321a228678ab56d4a0a