### PR TITLE
feat: protect bottom nav links

### DIFF
--- a/components/navigation/BottomNav.tsx
+++ b/components/navigation/BottomNav.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useRouter } from 'next/router';
 import { NavLink } from '@/components/design-system/NavLink';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
 const NAV_ITEMS = [
   { href: '/', label: 'Home', icon: 'fa-home', exact: true },
@@ -9,6 +11,22 @@ const NAV_ITEMS = [
 ];
 
 export const BottomNav: React.FC = () => {
+  const router = useRouter();
+  const [hasSession, setHasSession] = React.useState(false);
+
+  React.useEffect(() => {
+    supabaseBrowser.auth.getSession().then(({ data: { session } }) => {
+      setHasSession(!!session);
+    });
+  }, []);
+
+  const handleClick = (href: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!hasSession) {
+      e.preventDefault();
+      router.push('/login?next=' + href);
+    }
+  };
+
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-200 bg-white dark:bg-dark md:hidden">
       <ul className="flex justify-around">
@@ -19,6 +37,7 @@ export const BottomNav: React.FC = () => {
               exact={exact}
               variant="plain"
               className="flex flex-col items-center gap-1 py-2 text-xs text-gray-600 dark:text-grayish [&.is-active]:text-vibrantPurple"
+              onClick={handleClick(href)}
             >
               <i className={`fas ${icon} text-lg`} aria-hidden />
               <span>{label}</span>


### PR DESCRIPTION
## Summary
- intercept bottom navigation clicks and redirect unauthenticated users to login
- load supabase session and push to login with `next` parameter when needed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b67a30048321b3cac95634ad9935