### PR TITLE
feat: improve SEO and client-side handling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,7 @@
 // components/sections/Header.tsx
+'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTheme } from 'next-themes';
@@ -222,7 +224,14 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
             className="flex items-center gap-3 group"
             aria-label="Go to home"
           >
-            <img src="/brand/logo.png" alt="GramorX logo" className="h-11 w-11 rounded-lg object-contain" />
+            <Image
+              src="/brand/logo.png"
+              alt="GramorX logo"
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-lg object-contain"
+              priority
+            />
             <span className="font-slab font-bold text-3xl">
               <span className="text-gradient-primary group-hover:opacity-90 transition">GramorX</span>
             </span>

--- a/components/design-system/AvatarUploader.tsx
+++ b/components/design-system/AvatarUploader.tsx
@@ -1,5 +1,7 @@
+"use client";
 import { env } from "@/lib/env";
 import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
 import { Alert } from './Alert';
 import { Button } from './Button';
@@ -92,9 +94,11 @@ export const AvatarUploader: React.FC<Props> = ({
         onClick={() => inputRef.current?.click()}
       >
         {preview ? (
-          <img
+          <Image
             src={preview}
             alt="Avatar preview"
+            width={112}
+            height={112}
             className="mx-auto h-28 w-28 rounded-full object-cover ring-2 ring-primary/40"
           />
         ) : (

--- a/components/feature/StudyCalendar.tsx
+++ b/components/feature/StudyCalendar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card } from '@/components/design-system/Card';
 import { useStreak } from '@/hooks/useStreak';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,11 @@ const BYPASS_STRICT = process.env.BYPASS_STRICT_BUILD !== '0';
 const nextConfig = {
   reactStrictMode: true,
 
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [320, 420, 768, 1024, 1200],
+  },
+
   // 1) Skip ESLint during production builds (so warnings/errors won’t block)
   eslint: {
     ignoreDuringBuilds: BYPASS_STRICT,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,6 +5,14 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="GramorX – AI-powered IELTS preparation platform" />
+        <meta name="keywords" content="IELTS, exam prep, English learning" />
+        <meta property="og:title" content="GramorX" />
+        <meta property="og:description" content="AI-powered IELTS preparation platform" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://gramorx.example.com" />
+        <meta property="og:image" content="/brand/logo.png" />
+        <meta name="twitter:card" content="summary_large_image" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
@@ -12,6 +20,18 @@ export default function Document() {
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: 'GramorX',
+              url: 'https://gramorx.example.com',
+              logo: '/brand/logo.png',
+            }),
+          }}
+        />
       </Head>
       <body>
         <Main />

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -19,7 +19,8 @@ import { HeaderStreakChip } from '@/components/feature/HeaderStreakChip';
 
 import { useStreak } from '@/hooks/useStreak';
 import { getDayKeyInTZ } from '@/lib/streak';
-import StudyCalendar from '@/components/feature/StudyCalendar';
+import dynamic from 'next/dynamic';
+const StudyCalendar = dynamic(() => import('@/components/feature/StudyCalendar'), { ssr: false });
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
 import GapToGoal from '@/components/visa/GapToGoal';
 import MotivationCoach from '@/components/coach/MotivationCoach';


### PR DESCRIPTION
## Summary
- add client directives and dynamic import for browser-only components
- use Next.js Image for logos and avatar previews
- enhance SEO with meta and schema tags

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Failed to fetch font `Poppins`)*
- `npx lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lighthouse)*

------
https://chatgpt.com/codex/tasks/task_e_68b281736ea88321b12d869450ed42ae