### PR TITLE
refactor: move tracker styles to tokens

### DIFF
--- a/components/ai/Composer.tsx
+++ b/components/ai/Composer.tsx
@@ -49,8 +49,7 @@ export function Composer({
           }}
           rows={1}
           placeholder="Type or tap 🎙 to speak… (Enter to send, Shift+Enter = new line)"
-          className="w-full resize-none rounded-2xl border border-border bg-background px-3 py-2 text-small outline-none focus:ring-2 focus:ring-primary/40"
-          style={{ maxHeight: 148 }}
+          className="w-full resize-none rounded-2xl border border-border bg-background px-3 py-2 text-small outline-none focus:ring-2 focus:ring-primary/40 max-h-[148px]"
         />
         <button
           onClick={() => send()}

--- a/index.html
+++ b/index.html
@@ -4,55 +4,15 @@
   <meta charset="utf-8" />
   <title>IELTS Platform Implementation Tracker</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    :root{
-      --bg:#0b0c10; --card:#111319; --text:#e8eaed; --muted:#a7b0bf;
-      --border:#232733; --acc:#3b82f6; --ok:#10b981; --warn:#f59e0b;
-    }
-    *{box-sizing:border-box}
-    body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif}
-    .wrap{max-width:1200px;margin:0 auto;padding:20px}
-    h1{margin:0 0 8px}
-    .legend{color:var(--muted);margin-bottom:8px}
-    .bar{display:flex;gap:12px;align-items:center;flex-wrap:wrap;
-         position:sticky;top:0;background:rgba(11,12,16,.9);backdrop-filter:blur(6px);
-         border-bottom:1px solid var(--border);padding:10px;margin:6px 0 12px}
-    select,button{background:var(--card);color:var(--text);border:1px solid var(--border);
-           border-radius:8px;padding:8px 10px}
-    .stats{display:flex;gap:10px;flex-wrap:wrap;margin:6px 0 10px}
-    .stat{background:var(--card);border:1px solid var(--border);padding:6px 10px;border-radius:8px}
-    table{width:100%;border-collapse:collapse}
-    thead th{position:sticky;top:56px;background:var(--bg);z-index:2;color:#b9c2d0;
-             text-align:left;font-weight:600;padding:10px;border-bottom:1px solid var(--border)}
-    tbody td{padding:10px;border-bottom:1px solid var(--border);vertical-align:top}
-
-    .pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;border:1px solid var(--border)}
-    .pill.todo{background:#1a1d25}
-    .pill.prog{background:#1e2431;border-color:#2a3346;color:#c5d2ea}
-    .pill.done{background:#0f1d17;border-color:#124d3a;color:#a9efd4}
-    .nowrap{white-space:nowrap}
-    .muted{color:var(--muted)}
-    .card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:14px}
-    .section-title{font-weight:700;margin-bottom:8px}
-    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:8px}
-    .badge{display:inline-block;font-size:12px;padding:2px 8px;border-radius:999px;border:1px solid var(--border)}
-    .badge.ok{background:#0f1d17;color:#a9efd4}
-    .badge.warn{background:#241c0f;color:#f5d39e}
-    .bar .btn{cursor:pointer}
-    .sum{min-width:280px}
-    input[type="date"]{background:var(--card);border:1px solid var(--border);color:var(--text);border-radius:8px;padding:6px}
-    .hint{font-size:12px;color:#92a0b6;margin-top:6px}
-    a.link{color:var(--acc);text-decoration:none;border-bottom:1px dashed var(--acc)}
-    a.link:hover{opacity:.9}
-  </style>
+  <link rel="stylesheet" href="styles/tracker.css" />
 </head>
-<body>
+<body class="bg-dark text-foreground">
   <div class="wrap">
     <h1>📋 IELTS Platform Implementation Tracker</h1>
-    <div class="legend">Legend: <code>[ ]</code> Not started • <code>[~]</code> In progress • <code>[x]</code> Completed</div>
+    <div class="legend text-mutedText">Legend: <code>[ ]</code> Not started • <code>[~]</code> In progress • <code>[x]</code> Completed</div>
 
     <!-- QUICK NAV: deep links so you can go anywhere from anywhere -->
-    <div class="card" style="margin:12px 0 16px">
+    <div class="card card-spacing">
       <div class="section-title">🧭 Quick Nav — Deep Links</div>
       <div class="grid">
         <div><a href="/admin" class="link">/admin</a> → Overview KPIs & drill-downs</div>
@@ -69,7 +29,7 @@
     </div>
 
     <!-- START HERE: FIRST STEPS -->
-    <div class="card" style="margin:12px 0 16px">
+    <div class="card card-spacing">
       <div class="section-title">🚦 Start Here (Day 0 → Day 7)</div>
       <div class="grid">
         <div><span class="badge ok">P1</span> <b>Unblock the build</b><br/>Fix ESLint TypeScript errors; prefer <code>@ts-expect-error</code> for known temporary issues.</div>

--- a/pages/ai/index.tsx
+++ b/pages/ai/index.tsx
@@ -316,8 +316,7 @@ export default function AIChatPage() {
                 }}
                 rows={1}
                 placeholder="Ask anything… (Enter to send, Shift+Enter = new line)"
-                className="w-full resize-none rounded-2xl border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/40"
-                style={{ maxHeight: 148 }}
+                className="w-full resize-none rounded-2xl border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/40 max-h-[148px]"
               />
               <button
                 onClick={() => send()}

--- a/styles/tracker.css
+++ b/styles/tracker.css
@@ -1,0 +1,46 @@
+@import './tokens.css';
+
+/* Design system utility classes */
+.bg-dark{background-color:rgb(var(--color-dark));}
+.bg-card{background-color:rgb(var(--color-darker));}
+.text-foreground{color:rgb(var(--color-foreground));}
+.text-mutedText{color:rgb(var(--color-mutedText));}
+.border-border{border-color:rgb(var(--color-border));}
+.bg-primary{background-color:rgb(var(--color-primary));}
+.text-primary{color:rgb(var(--color-primary));}
+.bg-success{background-color:rgb(var(--color-success));}
+.text-success{color:rgb(var(--color-success));}
+.bg-warning{background-color:rgb(var(--color-goldenYellow));}
+.text-warning{color:rgb(var(--color-goldenYellow));}
+
+/* Tracker styles */
+*{box-sizing:border-box;}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;}
+.wrap{max-width:1200px;margin:0 auto;padding:20px;}
+h1{margin:0 0 8px;}
+.legend{margin-bottom:8px;}
+.bar{display:flex;gap:12px;align-items:center;flex-wrap:wrap;position:sticky;top:0;background:rgb(var(--color-dark)/0.9);backdrop-filter:blur(6px);border-bottom:1px solid rgb(var(--color-border));padding:10px;margin:6px 0 12px;}
+select,button{background:rgb(var(--color-darker));color:rgb(var(--color-foreground));border:1px solid rgb(var(--color-border));border-radius:8px;padding:8px 10px;}
+.stats{display:flex;gap:10px;flex-wrap:wrap;margin:6px 0 10px;}
+.stat{background:rgb(var(--color-darker));border:1px solid rgb(var(--color-border));padding:6px 10px;border-radius:8px;}
+table{width:100%;border-collapse:collapse;}
+thead th{position:sticky;top:56px;background:rgb(var(--color-dark));z-index:2;color:rgb(var(--color-mutedText));text-align:left;font-weight:600;padding:10px;border-bottom:1px solid rgb(var(--color-border));}
+tbody td{padding:10px;border-bottom:1px solid rgb(var(--color-border));vertical-align:top;}
+.pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;border:1px solid rgb(var(--color-border));}
+.pill.todo{background:rgb(var(--color-dark));}
+.pill.prog{background:rgb(var(--color-darker));border-color:rgb(var(--color-border));color:rgb(var(--color-mutedText));}
+.pill.done{background:rgb(var(--color-dark));border-color:rgb(var(--color-success));color:rgb(var(--color-success));}
+.nowrap{white-space:nowrap;}
+.card{background:rgb(var(--color-darker));border:1px solid rgb(var(--color-border));border-radius:12px;padding:14px;}
+.section-title{font-weight:700;margin-bottom:8px;}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:8px;}
+.badge{display:inline-block;font-size:12px;padding:2px 8px;border-radius:999px;border:1px solid rgb(var(--color-border));}
+.badge.ok{background:rgb(var(--color-success)/0.15);color:rgb(var(--color-success));}
+.badge.warn{background:rgb(var(--color-goldenYellow)/0.15);color:rgb(var(--color-goldenYellow));}
+.bar .btn{cursor:pointer;}
+.sum{min-width:280px;}
+input[type="date"]{background:rgb(var(--color-darker));border:1px solid rgb(var(--color-border));color:rgb(var(--color-foreground));border-radius:8px;padding:6px;}
+.hint{font-size:12px;color:rgb(var(--color-mutedText));margin-top:6px;}
+a.link{color:rgb(var(--color-primary));text-decoration:none;border-bottom:1px dashed rgb(var(--color-primary));}
+a.link:hover{opacity:.9;}
+.card-spacing{margin:12px 0 16px;}


### PR DESCRIPTION
## Summary
- move tracker inline styles into `styles/tracker.css`
- apply design token utility classes to tracker page
- drop inline max-height styles in Composer and AI chat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b24f56d0888321927d2daa284d2020