### PR TITLE
feat: add skeleton design system component

### DIFF
--- a/components/design-system/Skeleton.tsx
+++ b/components/design-system/Skeleton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const Skeleton: React.FC<{ className?: string }> = ({ className = '' }) => {
-  return <div className={`animate-pulse bg-border dark:bg-border/20 rounded ${className}`} />;
+  return <div className={`animate-pulse rounded bg-border/50 dark:bg-card/20 ${className}`} />;
 };

--- a/doc/design_system_implementation_guide_pages_router.md
+++ b/doc/design_system_implementation_guide_pages_router.md
@@ -21,6 +21,7 @@ components/
     Card.tsx
     Container.tsx
     GradientText.tsx
+    Skeleton.tsx
     StreakIndicator.tsx
   sections/
     Header.tsx
@@ -105,6 +106,7 @@ module.exports = {
 - **Button** — variants: `primary`, `secondary`, `accent`.
 - **GradientText** — brand gradient title text.
 - **StreakIndicator** — example chip (pattern for badges/pills).
+- **Skeleton** — loading placeholder component for content.
 
 **Extending Button (example):**
 
@@ -184,7 +186,7 @@ export default function Page() {
 
 ```tsx
 <Card className="p-6">
-  <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+  <Skeleton className="h-6 w-40" />
 </Card>
 ```
 

--- a/pages/learning/skills/[skill].tsx
+++ b/pages/learning/skills/[skill].tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 import { StreakIndicator } from '@/components/design-system/StreakIndicator';
+import { Skeleton } from '@/components/design-system/Skeleton';
 import type { Profile, AIPlan } from '@/types/profile';
 
 const supabase = createClient(
@@ -86,8 +87,8 @@ export default function Dashboard() {
           <div className="grid gap-6 md:grid-cols-3">
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="p-6 rounded-ds-2xl">
-                <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
-                <div className="mt-4 animate-pulse h-24 bg-gray-200 dark:bg-white/10 rounded" />
+                <Skeleton className="h-6 w-40" />
+                <Skeleton className="mt-4 h-24" />
               </Card>
             ))}
           </div>

--- a/pages/listening/index.tsx
+++ b/pages/listening/index.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
+import { Skeleton } from '@/components/design-system/Skeleton';
 
 type TestRow = {
   slug: string;
@@ -179,11 +180,11 @@ export default function ListeningIndexPage() {
           <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
               <Card key={i} className="card-surface p-6 rounded-ds-2xl">
-                <div className="animate-pulse h-6 w-2/3 bg-gray-200 dark:bg-white/10 rounded mb-3" />
-                <div className="animate-pulse h-4 w-1/3 bg-gray-200 dark:bg-white/10 rounded mb-6" />
+                <Skeleton className="h-6 w-2/3 mb-3" />
+                <Skeleton className="h-4 w-1/3 mb-6" />
                 <div className="flex gap-2">
-                  <div className="animate-pulse h-9 w-24 bg-gray-200 dark:bg-white/10 rounded" />
-                  <div className="animate-pulse h-9 w-24 bg-gray-200 dark:bg-white/10 rounded" />
+                  <Skeleton className="h-9 w-24" />
+                  <Skeleton className="h-9 w-24" />
                 </div>
               </Card>
             ))}


### PR DESCRIPTION
## Summary
- add simple Skeleton design-system component with token-based colors
- use Skeleton component on listening and learning skill pages
- document Skeleton usage in design system guide

## Testing
- `npm test` *(fails: admin.from is not a function in pages/api/auth/login-event.ts)*
- `npm run lint` *(fails: Parsing error: Unterminated string literal in components/paywall/PaywallGate.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac5d60948321991f27574bf32e42