### PR TITLE
refactor: use shared exam layout

### DIFF
--- a/components/mock-tests/SectionTest.tsx
+++ b/components/mock-tests/SectionTest.tsx
@@ -1,6 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useCountdown } from '@/hooks/useCountdown';
-import { Container } from '@/components/design-system/Container';
+import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Card } from '@/components/design-system/Card';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
@@ -20,174 +18,160 @@ export type SectionResult = {
   tabSwitches: number;
 };
 
+export type SectionTestHandle = {
+  submit: () => void;
+};
+
 type Props = {
   section: string;
-  duration: number;
   questions: Question[];
   onComplete?: (result: SectionResult) => void;
 };
 
-export function SectionTest({ section, duration, questions, onComplete }: Props) {
-  const { seconds, set, running, start, stop, reset } = useCountdown(duration, true);
-  const [answers, setAnswers] = useState<number[]>(Array(questions.length).fill(-1));
-  const [result, setResult] = useState<SectionResult | null>(null);
-  const [tabSwitches, setTabSwitches] = useState(0);
+export const SectionTest = forwardRef<SectionTestHandle, Props>(
+  function SectionTest({ section, questions, onComplete }, ref) {
+    const [answers, setAnswers] = useState<number[]>(Array(questions.length).fill(-1));
+    const [result, setResult] = useState<SectionResult | null>(null);
+    const [tabSwitches, setTabSwitches] = useState(0);
+    const startRef = useRef(Date.now());
 
-  // load saved state
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const saved = localStorage.getItem(`mock-${section}-state`);
-    if (saved) {
+    useImperativeHandle(ref, () => ({ submit: handleSubmit }));
+
+    useEffect(() => {
+      if (typeof window === 'undefined') return;
+      const saved = localStorage.getItem(`mock-${section}-state`);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (Array.isArray(parsed.answers)) setAnswers(parsed.answers);
+          if (typeof parsed.tabSwitches === 'number') setTabSwitches(parsed.tabSwitches);
+        } catch {
+          // ignore
+        }
+      }
+    }, [section]);
+
+    useEffect(() => {
+      if (typeof window === 'undefined') return;
+      const state = { answers, tabSwitches };
+      localStorage.setItem(`mock-${section}-state`, JSON.stringify(state));
+    }, [answers, section, tabSwitches]);
+
+    useEffect(() => {
+      const handler = () => {
+        if (document.hidden) setTabSwitches((n) => n + 1);
+      };
+      document.addEventListener('visibilitychange', handler);
+      return () => document.removeEventListener('visibilitychange', handler);
+    }, []);
+
+    function handleAnswer(qIndex: number, optIndex: number) {
+      const next = [...answers];
+      next[qIndex] = optIndex;
+      setAnswers(next);
+    }
+
+    async function handleSubmit() {
+      const correct = questions.reduce(
+        (sum, q, i) => sum + (answers[i] === q.answer ? 1 : 0),
+        0
+      );
+      const bandRaw = (correct / questions.length) * 9;
+      const band = Math.round(bandRaw * 2) / 2;
+      const res: SectionResult = {
+        section,
+        band,
+        correct,
+        total: questions.length,
+        timeTaken: Math.round((Date.now() - startRef.current) / 1000),
+        tabSwitches,
+      };
+      setResult(res);
+      if (typeof window !== 'undefined') {
+        try {
+          const existing: SectionResult[] = JSON.parse(
+            localStorage.getItem('mock-results') || '[]'
+          );
+          existing.push(res);
+          localStorage.setItem('mock-results', JSON.stringify(existing));
+          localStorage.removeItem(`mock-${section}-state`);
+        } catch {
+          // ignore
+        }
+      }
       try {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed.answers)) setAnswers(parsed.answers);
-        if (typeof parsed.seconds === 'number') set(parsed.seconds);
-        if (typeof parsed.tabSwitches === 'number') setTabSwitches(parsed.tabSwitches);
-      } catch {
-        // ignore
+        const {
+          data: { session },
+        } = await supabaseBrowser.auth.getSession();
+        const userId = session?.user?.id;
+        if (userId) {
+          await supabaseBrowser.from('mock_test_results').insert({
+            user_id: userId,
+            section: res.section,
+            band: res.band,
+            correct: res.correct,
+            total: res.total,
+            time_taken: res.timeTaken,
+            tab_switches: res.tabSwitches,
+            created_at: new Date().toISOString(),
+          });
+        }
+      } catch (e) {
+        console.error('Failed to save mock test result', e);
       }
+      onComplete?.(res);
     }
-  }, [section, set]);
 
-  // persist state
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const state = { answers, seconds, tabSwitches };
-    localStorage.setItem(`mock-${section}-state`, JSON.stringify(state));
-  }, [answers, seconds, section, tabSwitches]);
-
-  // tab switch detection
-  useEffect(() => {
-    const handler = () => {
-      if (document.hidden) setTabSwitches((n) => n + 1);
-    };
-    document.addEventListener('visibilitychange', handler);
-    return () => document.removeEventListener('visibilitychange', handler);
-  }, []);
-
-  // auto submit when time runs out
-  useEffect(() => {
-    if (seconds === 0 && result === null) handleSubmit();
-  }, [seconds, result]);
-
-  const handleAnswer = (qIndex: number, optIndex: number) => {
-    const next = [...answers];
-    next[qIndex] = optIndex;
-    setAnswers(next);
-  };
-
-  const handleSubmit = async () => {
-    stop();
-    const correct = questions.reduce(
-      (sum, q, i) => sum + (answers[i] === q.answer ? 1 : 0),
-      0
-    );
-    const bandRaw = (correct / questions.length) * 9;
-    const band = Math.round(bandRaw * 2) / 2;
-    const res: SectionResult = {
-      section,
-      band,
-      correct,
-      total: questions.length,
-      timeTaken: duration - seconds,
-      tabSwitches,
-    };
-    setResult(res);
-    if (typeof window !== 'undefined') {
-      try {
-        const existing: SectionResult[] = JSON.parse(
-          localStorage.getItem('mock-results') || '[]'
-        );
-        existing.push(res);
-        localStorage.setItem('mock-results', JSON.stringify(existing));
-        localStorage.removeItem(`mock-${section}-state`);
-      } catch {
-        // ignore
-      }
+    if (result) {
+      return (
+        <Card className="p-6 rounded-ds-2xl">
+          <h2 className="font-slab text-h3 capitalize">{section} Results</h2>
+          <p className="mt-4">Band score: {result.band}</p>
+          <p>Correct: {result.correct} / {result.total}</p>
+          <p>Time taken: {result.timeTaken}s</p>
+          <p>Tab switches: {result.tabSwitches}</p>
+        </Card>
+      );
     }
-    try {
-      const {
-        data: { session },
-      } = await supabaseBrowser.auth.getSession();
-      const userId = session?.user?.id;
-      if (userId) {
-        await supabaseBrowser.from('mock_test_results').insert({
-          user_id: userId,
-          section: res.section,
-          band: res.band,
-          correct: res.correct,
-          total: res.total,
-          time_taken: res.timeTaken,
-          tab_switches: res.tabSwitches,
-          created_at: new Date().toISOString(),
-        });
-      }
-    } catch (e) {
-      console.error('Failed to save mock test result', e);
-    }
-    onComplete?.(res);
-  };
 
-  if (result) {
     return (
-      <section className="py-8">
-        <Container>
-          <Card className="p-6 rounded-ds-2xl">
-            <h2 className="font-slab text-h3 capitalize">{section} Results</h2>
-            <p className="mt-4">Band score: {result.band}</p>
-            <p>Correct: {result.correct} / {result.total}</p>
-            <p>Time taken: {result.timeTaken}s</p>
-            <p>Tab switches: {result.tabSwitches}</p>
-          </Card>
-        </Container>
-      </section>
+      <Card className="p-6 rounded-ds-2xl">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          className="space-y-6"
+        >
+          {questions.map((q, qi) => (
+            <div key={q.id}>
+              <p className="mb-2">{q.question}</p>
+              <div className="space-y-1">
+                {q.options.map((opt, oi) => (
+                  <label key={oi} className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={`q${qi}`}
+                      checked={answers[qi] === oi}
+                      onChange={() => handleAnswer(qi, oi)}
+                    />
+                    {opt}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+          <button
+            type="submit"
+            className="mt-4 px-4 py-2 bg-primary text-white rounded"
+          >
+            Submit Section
+          </button>
+        </form>
+      </Card>
     );
   }
-
-  return (
-    <section className="py-8">
-      <Container>
-        <Card className="p-6 rounded-ds-2xl">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="font-slab text-h3 capitalize">{section} Section</h2>
-            <span className="font-mono">{seconds}s</span>
-          </div>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              handleSubmit();
-            }}
-            className="space-y-6"
-          >
-            {questions.map((q, qi) => (
-              <div key={q.id}>
-                <p className="mb-2">{q.question}</p>
-                <div className="space-y-1">
-                  {q.options.map((opt, oi) => (
-                    <label key={oi} className="flex items-center gap-2">
-                      <input
-                        type="radio"
-                        name={`q${qi}`}
-                        checked={answers[qi] === oi}
-                        onChange={() => handleAnswer(qi, oi)}
-                      />
-                      {opt}
-                    </label>
-                  ))}
-                </div>
-              </div>
-            ))}
-            <button
-              type="submit"
-              className="mt-4 px-4 py-2 bg-primary text-white rounded"
-            >
-              Submit Section
-            </button>
-          </form>
-        </Card>
-      </Container>
-    </section>
-  );
-}
+);
 
 export default SectionTest;
+

--- a/pages/exam/rehearsal.tsx
+++ b/pages/exam/rehearsal.tsx
@@ -2,18 +2,17 @@ import DeviceCheck from '@/components/exam/DeviceCheck';
 import TimingRehearsal from '@/components/exam/TimingRehearsal';
 import AnxietyScripts from '@/components/exam/AnxietyScripts';
 import ExamChecklist from '@/components/exam/ExamChecklist';
-import { Container } from '@/components/design-system/Container';
+import ExamLayout from '@/components/layouts/ExamLayout';
 
 export default function ExamRehearsalPage() {
   return (
-    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-      <Container>
-        <h1 className="font-slab text-h1 mb-8">Exam Rehearsal</h1>
+    <ExamLayout exam="rehearsal" seconds={0} title="Exam Rehearsal">
+      <div className="space-y-8">
         <DeviceCheck />
         <TimingRehearsal />
         <AnxietyScripts />
         <ExamChecklist />
-      </Container>
-    </section>
+      </div>
+    </ExamLayout>
   );
 }

--- a/pages/mock-tests/[section].tsx
+++ b/pages/mock-tests/[section].tsx
@@ -1,12 +1,15 @@
 import { useRouter } from 'next/router';
-import SectionTest from '@/components/mock-tests/SectionTest';
+import { useRef } from 'react';
+import SectionTest, { SectionTestHandle } from '@/components/mock-tests/SectionTest';
 import { mockSections } from '@/data/mockTests';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
+import ExamLayout from '@/components/layouts/ExamLayout';
 
 export default function SectionPage() {
   const router = useRouter();
   const { section } = router.query as { section?: string };
+  const testRef = useRef<SectionTestHandle>(null);
   if (!section || !mockSections[section]) {
     return (
       <section className="py-24">
@@ -20,10 +23,14 @@ export default function SectionPage() {
   }
   const { duration, questions } = mockSections[section];
   return (
-    <SectionTest
-      section={section}
-      duration={duration}
-      questions={questions}
-    />
+    <ExamLayout
+      exam="mock-test"
+      slug={section}
+      title={`${section.charAt(0).toUpperCase() + section.slice(1)} Section`}
+      seconds={duration}
+      onElapsed={() => testRef.current?.submit()}
+    >
+      <SectionTest ref={testRef} section={section} questions={questions} />
+    </ExamLayout>
   );
 }

--- a/pages/mock-tests/full.tsx
+++ b/pages/mock-tests/full.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
-import SectionTest, { SectionResult } from '@/components/mock-tests/SectionTest';
+import { useRef } from 'react';
+import SectionTest, { SectionResult, SectionTestHandle } from '@/components/mock-tests/SectionTest';
 import { mockSections } from '@/data/mockTests';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
+import ExamLayout from '@/components/layouts/ExamLayout';
 
 const order = ['listening', 'reading', 'writing', 'speaking'] as const;
 
@@ -14,6 +16,7 @@ type Progress = {
 export default function FullTestPage() {
   const [progress, setProgress] = useState<Progress>({ current: 0, results: [] });
   const [finished, setFinished] = useState(false);
+  const testRef = useRef<SectionTestHandle>(null);
 
   // load progress
   useEffect(() => {
@@ -88,11 +91,19 @@ export default function FullTestPage() {
   const sectionData = mockSections[currentKey];
 
   return (
-    <SectionTest
-      section={currentKey}
-      duration={sectionData.duration}
-      questions={sectionData.questions}
-      onComplete={handleSectionComplete}
-    />
+    <ExamLayout
+      exam="mock-test"
+      slug={`full-${currentKey}`}
+      title={`${currentKey.charAt(0).toUpperCase() + currentKey.slice(1)} Section`}
+      seconds={sectionData.duration}
+      onElapsed={() => testRef.current?.submit()}
+    >
+      <SectionTest
+        ref={testRef}
+        section={currentKey}
+        questions={sectionData.questions}
+        onComplete={handleSectionComplete}
+      />
+    </ExamLayout>
   );
 }


### PR DESCRIPTION
## Summary
- apply reusable `ExamLayout` to mock test and rehearsal pages for consistent header and timer
- simplify `SectionTest` by removing inline timer logic and exposing a submit handle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b265f5259c83219891fc93c695aa2f