### PR TITLE
Add AI review components for writing and speaking

### DIFF
--- a/components/speaking/AIReview.tsx
+++ b/components/speaking/AIReview.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Alert } from '@/components/design-system/Alert';
+import { ScoreCard } from '@/components/design-system/ScoreCard';
+
+/**
+ * Parse AI annotations in the same `[g]..[/g]` / `[v]..[/v]` format used by
+ * the writing review component. Grammar issues are highlighted in red and
+ * vocabulary issues in yellow.
+ */
+function renderAnnotated(text: string): React.ReactNode {
+  const out: React.ReactNode[] = [];
+  const regex = /\[(g|v)\](.*?)\[\/\1\]/gs;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = regex.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const cls =
+      m[1] === 'g'
+        ? 'bg-sunsetRed/20 text-sunsetRed dark:text-sunsetRed'
+        : 'bg-goldenYellow/20 text-sunsetOrange dark:text-sunsetOrange';
+    out.push(
+      <span key={key++} className={`rounded px-0.5 ${cls}`}>
+        {m[2]}
+      </span>
+    );
+    last = regex.lastIndex;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return <>{out}</>;
+}
+
+async function annotate(text: string): Promise<string> {
+  try {
+    const res = await fetch('/api/ai/chat?p=openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: [
+          {
+            role: 'system',
+            content:
+              'Highlight grammar with [g][/g] and vocabulary issues with [v][/v]. Return only the annotated text.'
+          },
+          { role: 'user', content: text }
+        ]
+      })
+    });
+    if (!res.body) return text;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let out = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n\n')) {
+        if (line.startsWith('data: ')) {
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const delta = json?.choices?.[0]?.delta?.content;
+            if (delta) out += delta;
+          } catch {}
+        }
+      }
+    }
+    return out || text;
+  } catch {
+    return text;
+  }
+}
+
+export interface SpeakingAIReviewProps {
+  attemptId: string;
+}
+
+/**
+ * Runs AI scoring for a speaking attempt, then renders the transcript with
+ * inline highlights plus band score and suggestions.
+ */
+export const AIReview: React.FC<SpeakingAIReviewProps> = ({ attemptId }) => {
+  const [data, setData] = useState<null | {
+    transcript: string;
+    bandOverall: number;
+    criteria: { fluency: number; lexical: number; grammar: number; pronunciation: number };
+    notes: string;
+  }>(null);
+  const [annotated, setAnnotated] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const resp = await fetch('/api/speaking/score', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ attemptId })
+        });
+        if (!resp.ok) throw new Error('Scoring failed');
+        const json = await resp.json();
+        if (!active) return;
+        setData(json);
+        const ann = await annotate(json.transcript);
+        if (!active) return;
+        setAnnotated(ann);
+      } catch (e: any) {
+        if (active) setError(e.message || 'Failed to score attempt');
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [attemptId]);
+
+  if (loading) {
+    return <Card className="card-surface p-6 rounded-ds-2xl">Scoring…</Card>;
+  }
+  if (error) {
+    return <Alert variant="error" title="AI review failed">{error}</Alert>;
+  }
+  if (!data) return null;
+
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl">
+      <ScoreCard
+        title="Speaking Band"
+        overall={data.bandOverall}
+        subscores={{
+          fluency: data.criteria.fluency,
+          vocabulary: data.criteria.lexical,
+          grammar: data.criteria.grammar,
+          pronunciation: data.criteria.pronunciation,
+        }}
+      />
+      <h3 className="text-h3 mt-6">Transcript</h3>
+      <div className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10 whitespace-pre-wrap">
+        {renderAnnotated(annotated || data.transcript)}
+      </div>
+      {data.notes && (
+        <Alert variant="info" title="Suggestions" className="mt-6">
+          {data.notes}
+        </Alert>
+      )}
+    </Card>
+  );
+};
+
+export default AIReview;
+

--- a/components/writing/AIReview.tsx
+++ b/components/writing/AIReview.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Alert } from '@/components/design-system/Alert';
+import { ScoreCard } from '@/components/design-system/ScoreCard';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+
+/**
+ * Highlight grammar and vocabulary issues by parsing custom markers
+ * produced by the AI. Grammar problems are wrapped in `[g]...[/g]` and
+ * vocabulary issues in `[v]...[/v]`. The returned React nodes preserve
+ * original spacing and new lines.
+ */
+function renderAnnotated(text: string): React.ReactNode {
+  const pieces: React.ReactNode[] = [];
+  const regex = /\[(g|v)\](.*?)\[\/\1\]/gs;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      pieces.push(text.slice(lastIndex, match.index));
+    }
+    const type = match[1];
+    const content = match[2];
+    const cls =
+      type === 'g'
+        ? 'bg-sunsetRed/20 text-sunsetRed dark:text-sunsetRed'
+        : 'bg-goldenYellow/20 text-sunsetOrange dark:text-sunsetOrange';
+    pieces.push(
+      <span key={key++} className={`rounded px-0.5 ${cls}`}>
+        {content}
+      </span>
+    );
+    lastIndex = regex.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    pieces.push(text.slice(lastIndex));
+  }
+  return <>{pieces}</>;
+}
+
+// Read server-sent events from /api/ai/chat and accumulate the delta text.
+async function annotateText(original: string): Promise<string> {
+  try {
+    const res = await fetch('/api/ai/chat?p=openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: [
+          {
+            role: 'system',
+            content:
+              'Surround grammar mistakes with [g][/g] and vocabulary issues with [v][/v]. Return only the annotated text.'
+          },
+          { role: 'user', content: original }
+        ]
+      })
+    });
+    if (!res.body) return original;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n\n')) {
+        if (line.startsWith('data: ')) {
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const delta = json?.choices?.[0]?.delta?.content;
+            if (delta) result += delta;
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      }
+    }
+    return result || original;
+  } catch {
+    return original;
+  }
+}
+
+export interface WritingAIReviewProps {
+  /** ID of the writing attempt already saved in Supabase */
+  attemptId: string;
+}
+
+type AttemptRow = {
+  essay_text: string;
+  band_overall: number;
+  band_breakdown: { task: number; coherence: number; lexical: number; grammar: number };
+  feedback: string | null;
+};
+
+/**
+ * Displays an AI generated review for a writing attempt. The component
+ * fetches the attempt details from Supabase, asks the AI to annotate the
+ * essay with grammar and vocabulary highlights, then renders the band
+ * score, annotated essay and a suggestions panel.
+ */
+export const AIReview: React.FC<WritingAIReviewProps> = ({ attemptId }) => {
+  const [attempt, setAttempt] = useState<AttemptRow | null>(null);
+  const [annotated, setAnnotated] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const { data, error } = await supabaseBrowser
+          .from('writing_attempts')
+          .select('essay_text, band_overall, band_breakdown, feedback')
+          .eq('id', attemptId)
+          .single();
+        if (error) throw error;
+        if (!mounted) return;
+        setAttempt(data as AttemptRow);
+        const a = await annotateText(data.essay_text);
+        if (!mounted) return;
+        setAnnotated(a);
+      } catch (e: any) {
+        if (mounted) setError(e.message || 'Failed to load review');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [attemptId]);
+
+  if (loading) {
+    return (
+      <Card className="card-surface p-6 rounded-ds-2xl">Loading…</Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="error" title="AI review failed">{error}</Alert>
+    );
+  }
+
+  if (!attempt) return null;
+
+  return (
+    <Card className="card-surface p-6 rounded-ds-2xl">
+      <ScoreCard
+        title="Writing Band"
+        overall={attempt.band_overall}
+        subscores={{
+          taskResponse: attempt.band_breakdown.task,
+          coherence: attempt.band_breakdown.coherence,
+          vocabulary: attempt.band_breakdown.lexical,
+          grammar: attempt.band_breakdown.grammar,
+        }}
+      />
+
+      <h3 className="text-h3 mt-6">Your Essay</h3>
+      <div className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10 whitespace-pre-wrap">
+        {renderAnnotated(annotated || attempt.essay_text)}
+      </div>
+
+      {attempt.feedback && (
+        <Alert variant="info" title="Suggestions" className="mt-6">
+          {attempt.feedback}
+        </Alert>
+      )}
+    </Card>
+  );
+};
+
+export default AIReview;
+


### PR DESCRIPTION
## Summary
- display AI-based review for writing attempts with inline grammar/vocabulary highlights and band scores
- run speaking evaluation after recordings, showing annotated transcript and score breakdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b208902d1483218d96956afa78a587