### PR TITLE
Include auth verify page in auth layout exclusion

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -60,7 +60,7 @@ function InnerApp({ Component, pageProps }: AppProps) {
   const isAuthPage = useMemo(
     () =>
       /^\/(login|signup|register)(\/|$)/.test(pathname) ||
-      /^\/auth\/(login|signup|register)(\/|$)/.test(pathname),
+      /^\/auth\/(login|signup|register|verify)(\/|$)/.test(pathname),
     [pathname]
   );
 


### PR DESCRIPTION
## Summary
- treat `/auth/verify` as an auth page so it isn't wrapped in the main layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38b94cf0c8321ad951acbaa027ff9