### PR TITLE
refactor auth side panel

### DIFF
--- a/components/layouts/AuthSidePanel.tsx
+++ b/components/layouts/AuthSidePanel.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Image from 'next/image';
+
+export interface AuthSidePanelProps {
+  title: string;
+  description: React.ReactNode;
+  features?: React.ReactNode[];
+  footerLink?: React.ReactNode;
+}
+
+export default function AuthSidePanel({ title, description, features, footerLink }: AuthSidePanelProps) {
+  return (
+    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
+      <div>
+        <div className="flex items-center gap-3 mb-6">
+          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
+          <h2 className="font-slab text-h2 text-gradient-primary">{title}</h2>
+        </div>
+        <p className="text-body text-grayish dark:text-gray-300 max-w-md">{description}</p>
+        {features && features.length > 0 && (
+          <ul className="mt-6 space-y-3 text-body text-grayish dark:text-gray-300">
+            {features.map((feature, idx) => (
+              <li key={idx} className="flex items-center gap-3">
+                {feature}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {footerLink && <div className="pt-8 text-small text-grayish dark:text-gray-400">{footerLink}</div>}
+    </div>
+  );
+}
+

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Input } from '@/components/design-system/Input';
 import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
@@ -80,20 +80,18 @@ export default function LoginWithEmail() {
   }
 
   const RightPanel = (
-    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
-          <h2 className="font-slab text-h2 text-gradient-primary">Sign in to GramorX</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">
-          Access all IELTS modules with progress tracking & AI feedback.
-        </p>
-      </div>
-      <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        New here? <Link href="/signup" className="text-primaryDark hover:underline">Create an account</Link>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Sign in to GramorX"
+      description="Access all IELTS modules with progress tracking & AI feedback."
+      footerLink={
+        <>
+          New here?{' '}
+          <Link href="/signup" className="text-primaryDark hover:underline">
+            Create an account
+          </Link>
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -81,62 +81,52 @@ export default function LoginOptions() {
     }
   }
 
-  // Right-side: soft brand panel (no Card), token gradients, light/dark compliant
+  const features = [
+    (
+      <>
+        <i className="fas fa-shield-alt text-success" aria-hidden />
+        Secure OAuth (Apple, Google, Facebook)
+      </>
+    ),
+    (
+      <>
+        <i className="fas fa-mobile-alt" aria-hidden />
+        Phone OTP sign-in
+      </>
+    ),
+    (
+      <>
+        <i className="fas fa-envelope" aria-hidden />
+        Email &amp; Password
+      </>
+    ),
+    (
+      <>
+        <i className="fas fa-chart-line text-electricBlue" aria-hidden />
+        Personalized study plan &amp; analytics
+      </>
+    ),
+  ];
+
   const RightPanel = (
-    <div className="hidden md:flex w-1/2">
-      <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image
-            src="/brand/logo.png"
-            alt="GramorX"
-            width={40}
-            height={40}
-            className="rounded-ds object-contain"
-            priority
-          />
-          <h2 className="font-slab text-h2 text-gradient-primary">Sign in to GramorX</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">
-          One account for all IELTS modules — Listening, Reading, Writing, and Speaking — with AI
-          feedback and progress tracking.
-        </p>
-
-        <ul className="mt-6 space-y-3 text-body text-grayish dark:text-gray-300">
-          <li className="flex items-center gap-3">
-            <i className="fas fa-shield-alt text-success" aria-hidden />
-            Secure OAuth (Apple, Google, Facebook)
-          </li>
-          <li className="flex items-center gap-3">
-            <i className="fas fa-mobile-alt" aria-hidden />
-            Phone OTP sign-in
-          </li>
-          <li className="flex items-center gap-3">
-            <i className="fas fa-envelope" aria-hidden />
-            Email &amp; Password
-          </li>
-          <li className="flex items-center gap-3">
-            <i className="fas fa-chart-line text-electricBlue" aria-hidden />
-            Personalized study plan &amp; analytics
-          </li>
-        </ul>
-      </div>
-
-        <div className="pt-8">
-          <div className="text-small text-grayish dark:text-gray-400">
-            By continuing, you agree to our{' '}
-            <Link href="/legal/terms" className="text-primaryDark hover:underline">
-              Terms
-            </Link>{' '}
-            and{' '}
-            <Link href="/legal/privacy" className="text-primaryDark hover:underline">
-              Privacy Policy
-            </Link>
-            .
-          </div>
-        </div>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Sign in to GramorX"
+      description="One account for all IELTS modules — Listening, Reading, Writing, and Speaking — with AI feedback and progress tracking."
+      features={features}
+      footerLink={
+        <>
+          By continuing, you agree to our{' '}
+          <Link href="/legal/terms" className="text-primaryDark hover:underline">
+            Terms
+          </Link>{' '}
+          and{' '}
+          <Link href="/legal/privacy" className="text-primaryDark hover:underline">
+            Privacy Policy
+          </Link>
+          .
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Input } from '@/components/design-system/Input';
 import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
@@ -80,20 +80,18 @@ export default function LoginWithPassword() {
   }
 
   const RightPanel = (
-    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
-          <h2 className="font-slab text-h2 text-gradient-primary">Welcome back</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">
-          Continue where you left off across Listening, Reading, Writing & Speaking.
-        </p>
-      </div>
-      <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Need an account? <Link href="/signup" className="text-primary hover:underline">Sign up</Link>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Welcome back"
+      description="Continue where you left off across Listening, Reading, Writing & Speaking."
+      footerLink={
+        <>
+          Need an account?{' '}
+          <Link href="/signup" className="text-primary hover:underline">
+            Sign up
+          </Link>
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Input } from '@/components/design-system/Input';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
@@ -103,18 +103,18 @@ export default function LoginWithPhone() {
   }
 
   const RightPanel = (
-    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
-          <h2 className="font-slab text-h2 text-gradient-primary">Phone sign-in</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">Use a one-time SMS code to sign in.</p>
-      </div>
-      <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Prefer email? <Link href="/login/email" className="text-primary hover:underline">Use email &amp; password</Link>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Phone sign-in"
+      description="Use a one-time SMS code to sign in."
+      footerLink={
+        <>
+          Prefer email?{' '}
+          <Link href="/login/email" className="text-primary hover:underline">
+            Use email &amp; password
+          </Link>
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Button } from '@/components/design-system/Button';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 
@@ -26,26 +26,41 @@ export default function SignupOptions() {
     }
   }
 
+  const features = [
+    (
+      <>
+        <i className="fas fa-user-check" aria-hidden />
+        Apple / Google / Facebook
+      </>
+    ),
+    (
+      <>
+        <i className="fas fa-envelope" aria-hidden />
+        Email &amp; password
+      </>
+    ),
+    (
+      <>
+        <i className="fas fa-mobile-alt" aria-hidden />
+        Phone (OTP)
+      </>
+    ),
+  ];
+
   const RightPanel = (
-    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
-          <h2 className="font-slab text-h2 text-gradient-primary">Create your account</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">
-          Start your IELTS journey with AI support and personalized plans.
-        </p>
-        <ul className="mt-6 space-y-3 text-body text-grayish dark:text-gray-300">
-          <li className="flex items-center gap-3"><i className="fas fa-user-check" aria-hidden />Apple / Google / Facebook</li>
-          <li className="flex items-center gap-3"><i className="fas fa-envelope" aria-hidden />Email & password</li>
-          <li className="flex items-center gap-3"><i className="fas fa-mobile-alt" aria-hidden />Phone (OTP)</li>
-        </ul>
-      </div>
-      <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Already have an account? <Link href="/login" className="text-primaryDark hover:underline">Log in</Link>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Create your account"
+      description="Start your IELTS journey with AI support and personalized plans."
+      features={features}
+      footerLink={
+        <>
+          Already have an account?{' '}
+          <Link href="/login" className="text-primaryDark hover:underline">
+            Log in
+          </Link>
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Input } from '@/components/design-system/Input';
 import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
@@ -85,16 +85,18 @@ export default function SignupWithPassword() {
   }
 
   const RightPanel = (
-    <div className="hidden md:flex w-1/2 relative items-center justify-center bg-primary/10 dark:bg-dark">
-      <Image
-        src="/brand/logo.png"
-        alt="GramorX Logo"
-        width={420}
-        height={420}
-        className="object-contain"
-        priority
-      />
-    </div>
+    <AuthSidePanel
+      title="Create your account"
+      description="Use your email & password to get started."
+      footerLink={
+        <>
+          Already have an account?{' '}
+          <Link href="/login" className="text-primaryDark hover:underline">
+            Log in
+          </Link>
+        </>
+      }
+    />
   );
 
   return (

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
+import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Input } from '@/components/design-system/Input';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
@@ -129,18 +129,18 @@ export default function SignupWithPhone() {
   }
 
   const RightPanel = (
-    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
-      <div>
-        <div className="flex items-center gap-3 mb-6">
-          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
-          <h2 className="font-slab text-h2 text-gradient-primary">Phone sign-up</h2>
-        </div>
-        <p className="text-body text-grayish dark:text-gray-300 max-w-md">Create your account with a one-time SMS code.</p>
-      </div>
-      <div className="pt-8 text-small text-grayish dark:text-gray-400">
-        Prefer email? <Link href="/signup/password" className="text-primaryDark hover:underline">Use Email & Password</Link>
-      </div>
-    </div>
+    <AuthSidePanel
+      title="Phone sign-up"
+      description="Create your account with a one-time SMS code."
+      footerLink={
+        <>
+          Prefer email?{' '}
+          <Link href="/signup/password" className="text-primaryDark hover:underline">
+            Use Email &amp; Password
+          </Link>
+        </>
+      }
+    />
   );
 
   return (


### PR DESCRIPTION
## Summary
- add reusable `AuthSidePanel` layout for gradient background, logo, title, optional features and footer link
- replace inline right panel markup in login and signup pages with `AuthSidePanel`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38eef8b8883219ae67c2e1347859e