### PR TITLE
feat(auth): unify right panel gradient

### DIFF
--- a/components/layouts/AuthLayout.tsx
+++ b/components/layouts/AuthLayout.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 const DefaultRight = () => (
-  <div className="relative w-full h-full flex items-center justify-center bg-primary/10 dark:bg-dark">
+  <div className="h-full flex items-center justify-center p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
     <Image src="/brand/logo.png" alt="GramorX Logo" width={420} height={420} className="object-contain" />
   </div>
 );

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -1,7 +1,6 @@
 // pages/auth/verify.tsx
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
-import Image from 'next/image';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
@@ -59,22 +58,7 @@ export default function VerifyPage() {
       : 'Check your inbox for a verification link.';
 
   return (
-    <AuthLayout
-      title="Verify your account"
-      subtitle={subtitle}
-      right={
-        <div className="relative w-full h-full flex items-center justify-center bg-primary/10 dark:bg-dark">
-          <Image
-            src="/brand/logo.png"
-            alt="GramorX Logo"
-            width={420}
-            height={420}
-            className="object-contain"
-          />
-        </div>
-      }
-      showRightOnMobile
-    >
+    <AuthLayout title="Verify your account" subtitle={subtitle} showRightOnMobile>
       {error ? (
         <Alert variant="error" title="Verification error" className="mt-4">
           {error}

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -85,15 +85,22 @@ export default function SignupWithPassword() {
   }
 
   const RightPanel = (
-    <div className="hidden md:flex w-1/2 relative items-center justify-center bg-primary/10 dark:bg-dark">
-      <Image
-        src="/brand/logo.png"
-        alt="GramorX Logo"
-        width={420}
-        height={420}
-        className="object-contain"
-        priority
-      />
+    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
+      <div>
+        <div className="flex items-center gap-3 mb-6">
+          <Image src="/brand/logo.png" alt="GramorX" width={40} height={40} className="rounded-ds object-contain" priority />
+          <h2 className="font-slab text-h2 text-gradient-primary">Email sign-up</h2>
+        </div>
+        <p className="text-body text-grayish dark:text-gray-300 max-w-md">
+          Create your account using email & password.
+        </p>
+      </div>
+      <div className="pt-8 text-small text-grayish dark:text-gray-400">
+        Prefer phone?{' '}
+        <Link href="/signup/phone" className="text-primaryDark hover:underline">
+          Use Phone (OTP)
+        </Link>
+      </div>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- apply shared gradient panel to email signup
- switch AuthLayout default right panel to gradient
- streamline verify page to use default gradient panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38ef698688321baac646f2c1a6617