### PR TITLE
Improve client-only components, SEO metadata, and image handling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,8 @@
 // components/sections/Header.tsx
+"use client";
+
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTheme } from 'next-themes';
@@ -7,8 +10,10 @@ import { Container } from '@/components/design-system/Container';
 import { NavLink } from '@/components/design-system/NavLink';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { UserMenu } from '@/components/design-system/UserMenu';
-import { NotificationBell } from '@/components/design-system/NotificationBell';
+import dynamic from 'next/dynamic';
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+
+const NotificationBell = dynamic(() => import('@/components/design-system/NotificationBell'), { ssr: false });
 
 type ModuleLink = { label: string; href: string; desc?: string };
 
@@ -222,7 +227,15 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
             className="flex items-center gap-3 group"
             aria-label="Go to home"
           >
-            <img src="/brand/logo.png" alt="GramorX logo" className="h-11 w-11 rounded-lg object-contain" />
+            <Image
+              src="/brand/logo.png"
+              alt="GramorX logo"
+              width={44}
+              height={44}
+              priority
+              sizes="44px"
+              className="h-11 w-11 rounded-lg object-contain"
+            />
             <span className="font-slab font-bold text-3xl">
               <span className="text-gradient-primary group-hover:opacity-90 transition">GramorX</span>
             </span>

--- a/components/design-system/AudioRecordButton.tsx
+++ b/components/design-system/AudioRecordButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 
 export type AudioRecordButtonProps = {

--- a/components/design-system/AvatarUploader.tsx
+++ b/components/design-system/AvatarUploader.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { env } from "@/lib/env";
 import React, { useEffect, useRef, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';

--- a/components/design-system/UserMenu.tsx
+++ b/components/design-system/UserMenu.tsx
@@ -1,4 +1,6 @@
 // components/design-system/UserMenu.tsx
+"use client";
+
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
@@ -124,7 +126,7 @@ export const UserMenu: React.FC<{
         {localAvatar ? (
           // Using <img> here to avoid Next remote domain config issues
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={localAvatar} alt="" className="h-9 w-9 rounded-full object-cover" decoding="async" />
+          <img src={localAvatar} alt="User avatar" className="h-9 w-9 rounded-full object-cover" decoding="async" />
         ) : (
           fallbackInitial
         )}
@@ -145,7 +147,7 @@ export const UserMenu: React.FC<{
                 <div className="h-9 w-9 rounded-full bg-vibrantPurple/15 flex items-center justify-center overflow-hidden">
                   {localAvatar ? (
                     // eslint-disable-next-line @next/next/no-img-element
-                    <img src={localAvatar} alt="" className="h-9 w-9 object-cover" decoding="async" />
+                    <img src={localAvatar} alt="User avatar" className="h-9 w-9 object-cover" decoding="async" />
                   ) : (
                     <span className="text-vibrantPurple font-semibold">{fallbackInitial}</span>
                   )}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,19 @@ const BYPASS_STRICT = process.env.BYPASS_STRICT_BUILD !== '0';
 const nextConfig = {
   reactStrictMode: true,
 
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.svg$/i,
+      issuer: /\.[jt]sx?$/,
+      use: ['@svgr/webpack'],
+    });
+    return config;
+  },
+
   // 1) Skip ESLint during production builds (so warnings/errors won’t block)
   eslint: {
     ignoreDuringBuilds: BYPASS_STRICT,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,6 +5,34 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="GramorX offers practice modules to master IELTS listening, reading, writing and speaking."
+        />
+        <meta
+          name="keywords"
+          content="IELTS, language learning, listening, reading, writing, speaking"
+        />
+        <meta property="og:title" content="GramorX" />
+        <meta
+          property="og:description"
+          content="Practice modules for IELTS listening, reading, writing and speaking."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://gramorx.com" />
+        <meta property="og:image" content="/brand/og-image.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'GramorX',
+              url: 'https://gramorx.com',
+            }),
+          }}
+        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -69,7 +69,14 @@ export default function BlogPostPage({ ok, post }: Props) {
                 {/* Content */}
                 <Card className="p-6 rounded-ds-2xl">
                   <div className="aspect-video rounded-ds bg-gradient-to-br from-primary/15 to-accent/15 mb-6 overflow-hidden">
-                    {post.hero_image_url ? <img src={post.hero_image_url} alt="" className="w-full h-full object-cover" /> : null}
+                    {post.hero_image_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={post.hero_image_url}
+                        alt={post.title ? `${post.title} hero image` : 'Blog hero image'}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : null}
                   </div>
                   <article className="prose prose-neutral dark:prose-invert max-w-none">
                     {/* Minimal markdown display (paragraph split) to avoid extra deps */}

--- a/pages/learning/[slug].tsx
+++ b/pages/learning/[slug].tsx
@@ -212,7 +212,11 @@ export default function CourseDetailPage() {
           <Card className="p-0 rounded-ds-2xl overflow-hidden">
             {course.thumbnail_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={course.thumbnail_url} alt="" className="h-64 w-full object-cover" />
+              <img
+                src={course.thumbnail_url}
+                alt={course.title ? `${course.title} thumbnail` : 'Course thumbnail'}
+                className="h-64 w-full object-cover"
+              />
             ) : (
               <div className="h-64 w-full bg-purpleVibe/10" />
             )}


### PR DESCRIPTION
## Summary
- mark browser-only widgets with `use client` directives
- add image and SVG optimization in Next.js config and swap logo to `<Image>`
- expand `_document.tsx` with SEO meta tags and Schema.org JSON-LD
- ensure accessible alt text for images on blog and learning pages

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Poppins` and `Roboto Slab` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b2813c161083218115edf54d01d539