### PR TITLE
Use Next.js routing components and add dashboard navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -217,7 +217,11 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
       <Container>
         <div className="flex items-center justify-between py-4 md:py-5">
           {/* Brand — bigger logo + name */}
-          <Link href="/" className="flex items-center gap-3 group" aria-label="Go to home">
+          <Link
+            href={user.id ? '/dashboard' : '/'}
+            className="flex items-center gap-3 group"
+            aria-label="Go to home"
+          >
             <img src="/brand/logo.png" alt="GramorX logo" className="h-11 w-11 rounded-lg object-contain" />
             <span className="font-slab font-bold text-3xl">
               <span className="text-gradient-primary group-hover:opacity-90 transition">GramorX</span>
@@ -227,6 +231,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
           {/* Desktop */}
           <nav className="hidden md:block" aria-label="Primary">
             <ul className="flex items-center gap-3 relative">
+              {user.id && <li><NavLink href="/dashboard" label="Dashboard" /></li>}
               <li className="relative" ref={modulesRef}>
                 <button
                   onClick={() => setOpenDesktopModules(v => !v)}
@@ -255,7 +260,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                         </div>
                         <div className="grid sm:grid-cols-2 gap-3">
                           {MODULE_LINKS.map((m) => (
-                            <Link
+                            <NavLink
                               key={m.href}
                               href={m.href}
                               className="group rounded-ds border border-transparent hover:border-purpleVibe/20 p-4 flex items-start gap-3 hover:bg-purpleVibe/10"
@@ -271,7 +276,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                                 <div className="font-medium">{m.label}</div>
                                 {m.desc && <div className="text-small text-grayish">{m.desc}</div>}
                               </div>
-                            </Link>
+                            </NavLink>
                           ))}
                         </div>
                       </div>
@@ -390,14 +395,25 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
 
             <nav aria-label="Mobile Navigation" className="pb-4">
               <ul className="flex flex-col gap-1">
+                {user.id && (
+                  <li>
+                    <NavLink
+                      href="/dashboard"
+                      className="block px-3 py-3 rounded-lg hover:bg-purpleVibe/10"
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      Dashboard
+                    </NavLink>
+                  </li>
+                )}
                 <li>
-                  <Link
+                  <NavLink
                     href="/learning"
                     className="block px-3 py-3 rounded-lg hover:bg-purpleVibe/10"
                     onClick={() => setMobileOpen(false)}
                   >
                     Learning
-                  </Link>
+                  </NavLink>
                 </li>
 
                 {/* Modules accordion */}
@@ -417,13 +433,13 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                     <ul id="mobile-modules-list" className="mt-1 ml-2 rounded-lg border border-purpleVibe/20 overflow-hidden">
                       {MODULE_LINKS.map((m) => (
                         <li key={m.href}>
-                          <Link
+                          <NavLink
                             href={m.href}
                             className="block px-4 py-3 hover:bg-purpleVibe/10"
                             onClick={() => setMobileOpen(false)}
                           >
                             {m.label}
-                          </Link>
+                          </NavLink>
                         </li>
                       ))}
                     </ul>
@@ -433,23 +449,23 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
                 {/* Pricing (waitlist removed) */}
                 {NAV.map((n) => (
                   <li key={n.href}>
-                    <Link
+                    <NavLink
                       href={n.href}
                       className="block px-3 py-3 rounded-lg hover:bg-purpleVibe/10"
                       onClick={() => setMobileOpen(false)}
                     >
                       {n.label}
-                    </Link>
+                    </NavLink>
                   </li>
                 ))}
                 <li>
-                  <Link
+                  <NavLink
                     href="/premium"
                     className="block px-3 py-3 rounded-lg hover:bg-purpleVibe/10"
                     onClick={() => setMobileOpen(false)}
                   >
                     premium
-                  </Link>
+                  </NavLink>
                 </li>
               </ul>
             </nav>

--- a/components/design-system/NavLink.tsx
+++ b/components/design-system/NavLink.tsx
@@ -10,7 +10,7 @@ type Props = {
   exact?: boolean;
   className?: string;
   variant?: 'pill' | 'plain';
-};
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const NavLink: React.FC<Props> = ({
   href,
@@ -19,17 +19,22 @@ export const NavLink: React.FC<Props> = ({
   exact = false,
   className = '',
   variant = 'pill',
+  ...rest
 }) => {
   const { pathname, asPath } = useRouter();
   // consider hashes as internal (e.g., #pricing)
   const current = asPath || pathname;
-  const isActive = exact ? current === href : current.startsWith(href);
+  const isActive = href.startsWith('#')
+    ? current.includes(href)
+    : exact
+      ? current === href
+      : current.startsWith(href);
 
   const base = variant === 'pill' ? 'nav-pill' : 'inline-flex items-center';
   const active = isActive ? 'is-active' : '';
 
   return (
-    <Link href={href} className={`${base} ${active} ${className}`.trim()}>
+    <Link href={href} className={`${base} ${active} ${className}`.trim()} {...rest}>
       {children ?? label}
     </Link>
   );

--- a/components/sections/ExamStrategy.tsx
+++ b/components/sections/ExamStrategy.tsx
@@ -3,6 +3,7 @@ import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
+import { NavLink } from '@/components/design-system/NavLink';
 
 export default function ExamStrategy() {
   return (
@@ -28,7 +29,7 @@ export default function ExamStrategy() {
               <li>• Build exam‑day checklist</li>
             </ul>
             <div className="mt-5 flex gap-3">
-              <Button as="a" href="/learning/strategies?area=all" variant="secondary" className="rounded-ds-xl">
+              <Button href="/learning/strategies?area=all" variant="secondary" className="rounded-ds-xl">
                 Read strategies
               </Button>
             </div>
@@ -43,8 +44,8 @@ export default function ExamStrategy() {
               <li>• Speaking: record → STT → pronunciation & feedback</li>
             </ul>
             <div className="mt-5 grid grid-cols-2 gap-3">
-              <Button as="a" href="/writing" variant="primary" className="rounded-ds-xl">Try Writing</Button>
-              <Button as="a" href="/listening" variant="secondary" className="rounded-ds-xl">Try Listening</Button>
+              <Button href="/writing" variant="primary" className="rounded-ds-xl">Try Writing</Button>
+              <Button href="/listening" variant="secondary" className="rounded-ds-xl">Try Listening</Button>
             </div>
           </Card>
 
@@ -57,8 +58,8 @@ export default function ExamStrategy() {
               <li>• Track progress; repeat weak areas</li>
             </ul>
             <div className="mt-5 grid grid-cols-2 gap-3">
-              <Button as="a" href="/writing" variant="secondary" className="rounded-ds-xl">Open Review</Button>
-              <Button as="a" href="/reading" variant="secondary" className="rounded-ds-xl">Open Reading</Button>
+              <Button href="/writing" variant="secondary" className="rounded-ds-xl">Open Review</Button>
+              <Button href="/reading" variant="secondary" className="rounded-ds-xl">Open Reading</Button>
             </div>
           </Card>
         </div>
@@ -71,12 +72,16 @@ export default function ExamStrategy() {
             { label: 'Writing', href: '/writing' },
             { label: 'Speaking', href: '/speaking' },
           ].map(x => (
-            <a key={x.href} href={x.href} className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10 hover:bg-electricBlue/5 transition">
+            <NavLink
+              key={x.href}
+              href={x.href}
+              className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10 hover:bg-electricBlue/5 transition"
+            >
               <div className="flex items-center justify-between">
                 <span className="font-medium">{x.label}</span>
                 <i className="fas fa-arrow-right text-grayish" aria-hidden="true" />
               </div>
-            </a>
+            </NavLink>
           ))}
         </div>
       </Container>

--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -86,7 +86,6 @@ export const Pricing: React.FC = () => {
               </ul>
 
               <Button
-                as="a"
                 href="#waitlist"
                 variant={t.featured ? 'primary' : 'secondary'}
                 className="w-full justify-center"


### PR DESCRIPTION
## Summary
- Replace anchor tags in landing sections with Next.js navigation components
- Extend NavLink to forward props and support hash-based routes
- Update header to highlight active modules and route logged-in users to dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b24f58186c8321bb0d94a25fe3f94a