### PR TITLE
Use fullWidth Button prop in auth pages

### DIFF
--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -124,23 +124,23 @@ export default function LoginWithEmail() {
             autoComplete="current-password"
             required
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={loading}>
             {loading ? 'Signing in…' : 'Continue'}
           </Button>
-          <Button asChild variant="secondary" className="mt-4 w-full rounded-ds-xl">
+          <Button asChild variant="secondary" className="mt-4 rounded-ds-xl" fullWidth>
             <Link href="/forgot-password">Forgot password?</Link>
           </Button>
         </form>
       ) : (
         <form onSubmit={verifyOtp} className="space-y-6 mt-2 max-w-xs">
           <Input label="Enter OTP" value={otp} onChange={e => setOtp(e.target.value)} autoComplete="one-time-code" placeholder="6-digit code" required />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={verifying}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={verifying}>
             {verifying ? 'Verifying…' : 'Verify'}
           </Button>
         </form>
       )}
 
-      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
+      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl" fullWidth>
         <Link href="/login">Back to Login Options</Link>
       </Button>
     </AuthLayout>

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -155,10 +155,10 @@ export default function LoginOptions() {
         <>
           <SectionLabel>Sign in as</SectionLabel>
           <div className="grid gap-3">
-            <Button onClick={() => chooseRole('student')} variant="secondary" className="rounded-ds-xl w-full">
+            <Button onClick={() => chooseRole('student')} variant="secondary" className="rounded-ds-xl" fullWidth>
               Student
             </Button>
-            <Button onClick={() => chooseRole('teacher')} variant="secondary" className="rounded-ds-xl w-full">
+            <Button onClick={() => chooseRole('teacher')} variant="secondary" className="rounded-ds-xl" fullWidth>
               Teacher
             </Button>
           </div>
@@ -172,7 +172,8 @@ export default function LoginOptions() {
               onClick={() => oauth('apple')}
               disabled={busy === 'apple'}
               variant="secondary"
-              className="rounded-ds-xl w-full"
+              className="rounded-ds-xl"
+              fullWidth
             >
               <span className="inline-flex items-center gap-3">
                 <i className="fab fa-apple text-xl" aria-hidden />
@@ -184,7 +185,8 @@ export default function LoginOptions() {
               onClick={() => oauth('google')}
               disabled={busy === 'google'}
               variant="secondary"
-              className="rounded-ds-xl w-full"
+              className="rounded-ds-xl"
+              fullWidth
             >
               <span className="inline-flex items-center gap-3">
                 <i className="fab fa-google text-xl" aria-hidden />
@@ -196,7 +198,8 @@ export default function LoginOptions() {
               onClick={() => oauth('facebook')}
               disabled={busy === 'facebook'}
               variant="secondary"
-              className="rounded-ds-xl w-full"
+              className="rounded-ds-xl"
+              fullWidth
             >
               <span className="inline-flex items-center gap-3">
                 <i className="fab fa-facebook-f text-xl" aria-hidden />
@@ -204,7 +207,7 @@ export default function LoginOptions() {
               </span>
             </Button>
 
-            <Button asChild variant="secondary" className="rounded-ds-xl w-full">
+            <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
               <Link
                 href={`/login/email${selectedRole ? `?role=${selectedRole}` : ''}`}
                 aria-label="Sign in with Email and Password"
@@ -216,7 +219,7 @@ export default function LoginOptions() {
               </Link>
             </Button>
 
-            <Button asChild variant="secondary" className="rounded-ds-xl w-full">
+            <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
               <Link
                 href={`/login/phone${selectedRole ? `?role=${selectedRole}` : ''}`}
                 aria-label="Sign in with Phone OTP"

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -124,23 +124,23 @@ export default function LoginWithPassword() {
             autoComplete="current-password"
             required
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={loading}>
             {loading ? 'Signing in…' : 'Continue'}
           </Button>
-          <Button asChild variant="secondary" className="mt-4 w-full rounded-ds-xl">
+          <Button asChild variant="secondary" className="mt-4 rounded-ds-xl" fullWidth>
             <Link href="/forgot-password">Forgot password?</Link>
           </Button>
         </form>
       ) : (
         <form onSubmit={verifyOtp} className="space-y-6 mt-2 max-w-xs">
           <Input label="Enter OTP" value={otp} onChange={e => setOtp(e.target.value)} autoComplete="one-time-code" placeholder="6-digit code" required />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={verifying}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={verifying}>
             {verifying ? 'Verifying…' : 'Verify'}
           </Button>
         </form>
       )}
 
-      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
+      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl" fullWidth>
         <Link href="/login">Back to Login Options</Link>
       </Button>
     </AuthLayout>

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -137,7 +137,7 @@ export default function LoginWithPhone() {
             hint="Use E.164 format, e.g. +923001234567"
             error={phoneErr ?? undefined}
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>
         </form>
@@ -154,7 +154,8 @@ export default function LoginWithPhone() {
           <Button
             type="submit"
             variant="primary"
-            className="w-full rounded-ds-xl"
+            className="rounded-ds-xl"
+            fullWidth
             disabled={loading && !resending}
           >
             {loading && !resending ? 'Verifying…' : 'Verify & Continue'}
@@ -162,7 +163,8 @@ export default function LoginWithPhone() {
           <Button
             type="button"
             variant="secondary"
-            className="w-full rounded-ds-xl"
+            className="rounded-ds-xl"
+            fullWidth
             onClick={resendOtp}
             disabled={loading || cooldown > 0 || resendAttempts >= MAX_RESENDS}
           >
@@ -184,7 +186,7 @@ export default function LoginWithPhone() {
         </form>
       )}
 
-      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
+      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl" fullWidth>
         <Link href="/login">Back to Login Options</Link>
       </Button>
     </AuthLayout>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -51,21 +51,21 @@ export default function SignupOptions() {
   return (
     <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method." right={RightPanel}>
       <div className="grid gap-3">
-        <Button onClick={() => signUpOAuth('apple')} variant="secondary" className="rounded-ds-xl w-full">
+        <Button onClick={() => signUpOAuth('apple')} variant="secondary" className="rounded-ds-xl" fullWidth>
           <span className="inline-flex items-center gap-3"><i className="fab fa-apple text-xl" aria-hidden /> Sign up with Apple</span>
         </Button>
-        <Button onClick={() => signUpOAuth('google')} variant="secondary" className="rounded-ds-xl w-full">
+        <Button onClick={() => signUpOAuth('google')} variant="secondary" className="rounded-ds-xl" fullWidth>
           <span className="inline-flex items-center gap-3"><i className="fab fa-google text-xl" aria-hidden /> Sign up with Google</span>
         </Button>
-        <Button onClick={() => signUpOAuth('facebook')} variant="secondary" className="rounded-ds-xl w-full">
+        <Button onClick={() => signUpOAuth('facebook')} variant="secondary" className="rounded-ds-xl" fullWidth>
           <span className="inline-flex items-center gap-3"><i className="fab fa-facebook-f text-xl" aria-hidden /> Sign up with Facebook</span>
         </Button>
-        <Button asChild variant="secondary" className="rounded-ds-xl w-full">
+        <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
           <Link href={`/signup/password${ref ? `?ref=${ref}` : ''}`}>
             <span className="inline-flex items-center gap-3"><i className="fas fa-envelope text-xl" aria-hidden /> Sign up with Email</span>
           </Link>
         </Button>
-        <Button asChild variant="secondary" className="rounded-ds-xl w-full">
+        <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
           <Link href={`/signup/phone${ref ? `?ref=${ref}` : ''}`}>
             <span className="inline-flex items-center gap-3"><i className="fas fa-sms text-xl" aria-hidden /> Sign up with Phone</span>
           </Link>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -151,7 +151,8 @@ export default function SignupWithPassword() {
         <Button
           type="submit"
           variant="primary"
-          className="w-full rounded-ds-xl"
+          className="rounded-ds-xl"
+          fullWidth
           disabled={loading}
         >
           {loading ? 'Creating…' : 'Create account'}
@@ -159,10 +160,10 @@ export default function SignupWithPassword() {
       </form>
 
       <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <Button asChild variant="secondary" className="rounded-ds-xl w-full">
+        <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
           <Link href="/signup">Back to Sign-up Options</Link>
         </Button>
-        <Button asChild variant="ghost" className="rounded-ds-xl w-full">
+        <Button asChild variant="ghost" className="rounded-ds-xl" fullWidth>
           <Link href="/login">Already have an account? Log in</Link>
         </Button>
       </div>

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -168,20 +168,21 @@ export default function SignupWithPhone() {
             value={referral}
             onChange={(e) => setReferral(e.target.value)}
           />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={loading}>
             {loading ? 'Sending…' : 'Send code'}
           </Button>
         </form>
       ) : (
         <form onSubmit={verifyOtp} className="space-y-6 mt-2">
           <Input label="Verification code" inputMode="numeric" placeholder="123456" value={code} onChange={(e)=>setCode(e.target.value)} required />
-          <Button type="submit" variant="primary" className="w-full rounded-ds-xl" disabled={loading && !resending}>
+          <Button type="submit" variant="primary" className="rounded-ds-xl" fullWidth disabled={loading && !resending}>
             {loading && !resending ? 'Verifying…' : 'Verify & Continue'}
           </Button>
           <Button
             type="button"
             variant="secondary"
-            className="w-full rounded-ds-xl"
+            className="rounded-ds-xl"
+            fullWidth
             onClick={resendOtp}
             disabled={loading || cooldown > 0 || resendAttempts >= MAX_RESENDS}
           >
@@ -203,7 +204,7 @@ export default function SignupWithPhone() {
         </form>
       )}
 
-      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl w-full">
+      <Button asChild variant="secondary" className="mt-6 rounded-ds-xl" fullWidth>
         <Link href="/signup">Back to Sign-up Options</Link>
       </Button>
     </AuthLayout>


### PR DESCRIPTION
## Summary
- replace manual `w-full` classes with the `fullWidth` prop on login and signup buttons
- retain shape styling like `rounded-ds-xl`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38ef518cc83218cc96c88ecb95517