### PR TITLE
feat: add media dock and scratchpad to exam shell

### DIFF
--- a/premium-ui/exam/ExamShell.tsx
+++ b/premium-ui/exam/ExamShell.tsx
@@ -18,6 +18,10 @@ type Props = {
   onTimeUp?: () => void;
   /** Optional answer sheet rendered beneath the question area */
   answerSheet?: React.ReactNode;
+  /** Optional scratchpad rendered in the side panel */
+  scratchpad?: React.ReactNode;
+  /** Optional media dock rendered in the side panel */
+  mediaDock?: React.ReactNode;
 };
 
 export function ExamShell({
@@ -30,6 +34,8 @@ export function ExamShell({
   seconds,
   onTimeUp,
   answerSheet,
+  scratchpad,
+  mediaDock,
 }: Props) {
   const [timeLeft, setTimeLeft] = React.useState(seconds ?? 0);
 
@@ -92,23 +98,27 @@ export function ExamShell({
             {answerSheet && <div className="mt-4 border-t border-[var(--pr-border)] pt-4">{answerSheet}</div>}
           </section>
 
-          <aside className="hidden md:block p-3 rounded-2xl border border-[var(--pr-border)] bg-[var(--pr-card)]">
-            <div className="text-sm opacity-70 mb-2">Questions</div>
-            <div className="grid grid-cols-5 gap-2">
-              {Array.from({ length: totalQuestions }).map((_, i) => {
-                const q = i + 1;
-                const active = q === currentQuestion;
-                return (
-                  <button
-                    key={q}
-                    onClick={() => onNavigate?.(q)}
-                    className={`aspect-square rounded-lg border border-[var(--pr-border)] text-sm hover:translate-y-[-1px] transition ${active ? 'bg-[var(--pr-primary)] text-white' : ''}`}
-                  >
-                    {q}
-                  </button>
-                );
-              })}
+          <aside className="pr hidden md:flex flex-col gap-4">
+            <div className="p-3 rounded-2xl border border-[var(--pr-border)] bg-[var(--pr-card)]">
+              <div className="text-sm opacity-70 mb-2">Questions</div>
+              <div className="grid grid-cols-5 gap-2">
+                {Array.from({ length: totalQuestions }).map((_, i) => {
+                  const q = i + 1;
+                  const active = q === currentQuestion;
+                  return (
+                    <button
+                      key={q}
+                      onClick={() => onNavigate?.(q)}
+                      className={`aspect-square rounded-lg border border-[var(--pr-border)] text-sm hover:translate-y-[-1px] transition ${active ? 'bg-[var(--pr-primary)] text-white' : ''}`}
+                    >
+                      {q}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
+            {scratchpad}
+            {mediaDock}
           </aside>
         </div>
       </main>

--- a/premium-ui/exam/MediaDock.tsx
+++ b/premium-ui/exam/MediaDock.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+export type MediaItem = {
+  id: string;
+  type: 'audio' | 'video';
+  src: string;
+  title?: string;
+};
+
+export type MediaDockProps = {
+  /** Initial list of media items */
+  initialItems?: MediaItem[];
+  /** Callback whenever the list changes */
+  onItemsChange?: (items: MediaItem[]) => void;
+};
+
+export function MediaDock({ initialItems = [], onItemsChange }: MediaDockProps) {
+  const [items, setItems] = React.useState<MediaItem[]>(initialItems);
+
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleAdd = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const id = `${Date.now()}-${file.name}`;
+    const type = file.type.startsWith('video') ? 'video' : 'audio';
+    const src = URL.createObjectURL(file);
+    const next = [...items, { id, type, src, title: file.name }];
+    setItems(next);
+    onItemsChange?.(next);
+    e.target.value = '';
+  };
+
+  const remove = (id: string) => {
+    setItems(prev => {
+      const next = prev.filter(i => i.id !== id);
+      onItemsChange?.(next);
+      return next;
+    });
+  };
+
+  return (
+    <div className="pr p-3 rounded-2xl border border-[var(--pr-border)] bg-[var(--pr-card)]">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-medium">Media Dock</h2>
+        <label className="cursor-pointer text-xs font-medium text-[var(--pr-primary)]">
+          + Add
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="audio/*,video/*"
+            className="hidden"
+            onChange={handleAdd}
+          />
+        </label>
+      </div>
+      {items.length === 0 ? (
+      <p className="text-sm opacity-70">No media added.</p>
+      ) : (
+      <ul className="space-y-2">
+        {items.map(item => (
+          <li key={item.id} className="flex flex-col gap-1">
+            {item.type === 'audio' ? (
+              <audio controls src={item.src} className="w-full rounded-md" />
+            ) : (
+              <video controls src={item.src} className="w-full rounded-md h-40" />
+            )}
+            <div className="flex items-center justify-between text-xs">
+              <span className="truncate">{item.title}</span>
+              <button
+                type="button"
+                onClick={() => remove(item.id)}
+                className="text-[var(--pr-primary)] hover:underline"
+              >
+                Remove
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      )}
+    </div>
+  );
+}
+

--- a/premium-ui/exam/Scratchpad.tsx
+++ b/premium-ui/exam/Scratchpad.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export type ScratchpadProps = {
+  value?: string;
+  onChange?: (value: string) => void;
+};
+
+export function Scratchpad({ value = '', onChange }: ScratchpadProps) {
+  const [text, setText] = React.useState(value);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+    onChange?.(e.target.value);
+  };
+
+  return (
+    <div className="pr p-3 rounded-2xl border border-[var(--pr-border)] bg-[var(--pr-card)]">
+      <div className="mb-2 text-sm font-medium">Scratchpad</div>
+      <textarea
+        value={text}
+        onChange={handleChange}
+        placeholder="Write notes here..."
+        className="w-full h-32 resize-none rounded-lg border border-[var(--pr-border)] bg-[var(--pr-surface,var(--pr-card))] p-2 text-sm"
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add optional scratchpad and media dock props to ExamShell layout
- create MediaDock component for managing audio and video snippets
- create Scratchpad component for taking notes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b79b27a08321a02e87ed3cf0d72e