### PR TITLE
Replace FontAwesome with React SVG icons

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,17 @@ import React from 'react';
 import { Container } from '@/components/design-system/Container';
 import { NavLink } from '@/components/design-system/NavLink';
 import { SocialIconLink } from '@/components/design-system/SocialIconLink';
+import {
+  FacebookIcon,
+  TwitterIcon,
+  InstagramIcon,
+  LinkedinIcon,
+  YoutubeIcon,
+  MailIcon,
+  PhoneIcon,
+  MapPinIcon,
+  ClockIcon,
+} from '@/components/design-system/icons';
 
 const RESOURCES = [
   { href: '/learning/strategies', label: 'IELTS Preparation Guide' },
@@ -36,11 +47,11 @@ export const Footer: React.FC = () => {
               teaching methodologies.
             </p>
             <div className="flex gap-3 mt-4">
-              <SocialIconLink href="https://facebook.com" icon="facebook-f" label="Facebook" />
-              <SocialIconLink href="https://twitter.com" icon="twitter" label="Twitter / X" />
-              <SocialIconLink href="https://instagram.com" icon="instagram" label="Instagram" />
-              <SocialIconLink href="https://linkedin.com" icon="linkedin-in" label="LinkedIn" />
-              <SocialIconLink href="https://youtube.com" icon="youtube" label="YouTube" />
+              <SocialIconLink href="https://facebook.com" icon={<FacebookIcon className="h-5 w-5" />} label="Facebook" />
+              <SocialIconLink href="https://twitter.com" icon={<TwitterIcon className="h-5 w-5" />} label="Twitter / X" />
+              <SocialIconLink href="https://instagram.com" icon={<InstagramIcon className="h-5 w-5" />} label="Instagram" />
+              <SocialIconLink href="https://linkedin.com" icon={<LinkedinIcon className="h-5 w-5" />} label="LinkedIn" />
+              <SocialIconLink href="https://youtube.com" icon={<YoutubeIcon className="h-5 w-5" />} label="YouTube" />
             </div>
           </div>
 
@@ -79,22 +90,22 @@ export const Footer: React.FC = () => {
             </h3>
             <ul className="space-y-3 text-gray-600 dark:text-grayish">
               <li>
-                <i className="fas fa-envelope mr-2" />
+                <MailIcon className="mr-2 inline h-4 w-4" />
                 <a href="mailto:info@solvioadvisors.com" className="hover:underline">
                   info@solvioadvisors.com
                 </a>
               </li>
               <li>
-                <i className="fas fa-phone mr-2" />
+                <PhoneIcon className="mr-2 inline h-4 w-4" />
                 <a href="tel:+19722954571" className="hover:underline">
                   +1 (972) 295-4571
                 </a>
               </li>
               <li>
-                <i className="fas fa-map-marker-alt mr-2" /> Houston, USA
+                <MapPinIcon className="mr-2 inline h-4 w-4" /> Houston, USA
               </li>
               <li>
-                <i className="fas fa-clock mr-2" /> Support: 24/7
+                <ClockIcon className="mr-2 inline h-4 w-4" /> Support: 24/7
               </li>
             </ul>
           </div>

--- a/components/design-system/SocialIconLink.tsx
+++ b/components/design-system/SocialIconLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const SocialIconLink: React.FC<{
   href: string;
-  icon: string; // e.g., 'facebook-f', 'twitter', 'instagram'
+  icon: React.ReactNode;
   label: string;
   className?: string;
 }> = ({ href, icon, label, className = '' }) => (
@@ -13,6 +13,6 @@ export const SocialIconLink: React.FC<{
       bg-primary/10 text-primary hover:-translate-y-0.5
       dark:bg-purpleVibe/10 dark:text-neonGreen ${className}`}
   >
-    <i className={`fab fa-${icon}`} aria-hidden="true" />
+    {icon}
   </a>
 );

--- a/components/design-system/icons.tsx
+++ b/components/design-system/icons.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+export const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M16 2c-1.2 0-2.6.8-3.4 1.8-.8 1-1.3 2.3-1.1 3.6 1.3.1 2.6-.7 3.4-1.8.8-1 1.3-2.3 1.1-3.6Z" />
+    <path d="M20.4 15.4c-.7 1.5-1 2.1-1.9 3.3-.9 1.2-1.8 2.5-3.1 2.5-1.2 0-1.6-.8-3.1-.8s-1.9.8-3.1.8c-1.3 0-2.2-1.3-3.1-2.5C3.6 16.1 2 11.8 4.2 8.5c1-1.5 2.8-2.5 4.6-2.5 1.2 0 2.3.9 3.1.9.8 0 2.1-.9 3.5-.8 1.5.1 3 .9 3.8 2.1-3.3 1.8-2.8 6.5-.8 8.2Z" />
+  </svg>
+);
+
+export const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M21.6 11.1H12v2.9h5.6c-.3 1.8-2 5.3-5.6 5.3A6.5 6.5 0 1 1 18.5 8l2.3-2.3A10 10 0 1 0 22 12c0-.3 0-.6-.1-.9Z" />
+  </svg>
+);
+
+export const FacebookIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M22 12a10 10 0 1 0-11.5 9.9v-7H7.6V12h2.9V9.8c0-2.9 1.7-4.5 4.3-4.5 1.2 0 2.4.2 2.4.2v2.6h-1.3c-1.3 0-1.7.8-1.7 1.6V12h3l-.5 2.9h-2.5v7A10 10 0 0 0 22 12Z" />
+  </svg>
+);
+
+export const MailIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <polyline points="3,7 12,13 21,7" />
+  </svg>
+);
+
+export const SmsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <rect x="2" y="3" width="20" height="14" rx="2" />
+    <path d="M8 21l4-4 4 4" />
+  </svg>
+);
+
+export const ShieldIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z" />
+  </svg>
+);
+
+export const PhoneIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <rect x="7" y="2" width="10" height="20" rx="2" />
+    <path d="M11 18h2" />
+  </svg>
+);
+
+export const ChartIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <path d="M3 3v18h18" />
+    <polyline points="7 14 11 10 15 14 21 8" />
+  </svg>
+);
+
+export const UserCheckIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <circle cx="8" cy="8" r="3" />
+    <path d="M5 21v-2a4 4 0 0 1 4-4h0a4 4 0 0 1 4 4v2" />
+    <path d="m16 11 2 2 4-4" />
+  </svg>
+);
+
+export const TwitterIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M22 5.8c-.8.4-1.6.6-2.5.8.9-.5 1.5-1.3 1.8-2.3-.8.5-1.8.9-2.8 1.1A4.3 4.3 0 0 0 12 8.6v.5c-3.5-.2-6.5-1.8-8.5-4.2-.4.7-.6 1.4-.6 2.3 0 1.5.8 2.8 1.9 3.6-.7 0-1.4-.2-2-.5v.1c0 2.1 1.5 3.9 3.4 4.3-.4.1-.8.2-1.3.2-.3 0-.6 0-.9-.1.6 1.8 2.3 3.1 4.3 3.1A8.7 8.7 0 0 1 2 19.5a12.2 12.2 0 0 0 6.6 1.9c7.9 0 12.3-6.6 12.3-12.3v-.6c.8-.6 1.5-1.3 2.1-2.1Z" />
+  </svg>
+);
+
+export const InstagramIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <rect x="2" y="2" width="20" height="20" rx="5" />
+    <circle cx="12" cy="12" r="4" />
+    <circle cx="17" cy="7" r="1" fill="currentColor" />
+  </svg>
+);
+
+export const LinkedinIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <rect x="2" y="2" width="20" height="20" rx="2" />
+    <path d="M7 10h2v7H7zM8 7a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm4 3h2v1a2 2 0 0 1 4 0v6h-2v-5a1 1 0 0 0-2 0v5h-2z" />
+  </svg>
+);
+
+export const YoutubeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <rect x="2" y="5" width="20" height="14" rx="2" />
+    <path d="m10 9 5 3-5 3z" fill="#fff" />
+  </svg>
+);
+
+export const MapPinIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <path d="M12 21s-6-5.3-6-10a6 6 0 1 1 12 0c0 4.7-6 10-6 10Z" />
+    <circle cx="12" cy="11" r="2" />
+  </svg>
+);
+
+export const ClockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true" {...props}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 3" />
+  </svg>
+);
+
+export type IconProps = React.SVGProps<SVGSVGElement>;
+

--- a/components/design-system/index.ts
+++ b/components/design-system/index.ts
@@ -2,3 +2,4 @@ export { Button } from './Button';
 export { Select } from './Select';
 export { Textarea } from './Textarea';
 export { SeasonToggle } from './SeasonToggle';
+export * from './icons';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -198,31 +198,7 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <Head>
-        {/* (Optional) Replace these with a package import to avoid the Next lint warning */}
-        <link
-          rel="preload"
-          as="style"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        />
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          media="print"
-          onLoad={(e) => {
-            const el = e.currentTarget as HTMLLinkElement;
-            el.media = 'all';
-          }}
-        />
-        <noscript>
-          <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          />
-        </noscript>
-
-        {isPremium ? <link rel="stylesheet" href="/premium.css" /> : null}
-      </Head>
+      <Head>{isPremium ? <link rel="stylesheet" href="/premium.css" /> : null}</Head>
 
       <div className={`${poppins.variable} ${slab.variable} ${poppins.className} min-h-[100dvh]`}>
         {showLayout ? (

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -34,10 +34,6 @@ export default function Document() {
           href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&family=Roboto+Slab:wght@300;400;500;600;700&display=swap"
           rel="stylesheet"
         />
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-        />
 
         {/* PWA */}
         <link rel="manifest" href="/manifest.json" />

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -5,6 +5,16 @@ import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
+import {
+  AppleIcon,
+  GoogleIcon,
+  FacebookIcon,
+  MailIcon,
+  SmsIcon,
+  ShieldIcon,
+  PhoneIcon,
+  ChartIcon,
+} from '@/components/design-system/icons';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -104,19 +114,19 @@ export default function LoginOptions() {
 
         <ul className="mt-6 space-y-3 text-body text-grayish dark:text-gray-300">
           <li className="flex items-center gap-3">
-            <i className="fas fa-shield-alt text-success" aria-hidden />
+            <ShieldIcon className="h-5 w-5 text-success" />
             Secure OAuth (Apple, Google, Facebook)
           </li>
           <li className="flex items-center gap-3">
-            <i className="fas fa-mobile-alt" aria-hidden />
+            <PhoneIcon className="h-5 w-5" />
             Phone OTP sign-in
           </li>
           <li className="flex items-center gap-3">
-            <i className="fas fa-envelope" aria-hidden />
+            <MailIcon className="h-5 w-5" />
             Email &amp; Password
           </li>
           <li className="flex items-center gap-3">
-            <i className="fas fa-chart-line text-electricBlue" aria-hidden />
+            <ChartIcon className="h-5 w-5 text-electricBlue" />
             Personalized study plan &amp; analytics
           </li>
         </ul>
@@ -175,7 +185,7 @@ export default function LoginOptions() {
               className="rounded-ds-xl w-full"
             >
               <span className="inline-flex items-center gap-3">
-                <i className="fab fa-apple text-xl" aria-hidden />
+                <AppleIcon className="h-5 w-5" />
                 {busy === 'apple' ? 'Opening Apple…' : 'Continue with Apple'}
               </span>
             </Button>
@@ -187,7 +197,7 @@ export default function LoginOptions() {
               className="rounded-ds-xl w-full"
             >
               <span className="inline-flex items-center gap-3">
-                <i className="fab fa-google text-xl" aria-hidden />
+                <GoogleIcon className="h-5 w-5" />
                 {busy === 'google' ? 'Opening Google…' : 'Continue with Google'}
               </span>
             </Button>
@@ -199,7 +209,7 @@ export default function LoginOptions() {
               className="rounded-ds-xl w-full"
             >
               <span className="inline-flex items-center gap-3">
-                <i className="fab fa-facebook-f text-xl" aria-hidden />
+                <FacebookIcon className="h-5 w-5" />
                 {busy === 'facebook' ? 'Opening Facebook…' : 'Continue with Facebook'}
               </span>
             </Button>
@@ -210,7 +220,7 @@ export default function LoginOptions() {
                 aria-label="Sign in with Email and Password"
               >
                 <span className="inline-flex items-center gap-3">
-                  <i className="fas fa-envelope text-xl" aria-hidden />
+                  <MailIcon className="h-5 w-5" />
                   Email (Password)
                 </span>
               </Link>
@@ -222,7 +232,7 @@ export default function LoginOptions() {
                 aria-label="Sign in with Phone OTP"
               >
                 <span className="inline-flex items-center gap-3">
-                  <i className="fas fa-sms text-xl" aria-hidden />
+                  <SmsIcon className="h-5 w-5" />
                   Phone (OTP)
                 </span>
               </Link>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -5,6 +5,15 @@ import { useRouter } from 'next/router';
 import AuthLayout from '@/components/layouts/AuthLayout';
 import { Button } from '@/components/design-system/Button';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import {
+  AppleIcon,
+  GoogleIcon,
+  FacebookIcon,
+  MailIcon,
+  SmsIcon,
+  PhoneIcon,
+  UserCheckIcon,
+} from '@/components/design-system/icons';
 
 export default function SignupOptions() {
   const router = useRouter();
@@ -37,9 +46,9 @@ export default function SignupOptions() {
           Start your IELTS journey with AI support and personalized plans.
         </p>
         <ul className="mt-6 space-y-3 text-body text-grayish dark:text-gray-300">
-          <li className="flex items-center gap-3"><i className="fas fa-user-check" aria-hidden />Apple / Google / Facebook</li>
-          <li className="flex items-center gap-3"><i className="fas fa-envelope" aria-hidden />Email & password</li>
-          <li className="flex items-center gap-3"><i className="fas fa-mobile-alt" aria-hidden />Phone (OTP)</li>
+          <li className="flex items-center gap-3"><UserCheckIcon className="h-5 w-5" />Apple / Google / Facebook</li>
+          <li className="flex items-center gap-3"><MailIcon className="h-5 w-5" />Email & password</li>
+          <li className="flex items-center gap-3"><PhoneIcon className="h-5 w-5" />Phone (OTP)</li>
         </ul>
       </div>
       <div className="pt-8 text-small text-grayish dark:text-gray-400">
@@ -52,22 +61,22 @@ export default function SignupOptions() {
     <AuthLayout title="Sign up to GramorX" subtitle="Choose a sign-up method." right={RightPanel}>
       <div className="grid gap-3">
         <Button onClick={() => signUpOAuth('apple')} variant="secondary" className="rounded-ds-xl w-full">
-          <span className="inline-flex items-center gap-3"><i className="fab fa-apple text-xl" aria-hidden /> Sign up with Apple</span>
+          <span className="inline-flex items-center gap-3"><AppleIcon className="h-5 w-5" /> Sign up with Apple</span>
         </Button>
         <Button onClick={() => signUpOAuth('google')} variant="secondary" className="rounded-ds-xl w-full">
-          <span className="inline-flex items-center gap-3"><i className="fab fa-google text-xl" aria-hidden /> Sign up with Google</span>
+          <span className="inline-flex items-center gap-3"><GoogleIcon className="h-5 w-5" /> Sign up with Google</span>
         </Button>
         <Button onClick={() => signUpOAuth('facebook')} variant="secondary" className="rounded-ds-xl w-full">
-          <span className="inline-flex items-center gap-3"><i className="fab fa-facebook-f text-xl" aria-hidden /> Sign up with Facebook</span>
+          <span className="inline-flex items-center gap-3"><FacebookIcon className="h-5 w-5" /> Sign up with Facebook</span>
         </Button>
         <Button asChild variant="secondary" className="rounded-ds-xl w-full">
           <Link href={`/signup/password${ref ? `?ref=${ref}` : ''}`}>
-            <span className="inline-flex items-center gap-3"><i className="fas fa-envelope text-xl" aria-hidden /> Sign up with Email</span>
+            <span className="inline-flex items-center gap-3"><MailIcon className="h-5 w-5" /> Sign up with Email</span>
           </Link>
         </Button>
         <Button asChild variant="secondary" className="rounded-ds-xl w-full">
           <Link href={`/signup/phone${ref ? `?ref=${ref}` : ''}`}>
-            <span className="inline-flex items-center gap-3"><i className="fas fa-sms text-xl" aria-hidden /> Sign up with Phone</span>
+            <span className="inline-flex items-center gap-3"><SmsIcon className="h-5 w-5" /> Sign up with Phone</span>
           </Link>
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- add design-system SVG icon set and helpers
- swap login and signup social auth buttons to new icons
- drop FontAwesome stylesheet imports to trim payload; footer and social links now use SVG icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b38ef2f0948321a1b87a8d2ec4d160