### PR TITLE
Skip PIN page from premium guard

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,7 @@ export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
   // Only guard premium here; everything else is handled by SSR
-  if (pathname.startsWith('/premium')) {
+  if (pathname.startsWith('/premium') && pathname !== '/premium/pin') {
     const token = req.cookies.get('sb-access-token')?.value ?? null;
     if (!token) {
       const url = req.nextUrl.clone();


### PR DESCRIPTION
## Summary
- allow `/premium/pin` to bypass premium middleware guard

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Poppins` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8be3aac832197ce9c621802373a