### PR TITLE
feat(ai): add re-evaluate API and UI

### DIFF
--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -1,0 +1,17 @@
+export type CreditLedger = Record<string, number>;
+
+const ledger: CreditLedger = {};
+
+/**
+ * Records a credit usage for a given user. Defaults to 1 credit per call.
+ */
+export function recordReevaluationCredit(userId: string, amount = 1) {
+  ledger[userId] = (ledger[userId] || 0) + amount;
+}
+
+/**
+ * Returns the total credits consumed by the user so far in this process.
+ */
+export function getCreditUsage(userId: string): number {
+  return ledger[userId] || 0;
+}

--- a/pages/ai/writing/[id].tsx
+++ b/pages/ai/writing/[id].tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+import { Badge } from '@/components/design-system/Badge';
+import { Button } from '@/components/design-system/Button';
+import { Alert } from '@/components/design-system/Alert';
+
+interface Criteria { task: number; coherence: number; lexical: number; grammar: number }
+interface Attempt {
+  id: string;
+  user_id?: string;
+  task_type: 'T1'|'T2'|'GT';
+  prompt: string;
+  essay_text: string;
+  band_overall: number;
+  band_breakdown: Criteria;
+  feedback: string;
+}
+
+export const getServerSideProps: GetServerSideProps<{ attempt: Attempt }> = async (ctx) => {
+  const supa = createServerSupabaseClient(ctx);
+  const { data: auth } = await supa.auth.getUser();
+  const userId = auth.user?.id ?? null;
+  const id = String(ctx.params!.id);
+  const { data: attempt, error } = await supa
+    .from('writing_attempts')
+    .select('id, user_id, task_type, prompt, essay_text, band_overall, band_breakdown, feedback')
+    .eq('id', id)
+    .single();
+  if (error || !attempt) return { notFound: true };
+  if (attempt.user_id && attempt.user_id !== userId) return { notFound: true };
+  return { props: { attempt } };
+};
+
+export default function WritingReview({ attempt }: { attempt: Attempt }) {
+  const [result, setResult] = useState<{ band_overall:number; band_breakdown:Criteria; feedback:string; model:string } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string|null>(null);
+
+  const delta = (a:number,b:number) => Math.round((a-b)*10)/10;
+
+  const reeval = async () => {
+    setLoading(true); setErr(null);
+    try {
+      const res = await fetch('/api/ai/re-evaluate', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ attemptId: attempt.id }),
+      });
+      if (!res.ok) {
+        const { error } = await res.json();
+        throw new Error(error || 'Request failed');
+      }
+      const data = await res.json();
+      setResult(data);
+    } catch (e:any) {
+      setErr(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+      <Container>
+        <h1 className="font-slab text-h1 md:text-display">Writing Review</h1>
+        <p className="text-grayish mt-1">Task {attempt.task_type}</p>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr] mt-6">
+          <Card className="card-surface p-6 rounded-ds-2xl">
+            <h3 className="text-h3">Scores</h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant="success" size="md">Overall: {attempt.band_overall}</Badge>
+              <Badge variant="info" size="sm">Task: {attempt.band_breakdown.task}</Badge>
+              <Badge variant="info" size="sm">Coherence: {attempt.band_breakdown.coherence}</Badge>
+              <Badge variant="info" size="sm">Lexical: {attempt.band_breakdown.lexical}</Badge>
+              <Badge variant="info" size="sm">Grammar: {attempt.band_breakdown.grammar}</Badge>
+            </div>
+
+            <h3 className="text-h3 mt-6">Model Answer (Reference)</h3>
+            <div className="prose dark:prose-invert max-w-none mt-2">
+              <p>{attempt.feedback || 'Model answer and comments will appear here.'}</p>
+            </div>
+
+            <h3 className="text-h3 mt-6">Your Essay</h3>
+            <div className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10 whitespace-pre-wrap">
+              {attempt.essay_text}
+            </div>
+          </Card>
+
+          <div className="grid gap-6">
+            <Card className="card-surface p-6 rounded-ds-2xl">
+              <h3 className="text-h3">AI Re-evaluation</h3>
+              <p className="text-grayish mt-1">Run a second pass and compare scores.</p>
+              <Button onClick={reeval} disabled={loading} variant="primary" className="mt-4 rounded-ds-xl">
+                {loading ? 'Re-evaluating…' : 'Re-evaluate'}
+              </Button>
+              {err && <Alert variant="error" title="Failed" className="mt-4">{err}</Alert>}
+              {result && (
+                <div className="mt-6 grid gap-4">
+                  <div className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10">
+                    <div className="flex items-center gap-3">
+                      <Badge variant="neutral" size="sm">Original: {attempt.band_overall}</Badge>
+                      <Badge
+                        variant={result.band_overall>attempt.band_overall?'success':result.band_overall<attempt.band_overall?'danger':'neutral'}
+                        size="sm"
+                      >
+                        New: {result.band_overall} ({delta(result.band_overall, attempt.band_overall)>0?'+':''}{delta(result.band_overall, attempt.band_overall)})
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="grid sm:grid-cols-2 gap-3">
+                    {(['task','coherence','lexical','grammar'] as const).map(k => (
+                      <div key={k} className="p-3.5 rounded-ds border border-gray-200 dark:border-white/10">
+                        <div className="flex items-center justify-between">
+                          <span className="capitalize">{k}</span>
+                          <Badge
+                            variant={result.band_breakdown[k]>attempt.band_breakdown[k]?'success':result.band_breakdown[k]<attempt.band_breakdown[k]?'danger':'neutral'}
+                            size="sm"
+                          >
+                            {attempt.band_breakdown[k]} → {result.band_breakdown[k]} ({delta(result.band_breakdown[k], attempt.band_breakdown[k])>0?'+':''}{delta(result.band_breakdown[k], attempt.band_breakdown[k])})
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <Alert variant="info" title="Feedback">{result.feedback}</Alert>
+                </div>
+              )}
+            </Card>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/pages/api/ai/re-evaluate.ts
+++ b/pages/api/ai/re-evaluate.ts
@@ -1,0 +1,78 @@
+import { env } from '@/lib/env';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { z } from 'zod';
+import { recordReevaluationCredit } from '@/lib/credits';
+
+const BodySchema = z.object({
+  attemptId: z.string().uuid(),
+});
+
+const EvalSchema = z.object({
+  band_overall: z.number().min(0).max(9),
+  band_breakdown: z.object({
+    task: z.number().min(0).max(9),
+    coherence: z.number().min(0).max(9),
+    lexical: z.number().min(0).max(9),
+    grammar: z.number().min(0).max(9),
+  }),
+  feedback: z.string().min(1),
+  model: z.string().min(1),
+});
+
+function buildPrompt(args: { task_type: 'T1'|'T2'|'GT'; prompt: string; essay_text: string; }) {
+  const { task_type, prompt, essay_text } = args;
+  return [
+    `You are an IELTS examiner. Evaluate the essay using IELTS ${task_type === 'GT' ? 'General Training Letter' : task_type === 'T1' ? 'Task 1 (Academic)' : 'Task 2'} rubrics.`,
+    `Return ONLY JSON with keys: band_overall (number, 0–9, use 0.5 increments), band_breakdown (object with task, coherence, lexical, grammar numbers), feedback (string), model (string: an ideal model answer).`,
+    `Essay prompt:\n${prompt}`,
+    `---`,
+    `Student essay:\n${essay_text}`,
+  ].join('\n\n');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const supabase = createServerSupabaseClient({ req, res });
+  const { data: userResp, error: authErr } = await supabase.auth.getUser();
+  if (authErr || !userResp?.user) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = userResp.user.id;
+
+  const parse = BodySchema.safeParse(req.body);
+  if (!parse.success) return res.status(400).json({ error: 'Invalid body', details: parse.error.flatten() });
+  const { attemptId } = parse.data;
+
+  const { data: attempt, error: attemptErr } = await supabase
+    .from('writing_attempts')
+    .select('id, user_id, task_type, prompt, essay_text')
+    .eq('id', attemptId)
+    .single();
+  if (attemptErr || !attempt) return res.status(404).json({ error: 'Attempt not found' });
+  if (attempt.user_id && attempt.user_id !== userId) return res.status(403).json({ error: 'Forbidden' });
+
+  try {
+    const genAI = new GoogleGenerativeAI(env.GEMINI_API_KEY as string);
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro' });
+    const prompt = buildPrompt({
+      task_type: attempt.task_type as 'T1'|'T2'|'GT',
+      prompt: attempt.prompt,
+      essay_text: attempt.essay_text,
+    });
+
+    const result = await model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: { responseMimeType: 'application/json' } as any,
+    });
+
+    const text = result.response.text();
+    const parsed = EvalSchema.parse(JSON.parse(text));
+
+    recordReevaluationCredit(userId);
+
+    return res.status(200).json(parsed);
+  } catch (e: any) {
+    return res.status(500).json({ error: 'LLM evaluation failed', details: e?.message ?? String(e) });
+  }
+}


### PR DESCRIPTION
## Summary
- add credit tracker for re-evaluations
- create API route to run second AI analysis and record credits
- add writing review page with re-evaluate button and comparison view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b276d124a08321806e12cc167ce025