### PR TITLE
feat: responsive auth layout with mobile brand panel

### DIFF
--- a/components/layouts/AuthLayout.tsx
+++ b/components/layouts/AuthLayout.tsx
@@ -15,14 +15,20 @@ type Props = {
   right?: React.ReactNode;
   rightIllustration?: React.ReactNode;
   /**
-   * Show the right panel on mobile view. Hidden by default.
+   * Render a condensed brand panel on mobile screens. Hidden by default.
    */
   showRightOnMobile?: boolean;
 };
 
 const DefaultRight = () => (
   <div className="relative w-full h-full flex items-center justify-center bg-primary/10 dark:bg-dark">
-    <Image src="/brand/logo.png" alt="GramorX Logo" width={420} height={420} className="object-contain" />
+    <Image
+      src="/brand/logo.png"
+      alt="GramorX Logo"
+      fill
+      sizes="100vw"
+      className="object-contain p-6"
+    />
   </div>
 );
 
@@ -36,18 +42,18 @@ export default function AuthLayout({
 }: Props) {
   const rightContent = right ?? rightIllustration ?? <DefaultRight />;
   const rightWrapperClass = showRightOnMobile
-    ? 'flex w-full md:w-1/2'
-    : 'hidden md:flex w-1/2';
+    ? 'flex h-24 sm:h-32 md:h-auto w-full md:w-1/2 lg:w-2/5 xl:w-1/3'
+    : 'hidden md:flex md:w-1/2 lg:w-2/5 xl:w-1/3';
   return (
     <div className="min-h-[100dvh] flex flex-col md:flex-row bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
       {/* Left: content */}
-      <div className="flex flex-col justify-center w-full md:w-1/2 px-6 py-8 sm:px-8 sm:py-12 lg:px-12 lg:py-16">
+      <div className="flex flex-col justify-center w-full md:w-1/2 lg:w-3/5 xl:w-2/3 px-6 py-8 sm:px-8 sm:py-12 lg:px-12 lg:py-16">
         <div className="flex justify-between items-center mb-6 sm:mb-8">
           <span className="font-slab text-h3 sm:text-h2 md:text-display text-gradient-primary">GramorX</span>
           <span className="text-xs sm:text-small text-grayish dark:text-gray-400">IELTS Portal</span>
         </div>
 
-        <Container className="w-full max-w-sm sm:max-w-md md:max-w-lg">
+        <Container className="w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl">
           <h1 className="font-slab text-h3 sm:text-h2 lg:text-display text-gradient-primary">{title}</h1>
           {subtitle && <p className="mt-1 text-sm sm:text-base text-grayish">{subtitle}</p>}
           <div className="mt-4 sm:mt-6">{children}</div>

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -47,7 +47,7 @@ export default function AuthCallback() {
   }, []);
 
   return (
-    <AuthLayout title="Signing you in..." subtitle={err ? undefined : 'Please wait...'}>
+    <AuthLayout title="Signing you in..." subtitle={err ? undefined : 'Please wait...'} showRightOnMobile>
       {err && (
         <Alert variant="error" title="Error" className="mt-4">
           {err}

--- a/pages/auth/mfa.tsx
+++ b/pages/auth/mfa.tsx
@@ -25,7 +25,7 @@ export default function MfaPage() {
   };
 
   return (
-    <AuthLayout title="Two-factor authentication" subtitle="Enter the 6-digit code from your authenticator app.">
+    <AuthLayout title="Two-factor authentication" subtitle="Enter the 6-digit code from your authenticator app." showRightOnMobile>
       <form onSubmit={submit} className="mt-4 space-y-4 max-w-sm">
         <input
           value={code}

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -67,9 +67,9 @@ export default function VerifyPage() {
           <Image
             src="/brand/logo.png"
             alt="GramorX Logo"
-            width={420}
-            height={420}
-            className="object-contain"
+            fill
+            sizes="100vw"
+            className="object-contain p-6"
           />
         </div>
       }

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -97,7 +97,7 @@ export default function LoginWithEmail() {
   );
 
   return (
-    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
+    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel} showRightOnMobile>
       {(err || mfaErr) && <Alert variant="error" title="Error">{err || mfaErr}</Alert>}
 
       {!otpSent ? (

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -83,8 +83,7 @@ export default function LoginOptions() {
 
   // Right-side: soft brand panel (no Card), token gradients, light/dark compliant
   const RightPanel = (
-    <div className="hidden md:flex w-1/2">
-      <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
+    <div className="h-full flex flex-col justify-between p-8 md:p-12 bg-gradient-to-br from-purpleVibe/10 via-electricBlue/5 to-neonGreen/10 dark:from-dark/50 dark:via-dark/30 dark:to-darker/60">
       <div>
         <div className="flex items-center gap-3 mb-6">
           <Image
@@ -122,18 +121,17 @@ export default function LoginOptions() {
         </ul>
       </div>
 
-        <div className="pt-8">
-          <div className="text-small text-grayish dark:text-gray-400">
-            By continuing, you agree to our{' '}
-            <Link href="/legal/terms" className="text-primaryDark hover:underline">
-              Terms
-            </Link>{' '}
-            and{' '}
-            <Link href="/legal/privacy" className="text-primaryDark hover:underline">
-              Privacy Policy
-            </Link>
-            .
-          </div>
+      <div className="pt-8">
+        <div className="text-small text-grayish dark:text-gray-400">
+          By continuing, you agree to our{' '}
+          <Link href="/legal/terms" className="text-primaryDark hover:underline">
+            Terms
+          </Link>{' '}
+          and{' '}
+          <Link href="/legal/privacy" className="text-primaryDark hover:underline">
+            Privacy Policy
+          </Link>
+          .
         </div>
       </div>
     </div>
@@ -144,6 +142,7 @@ export default function LoginOptions() {
       title="Welcome back"
       subtitle="Choose a sign-in method."
       right={RightPanel}
+      showRightOnMobile
     >
       {err && (
         <Alert variant="error" title="Error" className="mb-4">

--- a/pages/login/password.tsx
+++ b/pages/login/password.tsx
@@ -97,7 +97,7 @@ export default function LoginWithPassword() {
   );
 
   return (
-    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel}>
+    <AuthLayout title="Sign in with Email" subtitle="Use your email & password." right={RightPanel} showRightOnMobile>
       {(err || mfaErr) && <Alert variant="error" title="Error">{err || mfaErr}</Alert>}
 
       {!otpSent ? (

--- a/pages/login/phone.tsx
+++ b/pages/login/phone.tsx
@@ -118,7 +118,7 @@ export default function LoginWithPhone() {
   );
 
   return (
-    <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code." right={RightPanel}>
+    <AuthLayout title="Phone Verification" subtitle="Sign in with an SMS code." right={RightPanel} showRightOnMobile>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
 
       {stage === 'request' ? (

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -49,7 +49,7 @@ export default function SignupOptions() {
   );
 
   return (
-    <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method." right={RightPanel}>
+    <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method." right={RightPanel} showRightOnMobile>
       <div className="grid gap-3">
         <Button onClick={() => signUpOAuth('apple')} variant="secondary" className="rounded-ds-xl w-full">
           <span className="inline-flex items-center gap-3"><i className="fab fa-apple text-xl" aria-hidden /> Sign up with Apple</span>

--- a/pages/signup/password.tsx
+++ b/pages/signup/password.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Input } from '@/components/design-system/Input';
@@ -84,24 +83,11 @@ export default function SignupWithPassword() {
     }
   }
 
-  const RightPanel = (
-    <div className="hidden md:flex w-1/2 relative items-center justify-center bg-primary/10 dark:bg-dark">
-      <Image
-        src="/brand/logo.png"
-        alt="GramorX Logo"
-        width={420}
-        height={420}
-        className="object-contain"
-        priority
-      />
-    </div>
-  );
-
   return (
     <AuthLayout
       title="Sign up with Email"
       subtitle="Create an account using email & password."
-      right={RightPanel}
+      showRightOnMobile
     >
       {err && (
         <Alert variant="error" title="Error" className="mb-4">

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -144,7 +144,7 @@ export default function SignupWithPhone() {
   );
 
   return (
-    <AuthLayout title="Phone Verification" subtitle="Sign up with an SMS code." right={RightPanel}>
+    <AuthLayout title="Phone Verification" subtitle="Sign up with an SMS code." right={RightPanel} showRightOnMobile>
       {err && <Alert variant="error" title="Error" className="mb-4">{err}</Alert>}
 
       {stage === 'request' ? (


### PR DESCRIPTION
## Summary
- allow AuthLayout right panel to resize at breakpoints and show condensed brand on mobile
- center left content with responsive max widths
- update auth pages to use `showRightOnMobile`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38ef8cb888321a5c84886faec0794