### PR TITLE
feat: unify landing sections with reusable wrapper

### DIFF
--- a/components/design-system/Section.tsx
+++ b/components/design-system/Section.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Container as DSContainer } from './Container';
+
+export type SectionProps = React.HTMLAttributes<HTMLElement> & {
+  Container?: boolean;
+  containerClassName?: string;
+  children?: React.ReactNode;
+};
+
+export const Section: React.FC<SectionProps> = ({
+  id,
+  className = '',
+  Container = false,
+  containerClassName = '',
+  children,
+  ...rest
+}) => {
+  const content = Container ? <DSContainer className={containerClassName}>{children}</DSContainer> : children;
+  return (
+    <section
+      id={id}
+      className={`py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90 ${className}`}
+      {...rest}
+    >
+      {content}
+    </section>
+  );
+};
+
+export default Section;

--- a/components/sections/CertificationBadges.tsx
+++ b/components/sections/CertificationBadges.tsx
@@ -1,6 +1,7 @@
 // components/sections/CertificationBadges.tsx
 import * as React from 'react';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 
 type Partner = {
@@ -19,43 +20,45 @@ const partners: readonly Partner[] = [
 
 export const CertificationBadges: React.FC = () => {
   return (
-    <Container>
-      <div className="text-center mb-10">
-        <h2 className="font-slab text-h2 tracking-tight text-gradient-primary">
-          Trusted Exam Prep Standards
-        </h2>
-        <p className="text-grayish mt-2">
-          Inspired by leading bodies and aligned with real IELTS marking criteria.
-        </p>
-      </div>
+    <Section id="partners">
+      <Container>
+        <div className="text-center mb-10">
+          <h2 className="font-slab text-h2 tracking-tight text-gradient-primary">
+            Trusted Exam Prep Standards
+          </h2>
+          <p className="text-grayish mt-2">
+            Inspired by leading bodies and aligned with real IELTS marking criteria.
+          </p>
+        </div>
 
-      <div
-        role="list"
-        className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5"
-        aria-label="Trusted standards and inspirations"
-      >
-        {partners.map((p) => (
-          <a
-            key={p.name}
-            href={p.href}
-            role="listitem"
-            className="
-              block rounded-ds-xl border border-border bg-card/60
-              hover:border-electricBlue/40 hover:bg-electricBlue/5
-              transition p-4 text-center
-            "
-          >
-            <div className="text-sm font-medium">{p.name}</div>
-          </a>
-        ))}
-      </div>
+        <div
+          role="list"
+          className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5"
+          aria-label="Trusted standards and inspirations"
+        >
+          {partners.map((p) => (
+            <a
+              key={p.name}
+              href={p.href}
+              role="listitem"
+              className="
+                block rounded-ds-xl border border-border bg-card/60
+                hover:border-electricBlue/40 hover:bg-electricBlue/5
+                transition p-4 text-center
+              "
+            >
+              <div className="text-sm font-medium">{p.name}</div>
+            </a>
+          ))}
+        </div>
 
-      <Card className="mt-6 p-4 rounded-ds-xl text-center bg-card/60 border border-border">
-        <span className="text-small text-muted-foreground">
-          *Names listed as inspirations/standards to describe pedagogy influence. Not official partnerships.
-        </span>
-      </Card>
-    </Container>
+        <Card className="mt-6 p-4 rounded-ds-xl text-center bg-card/60 border border-border">
+          <span className="text-small text-muted-foreground">
+            *Names listed as inspirations/standards to describe pedagogy influence. Not official partnerships.
+          </span>
+        </Card>
+      </Container>
+    </Section>
   );
 };
 

--- a/components/sections/ExamStrategy.tsx
+++ b/components/sections/ExamStrategy.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
@@ -7,7 +8,7 @@ import { NavLink } from '@/components/design-system/NavLink';
 
 export default function ExamStrategy() {
   return (
-    <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+    <Section>
       <Container>
         <div className="flex items-end justify-between gap-4">
           <div>
@@ -85,6 +86,6 @@ export default function ExamStrategy() {
           ))}
         </div>
       </Container>
-    </section>
+    </Section>
   );
 }

--- a/components/sections/Modules.tsx
+++ b/components/sections/Modules.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 import { Badge } from '@/components/design-system/Badge';
 
@@ -102,7 +103,7 @@ const items: Item[] = [
 
 export const Modules: React.FC = () => {
   return (
-    <section id="modules" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+    <Section id="modules">
       <Container>
         <div className="text-center mb-16">
           <h2 className="font-slab text-4xl mb-3 text-gradient-primary">COMPREHENSIVE IELTS MODULES</h2>
@@ -147,6 +148,6 @@ export const Modules: React.FC = () => {
           })}
         </div>
       </Container>
-    </section>
+    </Section>
   );
 };

--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 import { Ribbon } from '@/components/design-system/Ribbon';
 import { Button } from '@/components/design-system/Button';
@@ -63,7 +64,7 @@ const planSlug = (name: Tier['name']) => name.toLowerCase();
 
 export const Pricing: React.FC = () => {
   return (
-    <section id="pricing" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+    <Section id="pricing">
       <Container>
         <div className="text-center mb-16">
           <h2 className="font-slab text-4xl mb-3 text-gradient-primary">FLEXIBLE PRICING PLANS</h2>
@@ -102,6 +103,6 @@ export const Pricing: React.FC = () => {
           ))}
         </div>
       </Container>
-    </section>
+    </Section>
   );
 };

--- a/components/sections/Testimonials.tsx
+++ b/components/sections/Testimonials.tsx
@@ -1,6 +1,7 @@
 // components/sections/Testimonials.tsx
 import * as React from 'react';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 
 export type Testimonial = {
@@ -43,53 +44,55 @@ const items: readonly Testimonial[] = [
 
 export const Testimonials: React.FC = () => {
   return (
-    <Container>
-      <div className="text-center mb-12">
-        <h2 className="font-slab text-h2 tracking-tight text-gradient-primary">Learners Who Leveled Up</h2>
-        <p className="text-grayish mt-2">Real prep. Real gains. Repeatable process.</p>
-      </div>
+    <Section id="testimonials">
+      <Container>
+        <div className="text-center mb-12">
+          <h2 className="font-slab text-h2 tracking-tight text-gradient-primary">Learners Who Leveled Up</h2>
+          <p className="text-grayish mt-2">Real prep. Real gains. Repeatable process.</p>
+        </div>
 
-      <div className="grid gap-6 md:grid-cols-3">
-        {items.map((t) => (
-          <Card
-            key={t.id}
-            className="p-6 rounded-ds-2xl border border-purpleVibe/20 hover:border-purpleVibe/40 transition bg-card/70"
-          >
-            <div className="flex items-center justify-between">
-              <div className="font-semibold">{t.name}</div>
-              <div className="text-electricBlue font-bold" aria-label={`Band score ${t.band}`}>
-                Band {t.band}
+        <div className="grid gap-6 md:grid-cols-3">
+          {items.map((t) => (
+            <Card
+              key={t.id}
+              className="p-6 rounded-ds-2xl border border-purpleVibe/20 hover:border-purpleVibe/40 transition bg-card/70"
+            >
+              <div className="flex items-center justify-between">
+                <div className="font-semibold">{t.name}</div>
+                <div className="text-electricBlue font-bold" aria-label={`Band score ${t.band}`}>
+                  Band {t.band}
+                </div>
               </div>
-            </div>
-            <div className="text-small text-muted-foreground mt-0.5">
-              {t.context}
-              {t.location ? ` • ${t.location}` : ''}
-            </div>
+              <div className="text-small text-muted-foreground mt-0.5">
+                {t.context}
+                {t.location ? ` • ${t.location}` : ''}
+              </div>
 
-            <blockquote className="mt-4 relative pl-4 border-l-4 border-border text-mutedText">
-              “{t.quote}”
-            </blockquote>
+              <blockquote className="mt-4 relative pl-4 border-l-4 border-border text-mutedText">
+                “{t.quote}”
+              </blockquote>
 
-            <div className="mt-5 flex items-center gap-1 text-warning/90" aria-hidden="true">
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star-half-alt" />
-            </div>
-          </Card>
-        ))}
-      </div>
+              <div className="mt-5 flex items-center gap-1 text-warning/90" aria-hidden="true">
+                <i className="fas fa-star" />
+                <i className="fas fa-star" />
+                <i className="fas fa-star" />
+                <i className="fas fa-star" />
+                <i className="fas fa-star-half-alt" />
+              </div>
+            </Card>
+          ))}
+        </div>
 
-      <div className="text-center mt-8">
-        <a
-          href="/reviews"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-ds border border-border hover:bg-electricBlue/5 transition"
-        >
-          Read more reviews <i className="fas fa-arrow-right" aria-hidden />
-        </a>
-      </div>
-    </Container>
+        <div className="text-center mt-8">
+          <a
+            href="/reviews"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-ds border border-border hover:bg-electricBlue/5 transition"
+          >
+            Read more reviews <i className="fas fa-arrow-right" aria-hidden />
+          </a>
+        </div>
+      </Container>
+    </Section>
   );
 };
 

--- a/components/sections/Waitlist.tsx
+++ b/components/sections/Waitlist.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { Card } from '@/components/design-system/Card';
 import { Input } from '@/components/design-system/Input';
 import { Alert } from '@/components/design-system/Alert';
@@ -133,7 +134,7 @@ export default function WaitlistSection() {
   };
 
   return (
-    <section id="waitlist" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+    <Section id="waitlist">
       <Container>
         <div className="text-center max-w-3xl mx-auto mb-10">
           <h2 className="font-slab text-h2 md:text-display tracking-tight uppercase text-gradient-primary">
@@ -209,6 +210,6 @@ export default function WaitlistSection() {
         <p className="text-small text-grayish mt-5 text-center">Have a referral code? Add <code>?ref=YOURCODE</code> to the URL.</p>
         <p className="text-small text-grayish mt-1 text-center">By joining, you agree to receive early-access emails.</p>
       </Container>
-    </section>
+    </Section>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,17 +75,13 @@ export default function HomePage() {
       </section>
 
       {/* Partners */}
-      <section id="partners" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <CertificationBadges />
-      </section>
+      <CertificationBadges />
 
       {/* Strategy → Practise → Review (clear path) */}
       <ExamStrategy />
 
       {/* Core modules */}
-      <section id="modules" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Modules />
-      </section>
+      <Modules />
 
       {/* Phase-3 retention strip */}
       <section id="scale-retention" className="py-16">
@@ -113,19 +109,13 @@ export default function HomePage() {
       </section>
 
       {/* Social proof */}
-      <section id="testimonials" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Testimonials />
-      </section>
+      <Testimonials />
 
       {/* Monetization always one click away */}
-      <section id="pricing" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Pricing />
-      </section>
+      <Pricing />
 
       {/* Capture demand */}
-      <section id="waitlist" className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Waitlist />
-      </section>
+      <Waitlist />
     </>
   );
 }

--- a/pages/waitlist.tsx
+++ b/pages/waitlist.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
-import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 import { WaitlistForm } from '@/components/waitlist/WaitlistForm';
 
 export default function WaitlistPage() {
@@ -9,12 +9,10 @@ export default function WaitlistPage() {
       <Head>
         <title>Join the Waitlist • GramorX</title>
       </Head>
-      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Container className="max-w-xl">
-          <h1 className="font-slab text-display text-center mb-8">Join the Waitlist</h1>
-          <WaitlistForm />
-        </Container>
-      </section>
+      <Section Container containerClassName="max-w-xl">
+        <h1 className="font-slab text-display text-center mb-8">Join the Waitlist</h1>
+        <WaitlistForm />
+      </Section>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add Section component with standard padding and dark-mode background
- swap manual `<section>` tags for partners, testimonials, pricing, waitlist, and other homepage blocks
- allow optional Container wrapping for standalone pages like the waitlist

## Testing
- `npm test` *(fails: admin.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f7075f40832199d10da8fb39b837