### PR TITLE
feat: server-side premium pin generation

### DIFF
--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -94,11 +94,24 @@ function AdminUsers() {
     setPinMsg(null);
   };
 
-  const generatePin = () => {
-    const len = Math.floor(Math.random() * 3) + 4; // 4-6
-    let s = '';
-    for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 10);
-    setPin(s);
+  const generatePin = async () => {
+    setPinBusy(true);
+    setPinMsg(null);
+    try {
+      const { data } = await supabaseBrowser.auth.getSession();
+      const tok = data?.session?.access_token;
+      if (!tok) throw new Error('No session');
+      const r = await fetch('/api/admin/premium/generate-pin', {
+        headers: { Authorization: `Bearer ${tok}` },
+      });
+      const j = await r.json();
+      if (!r.ok || !j?.pin) throw new Error(j?.error || 'Failed');
+      setPin(j.pin);
+    } catch (e: any) {
+      setPinMsg(e?.message || 'Error generating PIN');
+    } finally {
+      setPinBusy(false);
+    }
   };
 
   const callPinApi = async (path: string, body: any) => {

--- a/pages/api/admin/premium/generate-pin.ts
+++ b/pages/api/admin/premium/generate-pin.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { randomInt } from 'crypto';
+import { requireRole } from '@/lib/requireRole';
+
+type Resp = { ok: true; pin: string } | { ok: false; error: string };
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQ = 10;
+const hits = new Map<string, { count: number; time: number }>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = hits.get(ip);
+  if (!entry || now - entry.time > WINDOW_MS) {
+    hits.set(ip, { count: 1, time: now });
+    return false;
+  }
+  entry.count++;
+  entry.time = now;
+  hits.set(ip, entry);
+  return entry.count > MAX_REQ;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Resp>
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
+  }
+
+  try {
+    await requireRole(req, ['admin']);
+  } catch {
+    return res.status(403).json({ ok: false, error: 'NOT_ADMIN' });
+  }
+
+  const ip =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ||
+    req.socket.remoteAddress ||
+    'unknown';
+
+  if (rateLimited(ip)) {
+    return res.status(429).json({ ok: false, error: 'Too many requests' });
+  }
+
+  const len = randomInt(4, 7); // length 4-6
+  let pin = '';
+  for (let i = 0; i < len; i++) {
+    pin += randomInt(0, 10).toString();
+  }
+
+  return res.status(200).json({ ok: true, pin });
+}


### PR DESCRIPTION
## Summary
- generate premium PINs on server with auth and basic rate limiting
- fetch admin premium PINs from new API instead of generating in browser

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4beb5272c832195b98a4da9ae39c9