### PR TITLE
chore: mark client components and add SEO metadata

### DIFF
--- a/components/dashboard/ShareLinkCard.tsx
+++ b/components/dashboard/ShareLinkCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';

--- a/components/design-system/AudioRecordButton.tsx
+++ b/components/design-system/AudioRecordButton.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useEffect, useRef, useState } from 'react';
 
 export type AudioRecordButtonProps = {

--- a/components/exam/FocusGuard.tsx
+++ b/components/exam/FocusGuard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState } from 'react';
 import { Alert } from '@/components/design-system/Alert';
 import { recordFocusViolation } from '@/lib/examSecurity';

--- a/components/feature/StudyCalendar.tsx
+++ b/components/feature/StudyCalendar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card } from '@/components/design-system/Card';
 import { useStreak } from '@/hooks/useStreak';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,19 @@ const BYPASS_STRICT = process.env.BYPASS_STRICT_BUILD !== '0';
 const nextConfig = {
   reactStrictMode: true,
 
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/i,
+      issuer: /\.[jt]sx?$/,
+      type: 'asset',
+    });
+    return config;
+  },
+
   // 1) Skip ESLint during production builds (so warnings/errors won’t block)
   eslint: {
     ignoreDuringBuilds: BYPASS_STRICT,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,6 +5,23 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="GramorX IELTS practice platform" />
+        <meta name="keywords" content="IELTS, practice, exam prep" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="GramorX" />
+        <meta property="og:description" content="GramorX IELTS practice platform" />
+        <link rel="canonical" href="https://gramorx.example.com" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'GramorX',
+              url: 'https://gramorx.example.com',
+            }),
+          }}
+        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- mark browser-only components with the `use client` directive
- add responsive image formats and basic SVG handling in `next.config.mjs`
- add SEO meta tags and schema.org JSON-LD to `_document.tsx`

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Failed to fetch font `Roboto Slab`)*

------
https://chatgpt.com/codex/tasks/task_e_68b27dad4ab08321aad4f3cdee646fa6