### PR TITLE
feat: add logger utility and replace console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "twilio": "^5.8.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "pino": "^8.17.0"
   },
   "devDependencies": {
     "@mdx-js/react": "^2.3.0",

--- a/pages/api/support.ts
+++ b/pages/api/support.ts
@@ -1,6 +1,7 @@
 // pages/api/support.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import logger from '@/utils/logger';
 
 /** ========= Types ========= */
 type SupportCategory = 'account' | 'billing' | 'modules' | 'ai' | 'technical' | 'other';
@@ -111,14 +112,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   });
 
   if (error) {
-    // eslint-disable-next-line no-console
-    console.error('[SupportTicket][InsertError]', error);
+    logger.error('[SupportTicket][InsertError]', error);
     return res.status(500).json({ ok: false, message: 'Failed to save ticket.' });
   }
 
-  // Optional: log for debugging (remove in production)
-  // eslint-disable-next-line no-console
-  console.log('[SupportTicket][Created]', { ticketId, email: data.email, category: data.category });
+  // Optional: log for debugging
+  logger.debug('[SupportTicket][Created]', {
+    ticketId,
+    email: data.email,
+    category: data.category,
+  });
 
   return res.status(200).json({
     ok: true,

--- a/pages/learning/strategies/[tipSlug].tsx
+++ b/pages/learning/strategies/[tipSlug].tsx
@@ -5,6 +5,7 @@ import type { GetServerSideProps } from 'next';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import logger from '@/utils/logger';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -158,16 +159,18 @@ export default function TipDetail({
       const normalized = normalizeDrill(data);
 
       if (DEBUG) {
-        // eslint-disable-next-line no-console
-        console.groupCollapsed(`[drill/detail] ${tip.slug} (${tip.area}/${tip.difficulty})`);
-        // eslint-disable-next-line no-console
-        console.log('request', { skill: tip.area, level: tip.difficulty, tipSlug: tip.slug });
-        // eslint-disable-next-line no-console
-        console.log('response', data);
-        // eslint-disable-next-line no-console
-        console.log('normalized', normalized);
-        // eslint-disable-next-line no-console
-        console.groupEnd();
+        logger.debug(
+          `[drill/detail] ${tip.slug} (${tip.area}/${tip.difficulty}) request`,
+          { skill: tip.area, level: tip.difficulty, tipSlug: tip.slug }
+        );
+        logger.debug(
+          `[drill/detail] ${tip.slug} (${tip.area}/${tip.difficulty}) response`,
+          data
+        );
+        logger.debug(
+          `[drill/detail] ${tip.slug} (${tip.area}/${tip.difficulty}) normalized`,
+          normalized
+        );
       }
 
       setDrill(normalized);

--- a/twilio-sms-webhook.ts
+++ b/twilio-sms-webhook.ts
@@ -4,6 +4,7 @@ import Twilio from "twilio";
 import { z } from "zod";
 import { env } from "./lib/env";
 import { supabaseService } from "./lib/supabaseService";
+import logger from "@/utils/logger";
 
 const app = express();
 app.use(express.urlencoded({ extended: false }));
@@ -77,7 +78,7 @@ app.post(
         .upsert(payload, { onConflict: "message_sid" });
 
       if (error) {
-        console.error("Supabase error:", error);
+        logger.error("Supabase error:", error);
         return res.status(500).json({
           error: "Error storing message status",
           details: error.message,
@@ -86,11 +87,11 @@ app.post(
 
       res.status(200).send("OK");
     } catch (err) {
-      console.error("Webhook error:", err);
+      logger.error("Webhook error:", err);
       res.status(500).json({ error: "Server error" });
     }
   }
 );
 
 const port = env.PORT ?? 4000;
-app.listen(port, () => console.log(`Twilio webhook listening on :${port}`));
+app.listen(port, () => logger.info(`Twilio webhook listening on :${port}`));

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,36 @@
+// utils/logger.ts
+// Lightweight logger utility with optional pino integration.
+
+type LogFn = (...args: unknown[]) => void;
+
+interface Logger {
+  error: LogFn;
+  warn: LogFn;
+  info: LogFn;
+  debug: LogFn;
+}
+
+const level =
+  process.env.LOG_LEVEL ||
+  (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
+
+let logger: Logger;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // @ts-ignore - pino types may not be installed in this environment
+  const pino = require('pino');
+  logger = pino({ level });
+} catch {
+  const levels: Record<string, number> = { error: 0, warn: 1, info: 2, debug: 3 };
+  const current = levels[level] ?? 2;
+  logger = {
+    error: (...args) => current >= levels.error && console.error(...args),
+    warn: (...args) => current >= levels.warn && console.warn(...args),
+    info: (...args) => current >= levels.info && console.log(...args),
+    debug: (...args) => current >= levels.debug && console.debug(...args),
+  } as Logger;
+}
+
+export default logger;
+


### PR DESCRIPTION
## Summary
- add fallback logger utility that uses `pino` when available
- replace `console.log` statements with logger in support API, strategies tip page, and Twilio webhook
- declare `pino` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b612f0d88321be001a098685a367