### PR TITLE
Fix premium redirect and update header theme toggle

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -52,12 +52,14 @@ function IconOnlyThemeToggle() {
     >
       {/* Moon / Sun icons (inline SVG, no text) */}
       {isDark ? (
-        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
-      ) : (
+        // Show sun icon when in dark mode
         <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
           <path d="M6.76 4.84 5.34 3.42 3.92 4.84 5.34 6.26 6.76 4.84zM1 13h3v-2H1v2zm10 10h2v-3h-2v3zm9-10v-2h-3v2h3zm-2.76 7.16 1.42 1.42 1.42-1.42-1.42-1.42-1.42 1.42zM12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm7-1.58 1.42-1.42L19 0.58l-1.42 1.42L19 3.42zM4.84 17.24 3.42 18.66l1.42 1.42 1.42-1.42-1.42-1.42z" />
+        </svg>
+      ) : (
+        // Show moon icon when in light mode
+        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}
     </button>

--- a/middleware.ts
+++ b/middleware.ts
@@ -50,6 +50,15 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  // Require a verified premium PIN before accessing premium routes
+  const pinOk = req.cookies.get('pr_pin_ok')?.value === '1';
+  if (!pinOk && pathname !== '/premium/pin') {
+    const url = req.nextUrl.clone();
+    url.pathname = '/premium/pin';
+    url.search = `?next=${encodeURIComponent(pathname + (search || ''))}`;
+    return NextResponse.redirect(url);
+  }
+
   try {
     const resp = await fetch(`${origin}/api/premium/status`, {
       headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- ensure premium routes redirect to PIN entry instead of login
- adjust header theme toggle to show sun/moon icon per active theme

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b396b601a08321837ae29c5afeb71b