### PR TITLE
chore: optimize client assets

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,7 @@
 // components/sections/Header.tsx
+'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTheme } from 'next-themes';
@@ -222,7 +224,14 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
             className="flex items-center gap-3 group"
             aria-label="Go to home"
           >
-            <img src="/brand/logo.png" alt="GramorX logo" className="h-11 w-11 rounded-lg object-contain" />
+            <Image
+              src="/brand/logo.png"
+              alt="GramorX logo"
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-lg object-contain"
+              priority
+            />
             <span className="font-slab font-bold text-3xl">
               <span className="text-gradient-primary group-hover:opacity-90 transition">GramorX</span>
             </span>

--- a/components/design-system/AudioRecordButton.tsx
+++ b/components/design-system/AudioRecordButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect, useRef, useState } from 'react';
 
 export type AudioRecordButtonProps = {

--- a/components/reading/useReadingAnswers.ts
+++ b/components/reading/useReadingAnswers.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useMemo, useState } from 'react';
 
 /**

--- a/components/speaking/useSpeech.ts
+++ b/components/speaking/useSpeech.ts
@@ -1,3 +1,4 @@
+'use client';
 // components/speaking/useSpeech.ts
 import { useEffect, useRef, useState } from 'react';
 

--- a/components/speaking/useTTS.ts
+++ b/components/speaking/useTTS.ts
@@ -1,3 +1,4 @@
+'use client';
 // components/speaking/useTTS.ts
 export type Accent = 'UK' | 'US' | 'AUS';
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,13 @@ const nextConfig = {
     ignoreBuildErrors: BYPASS_STRICT,
   },
 
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'inline',
+  },
+
   // …any other Next config you already have
 };
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,13 +5,47 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="GramorX is an AI-powered platform for personalised IELTS preparation."
+        />
+        <meta
+          name="keywords"
+          content="IELTS, test prep, artificial intelligence, grammar"
+        />
+        <meta property="og:title" content="GramorX – AI IELTS Prep" />
+        <meta
+          property="og:description"
+          content="Achieve your IELTS goals with adaptive practice and real-time feedback."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://gramorx.example.com/" />
+        <meta property="og:image" content="/brand/og-image.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+        />
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: 'GramorX',
+              url: 'https://gramorx.example.com',
+              logo: '/brand/logo.png',
+            }),
+          }}
+        />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
- mark browser-only hooks and components with `use client`
- serve header logo through `next/image` and enable modern formats
- add SEO metadata and schema.org block in custom document

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Failed to fetch `Poppins` from Google Fonts)*
- `npx lighthouse https://example.com --quiet` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b282b96f608321bf2826263702f1b4