### PR TITLE
Remove extra section wrappers from homepage modules

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -83,9 +83,7 @@ export default function HomePage() {
       <ExamStrategy />
 
       {/* Core modules */}
-      <section id="modules" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Modules />
-      </section>
+      <Modules />
 
       {/* Phase-3 retention strip */}
       <section id="scale-retention" className="py-16">
@@ -118,14 +116,10 @@ export default function HomePage() {
       </section>
 
       {/* Monetization always one click away */}
-      <section id="pricing" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Pricing />
-      </section>
+      <Pricing />
 
       {/* Capture demand */}
-      <section id="waitlist" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Waitlist />
-      </section>
+      <Waitlist />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Render Modules, Pricing, and Waitlist components directly on the homepage to rely on their internal `<section>` elements
- Ensure modules, pricing, and waitlist sections expose proper IDs for in-page navigation

## Testing
- `npm test` *(fails: admin.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f703a5788321bf1ff1577d980e79