### PR TITLE
Add adaptive learning engine modules

### DIFF
--- a/_tests_/learning-modules.test.ts
+++ b/_tests_/learning-modules.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'node:assert';
+import { recommendTasks, HistoryItem } from '../lib/recommendations';
+import { scheduleDrill, isDue, Drill } from '../lib/spaced-repetition';
+import { calibrateDifficulty, Performance } from '../lib/difficulty';
+import { mapToRemedialExercises } from '../lib/error-mapping';
+import { selectNextTask } from '../lib/next-task';
+
+(async () => {
+  const history: HistoryItem[] = [
+    { taskId: 't1', score: 0.9, timestamp: new Date() },
+    { taskId: 't2', score: 0.4, timestamp: new Date() },
+  ];
+  const catalog = ['t1', 't2', 't3'];
+  assert.deepEqual(recommendTasks(history, catalog, 3), ['t2', 't1', 't3']);
+
+  const drill: Drill = { id: 'd1', interval: 1, repetition: 1, ease: 2.5, due: new Date() };
+  const nextDrill = scheduleDrill(drill, 5);
+  assert.equal(isDue(nextDrill), false);
+
+  const perf: Performance = { level: 3, correct: 9, attempts: 10 };
+  assert.equal(calibrateDifficulty(perf), 4);
+
+  assert.deepEqual(mapToRemedialExercises(['grammar', 'vocabulary', 'unknown']), [
+    'grammar-basics',
+    'vocab-drill',
+  ]);
+
+  const choice = await selectNextTask({
+    history,
+    catalog,
+    performance: perf,
+    errors: ['grammar'],
+    drills: [nextDrill],
+    ai: async () => [],
+  });
+  assert.equal(choice, 'grammar-basics');
+
+  console.log('learning modules tested');
+})();

--- a/lib/difficulty/index.ts
+++ b/lib/difficulty/index.ts
@@ -1,0 +1,20 @@
+export interface Performance {
+  /** Current difficulty level */
+  level: number;
+  /** Number of correct answers */
+  correct: number;
+  /** Total attempts */
+  attempts: number;
+}
+
+/**
+ * Calibrate difficulty based on learner performance. Accuracy above 85% raises
+ * the level, below 60% lowers it.
+ */
+export function calibrateDifficulty(perf: Performance, min = 1, max = 10): number {
+  const accuracy = perf.attempts > 0 ? perf.correct / perf.attempts : 0;
+  let level = perf.level;
+  if (accuracy > 0.85) level += 1;
+  else if (accuracy < 0.6) level -= 1;
+  return Math.min(Math.max(level, min), max);
+}

--- a/lib/error-mapping/index.ts
+++ b/lib/error-mapping/index.ts
@@ -1,0 +1,26 @@
+/** Mapping of error tags to remedial exercise identifiers */
+export const remediationMap: Record<string, string[]> = {
+  grammar: ['grammar-basics'],
+  vocabulary: ['vocab-drill'],
+  pronunciation: ['pronunciation-practice'],
+};
+
+/** Count occurrences of each error tag */
+export function tagErrors(errors: string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const err of errors) {
+    counts[err] = (counts[err] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/** Map error tags to remedial exercises */
+export function mapToRemedialExercises(errors: string[]): string[] {
+  const tags = tagErrors(errors);
+  const exercises = new Set<string>();
+  for (const tag of Object.keys(tags)) {
+    const mapped = remediationMap[tag];
+    if (mapped) mapped.forEach((e) => exercises.add(e));
+  }
+  return Array.from(exercises);
+}

--- a/lib/next-task/index.ts
+++ b/lib/next-task/index.ts
@@ -1,0 +1,56 @@
+import { HistoryItem, recommendTasks } from '../recommendations';
+import { Drill, isDue } from '../spaced-repetition';
+import { Performance, calibrateDifficulty } from '../difficulty';
+import { mapToRemedialExercises } from '../error-mapping';
+
+export interface NextTaskOptions {
+  /** User history */
+  history: HistoryItem[];
+  /** All available task identifiers */
+  catalog: string[];
+  /** Performance metrics for difficulty calibration */
+  performance: Performance;
+  /** Recent error tags */
+  errors: string[];
+  /** Current drill states */
+  drills: Drill[];
+  /** Analytics hook fired when a task is chosen */
+  analytics?: (taskId: string) => void;
+  /** Optional AI provider that can pick a task from candidates */
+  ai?: (prompt: string) => Promise<string[]>;
+}
+
+/**
+ * Select the next task for the learner. Remedial exercises take precedence,
+ * followed by due drills and finally general recommendations. An optional AI
+ * provider can override the final choice.
+ */
+export async function selectNextTask(opts: NextTaskOptions): Promise<string> {
+  const level = calibrateDifficulty(opts.performance);
+  const remedial = mapToRemedialExercises(opts.errors);
+  const dueDrills = opts.drills.filter((d) => isDue(d));
+  const recs = recommendTasks(opts.history, opts.catalog);
+
+  let candidates: string[];
+  if (remedial.length) candidates = remedial;
+  else if (dueDrills.length) candidates = dueDrills.map((d) => d.id);
+  else candidates = recs;
+
+  if (opts.ai) {
+    try {
+      const aiResult = await opts.ai(
+        `Choose the best next task for level ${level} from [${candidates.join(', ')}]`
+      );
+      if (aiResult && aiResult.length) {
+        opts.analytics?.(aiResult[0]);
+        return aiResult[0];
+      }
+    } catch {
+      // ignore AI errors and fall back to other strategies
+    }
+  }
+
+  const choice = candidates[0] ?? opts.catalog[0];
+  opts.analytics?.(choice);
+  return choice;
+}

--- a/lib/recommendations/index.ts
+++ b/lib/recommendations/index.ts
@@ -1,0 +1,36 @@
+export interface HistoryItem {
+  /** Unique identifier of the task */
+  taskId: string;
+  /** Score between 0 and 1 representing performance */
+  score: number;
+  /** When the task was last attempted */
+  timestamp: Date;
+}
+
+/**
+ * Recommend the next tasks for a learner. Tasks with lower scores are
+ * prioritised. Tasks that have not been attempted are appended afterwards.
+ */
+export function recommendTasks(
+  history: HistoryItem[],
+  catalog: string[],
+  limit = 5
+): string[] {
+  // Map of task -> best score (lower means needs more practice)
+  const scores = new Map<string, number>();
+  for (const item of history) {
+    const prev = scores.get(item.taskId);
+    if (prev === undefined || item.score < prev) {
+      scores.set(item.taskId, item.score);
+    }
+  }
+
+  const attempted = new Set(scores.keys());
+  const unseen = catalog.filter((id) => !attempted.has(id));
+
+  const sorted = [...scores.entries()]
+    .sort((a, b) => a[1] - b[1])
+    .map(([id]) => id);
+
+  return [...sorted, ...unseen].slice(0, limit);
+}

--- a/lib/spaced-repetition/index.ts
+++ b/lib/spaced-repetition/index.ts
@@ -1,0 +1,39 @@
+export interface Drill {
+  /** Unique identifier for the drill */
+  id: string;
+  /** Current interval in days */
+  interval: number;
+  /** Number of successful repetitions */
+  repetition: number;
+  /** Ease factor controlling growth of interval */
+  ease: number;
+  /** Date when the drill is due */
+  due: Date;
+}
+
+/**
+ * Schedule the next review for a drill using a simplified SM-2 algorithm.
+ * @param drill Current drill state
+ * @param grade Quality of the answer from 0 (complete blackout) to 5 (perfect)
+ */
+export function scheduleDrill(drill: Drill, grade: number): Drill {
+  const ease = Math.max(1.3, drill.ease + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02)));
+  const repetition = grade < 3 ? 0 : drill.repetition + 1;
+
+  let interval: number;
+  if (repetition <= 1) interval = 1;
+  else if (repetition === 2) interval = 6;
+  else interval = Math.round(drill.interval * ease);
+
+  const due = new Date();
+  due.setDate(due.getDate() + interval);
+
+  return { id: drill.id, interval, repetition, ease, due };
+}
+
+/**
+ * Whether the drill is due for review at the given date.
+ */
+export function isDue(drill: Drill, date: Date = new Date()): boolean {
+  return drill.due.getTime() <= date.getTime();
+}


### PR DESCRIPTION
## Summary
- implement user-history based recommendations
- add spaced repetition drill scheduler
- calibrate difficulty and tag errors with remedial exercises
- integrate analytics and optional AI in next-task selector
- cover new modules with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b276da8d848321a85ca0cd7fbc5545