### PR TITLE
Use token-based styles for FAQ and listening pages

### DIFF
--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -72,7 +72,7 @@ export default function FAQPage() {
               <label className="block">
                 <span className="mb-1.5 inline-block text-small text-grayish">Category</span>
                 <select
-                  className="w-full rounded-ds border bg-white text-lightText dark:bg-dark/50 dark:text-white
+                  className="w-full rounded-ds border bg-lightCard text-lightText dark:bg-dark/50 dark:text-white
                              dark:border-purpleVibe/30 focus:outline-none focus:ring-2 focus:ring-primary py-3 px-3"
                   value={cat}
                   onChange={e => setCat(e.target.value as Cat | 'all')}
@@ -88,7 +88,7 @@ export default function FAQPage() {
                 <details key={i} className="group">
                   <summary
                     className="cursor-pointer select-none font-medium py-3 px-4 rounded-ds card-surface
-                               hover:bg-purpleVibe/10 dark:hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary"
+                               hover:bg-purpleVibe/10 dark:hover:bg-lightCard/5 focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     {f.q}
                   </summary>

--- a/pages/listening/index.tsx
+++ b/pages/listening/index.tsx
@@ -179,11 +179,11 @@ export default function ListeningIndexPage() {
           <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
               <Card key={i} className="card-surface p-6 rounded-ds-2xl">
-                <div className="animate-pulse h-6 w-2/3 bg-gray-200 dark:bg-white/10 rounded mb-3" />
-                <div className="animate-pulse h-4 w-1/3 bg-gray-200 dark:bg-white/10 rounded mb-6" />
+                <div className="skeleton h-6 w-2/3 rounded mb-3" />
+                <div className="skeleton h-4 w-1/3 rounded mb-6" />
                 <div className="flex gap-2">
-                  <div className="animate-pulse h-9 w-24 bg-gray-200 dark:bg-white/10 rounded" />
-                  <div className="animate-pulse h-9 w-24 bg-gray-200 dark:bg-white/10 rounded" />
+                  <div className="skeleton h-9 w-24 rounded" />
+                  <div className="skeleton h-9 w-24 rounded" />
                 </div>
               </Card>
             ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,11 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 .card-surface { @apply rounded-ds-2xl border bg-lightCard border-lightBorder text-lightText; }
 .dark .card-surface { @apply border-purpleVibe/20 backdrop-blur-md bg-purpleVibe/10 text-foreground; }
 
+/* =========================
+   Skeleton placeholder
+   ========================= */
+.skeleton { @apply animate-pulse bg-border dark:bg-border/10; }
+
 /* Glass card variant */
 .card-glass {
   @apply rounded-ds-2xl backdrop-blur-xl border shadow-glowLg;


### PR DESCRIPTION
## Summary
- replace raw `bg-white` use in FAQ select with `bg-lightCard`
- refactor listening test skeletons to use new `skeleton` utility
- add shared `.skeleton` utility based on border token

## Testing
- `npm test` *(fails: admin.from is not a function)*
- `npm run lint` *(fails: EmptyState is not defined; Parsing error in PaywallGate.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac4fda4083218bf231c2a2a6d1e1