### PR TITLE
feat: add waitlist page and links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,8 +19,8 @@ const MODULE_LINKS: ModuleLink[] = [
   { label: 'Speaking', href: '/speaking', desc: 'Pronunciation & fluency' },
 ];
 
-// Removed Join Waitlist
 const NAV: { href: string; label: string }[] = [
+  { href: '/waitlist', label: 'Join Waitlist' },
   { href: '#pricing', label: 'Pricing' },
 ];
 

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -228,7 +228,7 @@ export const Hero: React.FC<HeroProps> = ({ onStreakChange }) => {
           </Card>
 
           <div className="flex gap-4 mt-8 justify-center">
-            <Button href="/#waitlist" variant="primary">
+            <Button href="/waitlist" variant="primary">
               Join Exclusive Waitlist
             </Button>
             <Button href="/learning" variant="secondary">

--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -86,7 +86,7 @@ export const Pricing: React.FC = () => {
               </ul>
 
               <Button
-                href="#waitlist"
+                href="/waitlist"
                 variant={t.featured ? 'primary' : 'secondary'}
                 className="w-full justify-center"
               >

--- a/pages/r/[code].tsx
+++ b/pages/r/[code].tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps } from 'next';
 export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
   const code = params?.code as string;
   res.setHeader('Set-Cookie', `ref=${code}; Path=/; Max-Age=${60 * 60 * 24 * 14}`);
-  return { redirect: { destination: '/#waitlist', permanent: false } };
+  return { redirect: { destination: '/waitlist', permanent: false } };
 };
 
 export default function Referral() { return null; }

--- a/pages/waitlist.tsx
+++ b/pages/waitlist.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Head from 'next/head';
+import { Container } from '@/components/design-system/Container';
+import { WaitlistForm } from '@/components/waitlist/WaitlistForm';
+
+export default function WaitlistPage() {
+  return (
+    <>
+      <Head>
+        <title>Join the Waitlist • GramorX</title>
+      </Head>
+      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+        <Container className="max-w-xl">
+          <h1 className="font-slab text-display text-center mb-8">Join the Waitlist</h1>
+          <WaitlistForm />
+        </Container>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add waitlist marketing page rendering WaitlistForm
- link header, hero, and pricing sections to new waitlist page
- update referral redirect to new waitlist route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b265f97d648321b49e097e116d5fbf