### PR TITLE
Show AuthAssistant on all pages

### DIFF
--- a/components/auth/AuthAssistant.tsx
+++ b/components/auth/AuthAssistant.tsx
@@ -19,7 +19,9 @@ export default function AuthAssistant() {
   const router = useRouter();
 
   useEffect(() => {
-    const isLogin = router.pathname.startsWith('/login');
+    const path = router.pathname;
+    const isLogin = path.startsWith('/login');
+    const isSignup = path.startsWith('/signup');
     setMessages([
       {
         role: 'assistant',
@@ -37,7 +39,7 @@ export default function AuthAssistant() {
                 </Link>
                 .
               </>
-            ) : (
+            ) : isSignup ? (
               <>
                 Need help creating an account? Check our{' '}
                 <Link href="/faq" className="underline">
@@ -48,6 +50,14 @@ export default function AuthAssistant() {
                   sign in
                 </Link>{' '}
                 if you already have one.
+              </>
+            ) : (
+              <>
+                Need help with something on this page? You can{' '}
+                <Link href="/faq" className="underline">
+                  browse our FAQ
+                </Link>{' '}
+                or ask a question below.
               </>
             )}
           </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -52,7 +52,6 @@ function InnerApp({ Component, pageProps }: AppProps) {
       /^\/auth\/(login|signup|register)(\/|$)/.test(pathname),
     [pathname]
   );
-  const showAuthAssistant = useMemo(() => /^\/(login|signup)(\/|$)/.test(pathname), [pathname]);
   const isNoChromeRoute = useMemo(
     () => /\/exam(\/|$)|\/exam-room(\/|$)|\/focus-mode(\/|$)/.test(pathname),
     [pathname]
@@ -208,7 +207,7 @@ function InnerApp({ Component, pageProps }: AppProps) {
             {pageBody}
           </>
         )}
-        {showAuthAssistant && <AuthAssistant />}
+        <AuthAssistant />
         <SidebarAI />
       </div>
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- render `AuthAssistant` on every route
- make assistant's initial message generic on non-auth pages

## Testing
- `npm run lint` *(fails: components/paywall/PaywallGate.tsx Parsing error: Unterminated string literal)*
- `npm test` *(fails: TypeError: admin.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac7475888321996f83f3e754d578