### PR TITLE
chore: improve seo metadata and client-only hooks

### DIFF
--- a/components/admin/ImpersonationBanner.tsx
+++ b/components/admin/ImpersonationBanner.tsx
@@ -1,3 +1,4 @@
+"use client";
 // components/admin/ImpersonationBanner.tsx
 import React, { useEffect, useState } from 'react';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';

--- a/components/exam/FocusGuard.tsx
+++ b/components/exam/FocusGuard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState } from 'react';
 import { Alert } from '@/components/design-system/Alert';
 import { recordFocusViolation } from '@/lib/examSecurity';

--- a/hooks/useCountdown.ts
+++ b/hooks/useCountdown.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useRef, useState } from "react";
 
 export function useCountdown(totalSeconds: number, autoStart = false) {

--- a/hooks/useTTS.ts
+++ b/hooks/useTTS.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useRef, useState } from "react";
 
 export function useTTS() {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,12 +13,6 @@ const BYPASS_STRICT = process.env.BYPASS_STRICT_BUILD !== '0';
 
 const nextConfig = {
   reactStrictMode: true,
-
-  images: {
-    formats: ['image/avif', 'image/webp'],
-    deviceSizes: [320, 420, 768, 1024, 1200],
-  },
-
   // 1) Skip ESLint during production builds (so warnings/errors won’t block)
   eslint: {
     ignoreDuringBuilds: BYPASS_STRICT,
@@ -31,7 +25,7 @@ const nextConfig = {
 
   images: {
     formats: ['image/avif', 'image/webp'],
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    deviceSizes: [320, 420, 640, 750, 768, 828, 1024, 1080, 1200, 1920],
     dangerouslyAllowSVG: true,
     contentDispositionType: 'inline',
   },

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <meta charSet="utf-8" />
         {/* Do NOT include viewport meta here (Next.js warns). Use per-page <Head>. */}
 
         {/* Base SEO */}
@@ -15,9 +16,13 @@ export default function Document() {
           name="keywords"
           content="IELTS, exam prep, English learning, AI, listening, reading, writing, speaking"
         />
+        <meta name="robots" content="index,follow" />
+        <meta name="author" content="GramorX" />
+        <link rel="canonical" href="https://gramorx.com" />
 
         {/* Open Graph / Twitter */}
         <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="GramorX" />
         <meta property="og:title" content="GramorX – AI IELTS Prep" />
         <meta
           property="og:description"
@@ -54,6 +59,23 @@ export default function Document() {
               name: 'GramorX',
               url: 'https://gramorx.com',
               logo: '/brand/logo.png',
+            }),
+          }}
+        />
+        {/* JSON-LD: WebSite */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'GramorX',
+              url: 'https://gramorx.com',
+              potentialAction: {
+                '@type': 'SearchAction',
+                target: 'https://gramorx.com/search?q={search_term_string}',
+                'query-input': 'required name=search_term_string',
+              },
             }),
           }}
         />


### PR DESCRIPTION
## Summary
- mark browser-only components and hooks with `"use client"`
- consolidate image settings for responsive AVIF/WEBP output
- expand global SEO metadata and schema in custom Document

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31ed35ab08321bac81ccecdfb89a0