### PR TITLE
Use API login endpoint for email/password sign-in

### DIFF
--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -41,29 +41,24 @@ export default function LoginWithPassword() {
     setEmailErr(null);
 
     setLoading(true);
-    const { error, data } = await supabase.auth.signInWithPassword({
-      email: trimmedEmail,
-      password: pw,
-    });
-    setLoading(false);
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmedEmail, password: pw }),
+      });
+      const body = await res.json().catch(() => ({}));
+      setLoading(false);
 
-    if (error) {
-      const msg = error.message?.toLowerCase() ?? '';
-      if (
-        error.code === 'invalid_grant' &&
-        (msg.includes('weak_password') || (msg.includes('password') && msg.includes('undefined')))
-      ) {
-        setErr('Use your Google/Facebook/Apple account to sign in');
-      } else {
-        setErr(getAuthErrorMessage(error));
+      if (!res.ok || !body.session) {
+        const msg = typeof body.error === 'string' ? body.error : 'Unable to sign in. Please try again.';
+        setErr(msg);
+        return;
       }
-      return;
-    }
 
-    if (data.session) {
       await supabase.auth.setSession({
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
+        access_token: body.session.access_token,
+        refresh_token: body.session.refresh_token,
       });
 
       const { data: { user } } = await supabase.auth.getUser();
@@ -79,7 +74,10 @@ export default function LoginWithPassword() {
       }
 
       try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
-      redirectByRole(data.session.user);
+      redirectByRole(body.session.user);
+    } catch (e) {
+      setLoading(false);
+      setErr('Unable to sign in. Please try again.');
     }
   }
 


### PR DESCRIPTION
## Summary
- Authenticate via internal /api/auth/login endpoint and set Supabase session
- Display API error messages during login failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2490732d0832188fd967f4c146bf3