### PR TITLE
chore: improve client rendering, SEO, and image loading

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,7 @@
 // components/sections/Header.tsx
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useTheme } from 'next-themes';
 import { Container } from '@/components/design-system/Container';
@@ -222,7 +223,14 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
             className="flex items-center gap-3 group"
             aria-label="Go to home"
           >
-            <img src="/brand/logo.png" alt="GramorX logo" className="h-11 w-11 rounded-lg object-contain" />
+            <Image
+              src="/brand/logo.png"
+              alt="GramorX logo"
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-lg object-contain"
+              priority
+            />
             <span className="font-slab font-bold text-3xl">
               <span className="text-gradient-primary group-hover:opacity-90 transition">GramorX</span>
             </span>

--- a/components/dashboard/ShareLinkCard.tsx
+++ b/components/dashboard/ShareLinkCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';

--- a/components/design-system/AudioRecordButton.tsx
+++ b/components/design-system/AudioRecordButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 
 export type AudioRecordButtonProps = {

--- a/components/exam/FocusGuard.tsx
+++ b/components/exam/FocusGuard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { Alert } from '@/components/design-system/Alert';
 import { recordFocusViolation } from '@/lib/examSecurity';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,12 @@ const BYPASS_STRICT = process.env.BYPASS_STRICT_BUILD !== '0';
 const nextConfig = {
   reactStrictMode: true,
 
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    dangerouslyAllowSVG: true,
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
+
   // 1) Skip ESLint during production builds (so warnings/errors won’t block)
   eslint: {
     ignoreDuringBuilds: BYPASS_STRICT,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,13 +5,41 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="GramorX helps you prepare for the IELTS exam with interactive lessons and mock tests." />
+        <meta name="author" content="GramorX" />
+        <link rel="canonical" href="https://gramorx.com" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="GramorX" />
+        <meta property="og:title" content="GramorX" />
+        <meta property="og:description" content="Prepare for IELTS with GramorX's comprehensive platform." />
+        <meta property="og:url" content="https://gramorx.com" />
+        <meta property="og:image" content="/brand/logo.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'GramorX',
+              url: 'https://gramorx.com',
+              potentialAction: {
+                '@type': 'SearchAction',
+                target: 'https://gramorx.com/search?q={search_term_string}',
+                'query-input': 'required name=search_term_string',
+              },
+            }),
+          }}
+        />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
- mark browser-only components with `"use client"`
- add responsive Image and configure image formats
- enhance global SEO metadata with Open Graph and schema.org tags

## Testing
- `npm test`
- `npm run lint`
- `npx @axe-core/cli http://localhost:3000` *(fails: 403 Forbidden)*
- `npx lighthouse http://localhost:3001 --quiet --chrome-flags="--headless"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b27eb693248321b87e0b91e75e4f0d