### PR TITLE
Handle missing OAuth code on auth callback

### DIFF
--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -9,9 +9,21 @@ export default function AuthCallback() {
 
   useEffect(() => {
     (async () => {
-      const { data, error } = await supabase.auth.exchangeCodeForSession(
-        typeof window !== 'undefined' ? window.location.href : ''
-      );
+      const url = typeof window !== 'undefined' ? window.location.href : '';
+      const sp = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams();
+      const code = sp.get('code');
+      const urlError = sp.get('error_description') || sp.get('error');
+
+      if (urlError) {
+        setErr(urlError);
+        return;
+      }
+      if (!code) {
+        setErr('Missing authorization code. Please try signing in again.');
+        return;
+      }
+
+      const { data, error } = await supabase.auth.exchangeCodeForSession(url);
       if (error) {
         setErr(error.message);
       } else {
@@ -35,4 +47,3 @@ export default function AuthCallback() {
     </AuthLayout>
   );
 }
-


### PR DESCRIPTION
## Summary
- gracefully handle OAuth callback without code by showing a clear error
- exchange session only when code is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2732b6ddc83218aafbba8286ed1a0