### PR TITLE
Add risk screening and metrics to auth APIs

### DIFF
--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,21 @@
+export type Metrics = {
+  flaggedLoginAttempts: number;
+  flaggedSignupAttempts: number;
+};
+
+const metrics: Metrics = {
+  flaggedLoginAttempts: 0,
+  flaggedSignupAttempts: 0,
+};
+
+export function incrementFlaggedLogin() {
+  metrics.flaggedLoginAttempts += 1;
+}
+
+export function incrementFlaggedSignup() {
+  metrics.flaggedSignupAttempts += 1;
+}
+
+export function getMetrics(): Metrics {
+  return { ...metrics };
+}

--- a/lib/risk.ts
+++ b/lib/risk.ts
@@ -1,0 +1,38 @@
+export type RiskMetadata = {
+  ip: string;
+  userAgent?: string;
+  [key: string]: any;
+};
+
+const RISK_THRESHOLD = Number(process.env.RISK_THRESHOLD || '0.8');
+const RISK_API_URL = process.env.RISK_API_URL;
+
+export async function evaluateRisk(
+  metadata: RiskMetadata,
+): Promise<{ score: number }> {
+  if (!RISK_API_URL) {
+    // No risk model configured; treat as low risk
+    return { score: 0 };
+  }
+
+  try {
+    const response = await fetch(RISK_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(metadata),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Risk API responded ${response.status}`);
+    }
+
+    const data = (await response.json()) as { score?: number };
+    return { score: data.score ?? 0 };
+  } catch (error) {
+    console.error('Failed to evaluate risk', error);
+    // Fallback to allow request when risk model fails
+    return { score: 0 };
+  }
+}
+
+export const riskThreshold = RISK_THRESHOLD;

--- a/pages/api/metrics.ts
+++ b/pages/api/metrics.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getMetrics } from '@/lib/metrics';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(getMetrics());
+}


### PR DESCRIPTION
## Summary
- Add risk evaluation to login and signup APIs, blocking high-risk requests
- Log flagged attempts and track counters in new metrics module
- Expose `/api/metrics` for monitoring flagged login and signup attempts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26268dccc8321844311115f530a9e