### PR TITLE
feat: enlarge question nav buttons on mobile

### DIFF
--- a/components/reading/QuestionNav.tsx
+++ b/components/reading/QuestionNav.tsx
@@ -82,7 +82,7 @@ export const QuestionNav: React.FC<{
       </div>
 
       {/* Chips */}
-      <div className="mt-3 grid grid-cols-6 sm:grid-cols-8 lg:grid-cols-4 gap-2">
+      <div className="mt-3 grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-2">
         {visible.map(q => {
           const flagged = !!flags[q.id];
           const answered = !(answers[q.id]?.value == null || answers[q.id]?.value === '');


### PR DESCRIPTION
## Summary
- widen touch targets for question navigation by using fewer base grid columns

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3c647f3488321b21d0f9a1dc54f52