### PR TITLE
Redirect premium navigation to PIN entry

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -318,7 +318,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
 
               <li><NavLink href="/learning" label="Learning" /></li>
               {NAV.map((n) => (<li key={n.href}><NavLink href={n.href} label={n.label} /></li>))}
-              <li><NavLink href="/premium" label="premium" /></li>
+              <li><NavLink href="/premium/pin" label="premium" /></li>
 
               {ready ? (
                 user.id ? (


### PR DESCRIPTION
## Summary
- Redirect the Premium header link to point to the PIN entry screen

## Testing
- `npm run build` *(fails: Failed to fetch font `Poppins` and `Roboto Slab`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a0a3a3b8832191d6078d5720a082