### PR TITLE
Fix send-otp error handling

### DIFF
--- a/pages/api/send-otp.ts
+++ b/pages/api/send-otp.ts
@@ -65,4 +65,7 @@ export default async function handler(
   } catch (err) {
     console.error('Verify start error', err);
     const message = err instanceof Error ? err.message : 'Unknown error';
-    return res.status(500).json({ o
+    return res.status(500).json({ ok: false, error: message });
+  }
+}
+


### PR DESCRIPTION
## Summary
- Replace truncated error response in send-otp API with structured JSON
- Close the catch block and handler function properly

## Testing
- `npm test` *(fails: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal: 200 !== undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b3825de1c08321802f2a81a30ea8f1