### PR TITLE
feat: improve reading question handling and stats

### DIFF
--- a/components/reading/templates.ts
+++ b/components/reading/templates.ts
@@ -1,0 +1,83 @@
+import { AnswerValue } from './useReadingAnswers';
+
+export type TFNGTemplate = {
+  kind: 'tfng';
+  id: string;
+  prompt: string;
+  correct: 'True' | 'False' | 'Not Given';
+};
+
+export type MCQTemplate = {
+  kind: 'mcq';
+  id: string;
+  prompt: string;
+  options: string[];
+  correct: string;
+};
+
+export type MatchingTemplate = {
+  kind: 'matching';
+  id: string;
+  prompt: string;
+  pairs: { left: string; right: string[] }[];
+  correct: string[];
+};
+
+export type ShortTemplate = {
+  kind: 'short';
+  id: string;
+  prompt: string;
+  acceptable: string[];
+};
+
+export type QuestionTemplate =
+  | TFNGTemplate
+  | MCQTemplate
+  | MatchingTemplate
+  | ShortTemplate;
+
+function norm(val: any) {
+  return String(val).trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function scoreQuestion(
+  tmpl: QuestionTemplate,
+  answer: AnswerValue,
+): number {
+  switch (tmpl.kind) {
+    case 'tfng':
+    case 'mcq':
+      return answer != null && String(answer) === String(tmpl.correct) ? 1 : 0;
+    case 'short': {
+      const ans = String(answer ?? '');
+      return tmpl.acceptable.some((a) => norm(a) === norm(ans)) ? 1 : 0;
+    }
+    case 'matching': {
+      if (!Array.isArray(answer)) return 0;
+      return answer.length === tmpl.correct.length &&
+        answer.every((a, i) => norm(a) === norm(tmpl.correct[i]))
+        ? 1
+        : 0;
+    }
+    default:
+      return 0;
+  }
+}
+
+export const exampleTFNG: TFNGTemplate = {
+  kind: 'tfng',
+  id: 'tf1',
+  prompt: 'The sky is blue.',
+  correct: 'True',
+};
+
+export const exampleMatching: MatchingTemplate = {
+  kind: 'matching',
+  id: 'm1',
+  prompt: 'Match animals to habitats',
+  pairs: [
+    { left: 'Camel', right: ['Desert', 'Forest'] },
+    { left: 'Penguin', right: ['Antarctica', 'Jungle'] },
+  ],
+  correct: ['Desert', 'Antarctica'],
+};

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,32 @@
+export type ReadingAttempt = {
+  score: number;
+  maxScore: number;
+  byType: Record<string, { correct: number; total: number }>;
+};
+
+export type ReadingStats = {
+  attempts: number;
+  totalScore: number;
+  totalMax: number;
+  byType: Record<string, { correct: number; total: number }>;
+};
+
+export async function getReadingStats(): Promise<ReadingStats> {
+  try {
+    const raw = typeof window !== 'undefined' ? localStorage.getItem('readingAttempts') : null;
+    const arr: ReadingAttempt[] = raw ? JSON.parse(raw) : [];
+    const stats: ReadingStats = { attempts: arr.length, totalScore: 0, totalMax: 0, byType: {} };
+    arr.forEach((a) => {
+      stats.totalScore += a.score;
+      stats.totalMax += a.maxScore;
+      Object.entries(a.byType || {}).forEach(([k, v]) => {
+        stats.byType[k] ||= { correct: 0, total: 0 };
+        stats.byType[k].correct += v.correct;
+        stats.byType[k].total += v.total;
+      });
+    });
+    return stats;
+  } catch {
+    return { attempts: 0, totalScore: 0, totalMax: 0, byType: {} };
+  }
+}

--- a/pages/reading/index.tsx
+++ b/pages/reading/index.tsx
@@ -1,31 +1,68 @@
 // pages/reading/index.tsx
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
+import { ReadingFilterBar } from '@/components/reading/ReadingFilterBar';
 
-type ReadingListItem = { slug: string; title: string; difficulty: 'Easy'|'Medium'|'Hard'; qCount: number; estMinutes: number };
+type Kind = 'tfng' | 'mcq' | 'matching' | 'short';
+type ReadingListItem = {
+  slug: string;
+  title: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  qCount: number;
+  estMinutes: number;
+  types: Kind[];
+};
 
 export default function ReadingListPage() {
-  const [items, setItems] = useState<ReadingListItem[]|null>(null);
-  const [error, setError] = useState<string|undefined>();
+  const [items, setItems] = useState<ReadingListItem[] | null>(null);
+  const [error, setError] = useState<string | undefined>();
+  const router = useRouter();
+  const activeType = (router.query.type as string) || 'all';
 
   useEffect(() => {
     try {
       setItems([
-        { slug: 'sample-reading-1', title: 'The Honey Bee Ecosystem', difficulty: 'Medium', qCount: 14, estMinutes: 20 },
+        {
+          slug: 'sample-reading-1',
+          title: 'The Honey Bee Ecosystem',
+          difficulty: 'Medium',
+          qCount: 14,
+          estMinutes: 20,
+          types: ['tfng', 'mcq', 'matching', 'short'],
+        },
+        {
+          slug: 'sample-reading-2',
+          title: 'Migration Patterns',
+          difficulty: 'Easy',
+          qCount: 8,
+          estMinutes: 12,
+          types: ['mcq', 'short'],
+        },
       ]);
-    } catch (e:any) { setError(e?.message || 'Failed to load'); }
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load');
+    }
   }, []);
+
+  const filtered = useMemo(() => {
+    if (!items) return [] as ReadingListItem[];
+    if (activeType === 'all') return items;
+    return items.filter((i) => i.types.includes(activeType as Kind));
+  }, [items, activeType]);
 
   return (
     <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
       <Container>
         <h1 className="font-slab text-4xl text-gradient-primary">Reading Practice</h1>
         <p className="text-grayish max-w-2xl">Choose a passage and start a timed practice. Your answers autosave locally.</p>
+
+        <ReadingFilterBar className="mt-6" />
 
         {error && <div className="mt-6"><Alert variant="error" title="Couldn’t load tests">{error}</Alert></div>}
 
@@ -35,7 +72,7 @@ export default function ReadingListPage() {
           </div>
         ) : (
           <div className="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {items.map(t => (
+            {filtered.map(t => (
               <Card key={t.slug} className="p-6 flex flex-col justify-between">
                 <div>
                   <h3 className="text-h3 font-semibold mb-1">{t.title}</h3>

--- a/pages/reading/review/index.tsx
+++ b/pages/reading/review/index.tsx
@@ -259,21 +259,14 @@ const ReviewPage: NextPage<Props> = ({ passage, questions, notFound, error }) =>
 
   async function explain(q: ReviewQuestion) {
     try {
-      const payload = {
-        passage: passage?.contentHtml ?? '',
-        question: { kind: q.kind, prompt: q.prompt, id: q.id },
-        userAnswer: answers ? answers[q.id] : null,
-        correctAnswer:
-          Array.isArray(q.answers) && q.kind !== 'matching' ? q.answers[0] : q.answers,
-      };
       const res = await fetch('/api/reading/explain', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ attemptId, qid: q.id }),
       });
       const json = await res.json();
-      if (json?.explanation) {
-        const text = await translateExplanation(json.explanation, explanationLocale);
+      if (json?.text) {
+        const text = await translateExplanation(json.text, explanationLocale);
         setExplanations((prev) => ({ ...prev, [q.id]: text }));
       }
     } catch {

--- a/pages/reading/stats.tsx
+++ b/pages/reading/stats.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+import { Badge } from '@/components/design-system/Badge';
+import { getReadingStats, type ReadingStats } from '@/lib/analytics';
+
+export default function ReadingStatsPage() {
+  const [stats, setStats] = useState<ReadingStats | null>(null);
+
+  useEffect(() => {
+    getReadingStats().then(setStats);
+  }, []);
+
+  return (
+    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+      <Container>
+        <h1 className="font-slab text-4xl text-gradient-primary">Reading Stats</h1>
+        {!stats ? (
+          <Card className="p-6 mt-6">
+            <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+          </Card>
+        ) : (
+          <Card className="p-6 mt-6">
+            <div className="flex flex-wrap items-center gap-3 mb-4">
+              <Badge variant="neutral">Attempts: {stats.attempts}</Badge>
+              <Badge variant="neutral">Points: {stats.totalScore}/{stats.totalMax}</Badge>
+            </div>
+            <ul className="grid gap-2">
+              {Object.entries(stats.byType).map(([k, v]) => (
+                <li key={k}>
+                  <Badge variant="info">
+                    {k}: {v.correct}/{v.total}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+      </Container>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable question templates and scoring utilities for TF/NG, MCQ, matching, and short answers
- filter reading passages by question type
- hook review page to AI explanation endpoint
- show aggregated reading stats using local analytics helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b276d7a45483218b08cf5f9389c994