### PR TITLE
Tokenize header glass background colors

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,7 +21,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 /* =========================
    Header / Nav (GLOBAL)
    ========================= */
-.header-glass { @apply text-lightText bg-white/90 backdrop-blur-md border-b border-border; }
+.header-glass { @apply text-lightText bg-lightCard/90 backdrop-blur-md border-b border-border; }
 .dark .header-glass { @apply text-foreground bg-dark/95 border-purpleVibe/20; }
 
 /* Navigation pill with underline */


### PR DESCRIPTION
## Summary
- use lightCard token for header glass background
- keep dark header glass using dark token

## Testing
- `npm run lint` *(fails: Parsing error: Unterminated string literal in components/paywall/PaywallGate.tsx)*
- `npm test` *(fails: TypeError: admin.from is not a function in login-event.ts)*
- `npm run build` *(fails: Failed to fetch font `Roboto Slab`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac59cccc8321a5c8cf336bdcad79