### PR TITLE
feat: make target summary grid responsive

### DIFF
--- a/components/study-plan/TargetSummary.tsx
+++ b/components/study-plan/TargetSummary.tsx
@@ -10,7 +10,7 @@ interface Props {
 export const TargetSummary: React.FC<Props> = ({ daily, weekly, eta }) => (
   <Card className="p-6 rounded-ds-2xl">
     <h3 className="font-slab text-h3 mb-4">Your Targets</h3>
-    <div className="grid grid-cols-2 gap-4 mb-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
       <div>
         <div className="text-sm text-gray-600 dark:text-grayish">Daily</div>
         <div className="text-xl font-semibold">{daily}</div>


### PR DESCRIPTION
## Summary
- adjust TargetSummary grid to single column on mobile and two on larger screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c642d8f883219abf0ad5d71e4280