### PR TITLE
Add analytics reports, study time, and AI plan features

### DIFF
--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -1,0 +1,46 @@
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+
+export interface ModuleScore {
+  module: string;
+  score: number;
+}
+
+/** Aggregate scores across different modules for a user */
+export async function aggregateScores(userId: string): Promise<Record<string, number>> {
+  const { data, error } = await supabase
+    .from('scores')
+    .select('module, score')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return (data || []).reduce((acc: Record<string, number>, { module, score }: any) => {
+    acc[module] = (acc[module] || 0) + score;
+    return acc;
+  }, {});
+}
+
+/** Analyse incorrect answers to surface weaknesses and suggestions */
+export async function analyzeIncorrectAnswers(userId: string) {
+  const { data, error } = await supabase
+    .from('mistakes')
+    .select('topic')
+    .eq('user_id', userId)
+    .eq('correct', false);
+  if (error) throw error;
+  const counts: Record<string, number> = {};
+  (data || []).forEach((row: any) => {
+    const topic = row.topic || 'general';
+    counts[topic] = (counts[topic] || 0) + 1;
+  });
+  const top = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
+  const suggestion = top ? `Focus more on ${top[0]}` : 'Keep up the good work';
+  return { counts, suggestion };
+}
+
+/** Create a combined report */
+export async function generateReport(userId: string) {
+  const [scores, analysis] = await Promise.all([
+    aggregateScores(userId),
+    analyzeIncorrectAnswers(userId),
+  ]);
+  return { scores, analysis };
+}

--- a/lib/study-time/index.ts
+++ b/lib/study-time/index.ts
@@ -1,0 +1,14 @@
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+
+export async function logStudyTime(userId: string, minutes: number) {
+  await supabase.from('study_time').insert({ user_id: userId, minutes });
+}
+
+export async function getTotalStudyTime(userId: string) {
+  const { data, error } = await supabase
+    .from('study_time')
+    .select('minutes')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return (data || []).reduce((sum: number, row: any) => sum + row.minutes, 0);
+}

--- a/pages/api/reports/index.ts
+++ b/pages/api/reports/index.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { generateReport } from '@/lib/analytics';
+
+let weeklyTimer: NodeJS.Timeout | null = null;
+let monthlyTimer: NodeJS.Timeout | null = null;
+
+async function sendEmail(to: string, report: any) {
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+    },
+    body: JSON.stringify({
+      from: 'reports@gramorx.com',
+      to,
+      subject: 'Your progress report',
+      html: `<pre>${JSON.stringify(report, null, 2)}</pre>`,
+    }),
+  });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+  const { userId, email, interval } = req.body as {
+    userId?: string;
+    email?: string;
+    interval?: 'weekly' | 'monthly';
+  };
+  if (!userId || !email || !interval) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+  const run = async () => {
+    const report = await generateReport(userId);
+    await sendEmail(email, report);
+  };
+  if (interval === 'weekly' && !weeklyTimer) {
+    weeklyTimer = setInterval(run, 7 * 24 * 60 * 60 * 1000);
+  }
+  if (interval === 'monthly' && !monthlyTimer) {
+    monthlyTimer = setInterval(run, 30 * 24 * 60 * 60 * 1000);
+  }
+  await run();
+  res.status(200).json({ scheduled: interval });
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -12,6 +12,7 @@ import { StreakIndicator } from '@/components/design-system/StreakIndicator';
 import { badges } from '@/data/badges';
 
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { getTotalStudyTime } from '@/lib/study-time';
 import { ReadingStatsCard } from '@/components/reading/ReadingStatsCard';
 import QuickDrillButton from '@/components/quick/QuickDrillButton';
 import { WordOfTheDayCard } from '@/components/feature/WordOfTheDayCard';
@@ -33,6 +34,7 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [showTips, setShowTips] = useState(false);
+  const [studyTime, setStudyTime] = useState(0);
 
   // Hook now exposes: nextRestart + shields + claimShield + useShield
   const {
@@ -101,6 +103,8 @@ export default function Dashboard() {
         }
 
         setProfile(data as Profile);
+        const total = await getTotalStudyTime(session.user.id);
+        setStudyTime(total);
         setLoading(false);
       } catch (e) {
         console.error(e);
@@ -224,7 +228,7 @@ export default function Dashboard() {
         </div>
 
         {/* Top summary cards */}
-        <div className="mt-10 grid gap-6 md:grid-cols-3">
+        <div className="mt-10 grid gap-6 md:grid-cols-4">
           <Card className="p-6 rounded-ds-2xl">
             <div className="text-small opacity-70 mb-1">Goal Band</div>
             <div className="text-h1 font-semibold">
@@ -254,6 +258,17 @@ export default function Dashboard() {
                   {s}
                 </Badge>
               ))}
+            </div>
+          </Card>
+
+          <Card className="p-6 rounded-ds-2xl">
+            <div className="text-small opacity-70 mb-1">Study Time</div>
+            <div className="text-h1 font-semibold">
+              {Math.round(studyTime / 60)}
+              <span className="text-h3 ml-1">hrs</span>
+            </div>
+            <div className="mt-3 text-small opacity-80">
+              Total minutes: {studyTime}
             </div>
           </Card>
         </div>

--- a/pages/leaderboard/index.tsx
+++ b/pages/leaderboard/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 
 interface Entry {
@@ -12,11 +13,14 @@ interface Entry {
 export default function WeeklyLeaderboard() {
   const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState<'weekly' | 'monthly'>('weekly');
 
   useEffect(() => {
     (async () => {
+      setLoading(true);
+      const table = period === 'weekly' ? 'weekly_leaderboard' : 'monthly_leaderboard';
       const { data, error } = await supabase
-        .from('weekly_leaderboard')
+        .from(table)
         .select('user_id, score, user_profiles(full_name)')
         .order('score', { ascending: false })
         .limit(10);
@@ -30,13 +34,29 @@ export default function WeeklyLeaderboard() {
       }
       setLoading(false);
     })();
-  }, []);
+  }, [period]);
 
   return (
     <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
       <Container>
         <Card className="p-6 rounded-ds-2xl max-w-xl mx-auto">
-          <h1 className="font-slab text-display mb-4">Weekly Leaderboard</h1>
+          <h1 className="font-slab text-display mb-4 capitalize">{period} Leaderboard</h1>
+          <div className="flex gap-2 mb-4">
+            <Button
+              size="sm"
+              variant={period === 'weekly' ? 'primary' : 'secondary'}
+              onClick={() => setPeriod('weekly')}
+            >
+              Weekly
+            </Button>
+            <Button
+              size="sm"
+              variant={period === 'monthly' ? 'primary' : 'secondary'}
+              onClick={() => setPeriod('monthly')}
+            >
+              Monthly
+            </Button>
+          </div>
           {loading ? (
             <div>Loading…</div>
           ) : (

--- a/pages/progress/plan.tsx
+++ b/pages/progress/plan.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { generateAIPlan } from '@/lib/aiPlan';
+import type { Profile, AIPlan } from '@/types/profile';
+
+export default function PlanPage() {
+  const [plan, setPlan] = useState<AIPlan | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { session } } = await supabaseBrowser.auth.getSession();
+      if (!session?.user) return;
+      const { data } = await supabaseBrowser
+        .from('user_profiles')
+        .select('*')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+      if (data) {
+        setPlan(generateAIPlan(data as Profile));
+      }
+    })();
+  }, []);
+
+  return (
+    <section className="py-24 bg-lightBg dark:bg-dark/80">
+      <Container>
+        <Card className="p-6 rounded-ds-2xl max-w-xl mx-auto">
+          <h1 className="font-slab text-display mb-4">Personalized Study Plan</h1>
+          {plan ? (
+            <ol className="list-decimal pl-6 space-y-2">
+              {plan.sequence.map((s) => (
+                <li key={s}>{s}</li>
+              ))}
+            </ol>
+          ) : (
+            <div>Loading…</div>
+          )}
+        </Card>
+      </Container>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Aggregate scores and analyze incorrect answers for user reports
- Schedule weekly/monthly report emails via new API route
- Track study time and surface personalized AI study plans

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b276d90b008321a189e78e080ad1a4