### PR TITLE
feat(theme): add preview swatches and display switcher

### DIFF
--- a/pages/premium/index.tsx
+++ b/pages/premium/index.tsx
@@ -70,10 +70,10 @@ export default function PremiumHome({ plan }: Props) {
 
   return (
     <main className="pr-p-6 pr-space-y-6">
-      <div className="pr-flex pr-items-center pr-justify-between">
+      <header className="pr-flex pr-items-center pr-justify-between">
         <h1 className="pr-text-2xl pr-font-semibold">Premium Exam Room</h1>
         <ThemeSwitcherPremium />
-      </div>
+      </header>
 
       <div className="pr-grid md:pr-grid-cols-2 pr-gap-6">
         <PrCard className="pr-p-6">

--- a/premium-ui/theme/ThemeSwitcher.tsx
+++ b/premium-ui/theme/ThemeSwitcher.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { PREMIUM_THEMES, type PremiumThemeId } from './premium-themes';
+import { PREMIUM_THEMES } from './premium-themes';
 import { usePremiumTheme } from './PremiumThemeProvider';
 
 export function ThemeSwitcherPremium() {
   const { theme, setTheme } = usePremiumTheme();
 
   return (
-    <div className="pr inline-flex items-center gap-2 p-1 rounded-2xl bg-[var(--pr-card)] border border-[var(--pr-border)]">
+    <div className="pr grid grid-cols-2 gap-2 p-2 rounded-2xl bg-[var(--pr-card)] border border-[var(--pr-border)]">
       {PREMIUM_THEMES.map((t) => (
         <button
           key={t.id}
@@ -14,16 +14,21 @@ export function ThemeSwitcherPremium() {
           onClick={() => setTheme(t.id)}
           aria-pressed={theme === t.id}
           className={[
-            'px-3 py-1.5 rounded-xl text-sm transition duration-150 border',
+            'aspect-square flex flex-col items-center justify-center gap-2 rounded-xl text-xs transition',
             theme === t.id
-              ? 'bg-[var(--pr-primary)] text-[var(--pr-on-primary)] border-transparent shadow-[var(--pr-shadow-md)]'
-              : 'bg-[color-mix(in oklab,var(--pr-card),white 6%)] text-[var(--pr-fg)] border-[var(--pr-border)] hover:bg-[color-mix(in oklab,var(--pr-card),white 12%)]'
+              ? 'ring-2 ring-[var(--pr-primary)] ring-offset-2 ring-offset-[var(--pr-card)]'
+              : 'border border-[var(--pr-border)] hover:bg-[color-mix(in oklab,var(--pr-card),white 12%)]'
           ].join(' ')}
-          title={t.note || t.label}
+          title={t.label}
         >
-          {t.label}
+          <span
+            className="w-8 h-8 rounded-md"
+            style={{ background: t.preview, backgroundSize: 'cover', backgroundPosition: 'center' }}
+          />
+          <span>{t.label}</span>
         </button>
       ))}
     </div>
   );
 }
+

--- a/premium-ui/theme/premium-themes.ts
+++ b/premium-ui/theme/premium-themes.ts
@@ -1,8 +1,8 @@
 export const PREMIUM_THEMES = [
-  { id: 'carbon', label: 'Carbon Noir' },
-  { id: 'ivory', label: 'Ivory Quartz' },
-  { id: 'royal', label: 'Royal Aster' },
-  { id: 'aurora', label: 'Aurora Neo' },
+  { id: 'carbon', label: 'Carbon Noir', preview: '#1b1b1f' },
+  { id: 'ivory', label: 'Ivory Quartz', preview: '#f8f4e7' },
+  { id: 'royal', label: 'Royal Aster', preview: '#4c1d95' },
+  { id: 'aurora', label: 'Aurora Neo', preview: '#0ea5e9' },
 ] as const;
 
 export type PremiumThemeId = typeof PREMIUM_THEMES[number]['id'];


### PR DESCRIPTION
## Summary
- add preview colors to premium theme metadata
- render premium theme switcher as swatch grid with active ring
- surface ThemeSwitcherPremium in premium page header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3c1f420c08321afbcbf3fd658829a