### PR TITLE
Add Stripe JS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.55.0",
+    "@stripe/stripe-js": "^1.54.1",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add @stripe/stripe-js dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@stripe%2fstripe-js)*
- `npm run build` *(fails: Failed to fetch Google Fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68b2541f70ec8321aed90c214fa96bcf