### PR TITLE
chore(a11y): hide decorative icons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -32,7 +32,7 @@ function FireStreak({ value }: { value: number }) {
       className="inline-flex items-center gap-1.5 rounded-full bg-primary/15 text-primary px-2.5 py-1 text-sm font-semibold"
       title="Daily streak"
     >
-      <span aria-hidden>🔥</span>
+      <span aria-hidden="true">🔥</span>
       <span className="tabular-nums">{value}</span>
     </span>
   );

--- a/components/SaveItemButton.tsx
+++ b/components/SaveItemButton.tsx
@@ -57,7 +57,7 @@ export const SaveItemButton: React.FC<Props> = ({ resourceId, type = '', categor
       onClick={toggle}
       disabled={loading}
       className="rounded-ds"
-      leadingIcon={<i className={`${saved ? 'fas' : 'far'} fa-bookmark`} />}
+      leadingIcon={<i className={`${saved ? 'fas' : 'far'} fa-bookmark`} aria-hidden="true" />}
     >
       {saved ? 'Saved' : 'Save'}
     </Button>

--- a/components/challenge/ChallengeCohortCard.tsx
+++ b/components/challenge/ChallengeCohortCard.tsx
@@ -64,7 +64,7 @@ export function ChallengeCohortCard({
           <div
             className="absolute left-0 top-0 h-full bg-primary"
             style={{ width: `${Math.min(Math.max(progressPct, 0), 100)}%` }}
-            aria-hidden
+            aria-hidden="true"
           />
         </div>
         <span className="text-xs tabular-nums text-muted-foreground">

--- a/components/design-system/Alert.tsx
+++ b/components/design-system/Alert.tsx
@@ -20,10 +20,10 @@ export const Alert: React.FC<{
       <div className="flex items-start gap-3">
         <div className="mt-0.5">
           {icon ?? (
-            variant === 'success' ? <i className="fas fa-check-circle" /> :
-            variant === 'warning' ? <i className="fas fa-exclamation-triangle" /> :
-            variant === 'error' ? <i className="fas fa-times-circle" /> :
-            <i className="fas fa-info-circle" />
+            variant === 'success' ? <i className="fas fa-check-circle" aria-hidden="true" /> :
+            variant === 'warning' ? <i className="fas fa-exclamation-triangle" aria-hidden="true" /> :
+            variant === 'error' ? <i className="fas fa-times-circle" aria-hidden="true" /> :
+            <i className="fas fa-info-circle" aria-hidden="true" />
           )}
         </div>
         <div>

--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -37,7 +37,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 
 const Spinner: React.FC = () => (
   <span
-    aria-hidden
+    aria-hidden="true"
     className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-foreground/60 border-t-foreground mr-2"
   />
 );

--- a/components/design-system/PasswordInput.tsx
+++ b/components/design-system/PasswordInput.tsx
@@ -15,7 +15,7 @@ export const PasswordInput: React.FC<InputProps> = (props) => {
           aria-label={show ? 'Hide password' : 'Show password'}
           className="focus:outline-none"
         >
-          <i className={`fas ${show ? 'fa-eye-slash' : 'fa-eye'}`} />
+          <i className={`fas ${show ? 'fa-eye-slash' : 'fa-eye'}`} aria-hidden="true" />
         </button>
       }
     />

--- a/components/design-system/Select.tsx
+++ b/components/design-system/Select.tsx
@@ -28,7 +28,7 @@ export const Select: React.FC<SelectProps> = ({ label, hint, error, options = []
           {children}
         </select>
         <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 opacity-70">
-          <ChevronDownIcon className="h-4 w-4" aria-hidden />
+          <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
         </span>
       </div>
       {error ? (

--- a/components/design-system/ThemeToggle.tsx
+++ b/components/design-system/ThemeToggle.tsx
@@ -17,9 +17,9 @@ export function ThemeToggle() {
       title="Toggle theme"
     >
       {isDark ? (
-        <MoonIcon className="h-4 w-4" aria-hidden />
+        <MoonIcon className="h-4 w-4" aria-hidden="true" />
       ) : (
-        <SunIcon className="h-4 w-4" aria-hidden />
+        <SunIcon className="h-4 w-4" aria-hidden="true" />
       )}
       <span className="opacity-80">{isDark ? 'Dark' : 'Light'}</span>
     </button>

--- a/components/design-system/UserMenu.tsx
+++ b/components/design-system/UserMenu.tsx
@@ -44,10 +44,10 @@ export const UserMenu: React.FC<{
 
   const defaultItems: MenuItem[] = useMemo(() => {
     const base: MenuItem[] = [
-      { label: 'Profile', href: '/profile', icon: <i className="fas fa-id-badge" aria-hidden /> },
-      { label: 'Account', href: '/account', icon: <i className="fas fa-user" aria-hidden /> },
+      { label: 'Profile', href: '/profile', icon: <i className="fas fa-id-badge" aria-hidden="true" /> },
+      { label: 'Account', href: '/account', icon: <i className="fas fa-user" aria-hidden="true" /> },
     ];
-    if (onSignOut) base.push({ label: 'Sign out', onClick: onSignOut, icon: <i className="fas fa-sign-out-alt" aria-hidden /> });
+    if (onSignOut) base.push({ label: 'Sign out', onClick: onSignOut, icon: <i className="fas fa-sign-out-alt" aria-hidden="true" /> });
     return base;
   }, [onSignOut]);
 

--- a/components/feature/HeaderStreakChip.tsx
+++ b/components/feature/HeaderStreakChip.tsx
@@ -37,7 +37,7 @@ export function HeaderStreakChip() {
 
   return (
     <div className="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-sm bg-background/70 backdrop-blur">
-      <span aria-hidden>🔥</span>
+      <span aria-hidden="true">🔥</span>
       <span className="font-medium">{days}</span>
       <span className="text-muted-foreground">day streak</span>
     </div>

--- a/components/listening/AudioSectionsPlayer.tsx
+++ b/components/listening/AudioSectionsPlayer.tsx
@@ -288,7 +288,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
             className="px-3 py-2 rounded-ds border border-gray-200 dark:border-white/10 hover:bg-white/5"
             aria-label="Previous section"
           >
-            <i className="fas fa-step-backward" />
+            <i className="fas fa-step-backward" aria-hidden="true" />
           </button>
           {playing ? (
             <button
@@ -297,7 +297,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
               className="px-4 py-2 rounded-ds-xl bg-primary text-white hover:opacity-90"
               aria-label="Pause"
             >
-              <i className="fas fa-pause" /> <span className="ml-2">Pause</span>
+              <i className="fas fa-pause" aria-hidden="true" /> <span className="ml-2">Pause</span>
             </button>
           ) : (
             <button
@@ -307,7 +307,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
               className="px-4 py-2 rounded-ds-xl bg-primary text-white disabled:opacity-50 hover:opacity-90"
               aria-label="Play"
             >
-              <i className="fas fa-play" /> <span className="ml-2">Play</span>
+              <i className="fas fa-play" aria-hidden="true" /> <span className="ml-2">Play</span>
             </button>
           )}
           <button
@@ -316,7 +316,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
             className="px-3 py-2 rounded-ds border border-gray-200 dark:border-white/10 hover:bg-white/5"
             aria-label="Next section"
           >
-            <i className="fas fa-step-forward" />
+            <i className="fas fa-step-forward" aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/components/nav/ModulesMenu.tsx
+++ b/components/nav/ModulesMenu.tsx
@@ -63,7 +63,7 @@ export function ModulesMenu() {
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        Modules <span aria-hidden>▾</span>
+        Modules <span aria-hidden="true">▾</span>
       </button>
 
       {mounted && open && rect &&

--- a/components/navigation/BottomNav.tsx
+++ b/components/navigation/BottomNav.tsx
@@ -39,7 +39,7 @@ export const BottomNav: React.FC = () => {
               className="flex flex-col items-center gap-1 py-2 text-xs text-gray-600 dark:text-grayish [&.is-active]:text-vibrantPurple"
               onClick={handleClick(href)}
             >
-              <i className={`fas ${icon} text-lg`} aria-hidden />
+              <i className={`fas ${icon} text-lg`} aria-hidden="true" />
               <span>{label}</span>
             </NavLink>
           </li>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -131,7 +131,7 @@ export const Hero: React.FC<HeroProps> = ({ onStreakChange }) => {
           {/* Word of the Day + streak */}
           <Card className="mt-6 max-w-md p-6 rounded-2xl mx-auto">
             <h3 className="text-primary font-semibold text-xl mb-4">
-              <i className="fas fa-book mr-2" /> Word of the Day
+              <i className="fas fa-book mr-2" aria-hidden="true" /> Word of the Day
             </h3>
 
             {auth === 'guest' && (
@@ -149,13 +149,13 @@ export const Hero: React.FC<HeroProps> = ({ onStreakChange }) => {
                 </div>
 
                 <Button variant={data.learnedToday ? 'secondary' : 'accent'} onClick={markLearned} disabled={busy || data.learnedToday}>
-                  <i className="fas fa-check-circle mr-2" />
+                  <i className="fas fa-check-circle mr-2" aria-hidden="true" />
                   {data.learnedToday ? 'Learned today' : 'Mark as Learned'}
                 </Button>
 
                 <div className="mt-4 rounded-xl p-4 bg-card border border-border text-left">
                   <div className="flex items-center gap-4">
-                    <div className="text-2xl" aria-hidden><i className="fas fa-fire" /></div>
+                    <div className="text-2xl" aria-hidden="true"><i className="fas fa-fire" aria-hidden="true" /></div>
                     <div>
                       <h4 className="font-semibold">Your Learning Streak</h4>
                       <div className="text-muted-foreground">Current streak: <span className="font-bold">{data.streakDays} {data.streakDays === 1 ? 'day' : 'days'}</span></div>

--- a/components/sections/Modules.tsx
+++ b/components/sections/Modules.tsx
@@ -118,11 +118,11 @@ export const Modules: React.FC = () => {
                 </Badge>
 
                 <div className="w-17.5 h-17.5 rounded-full flex items-center justify-center mb-6 text-white text-2xl bg-gradient-to-br from-purpleVibe to-electricBlue">
-                  <i className={`fas ${m.icon}`} />
+                  <i className={`fas ${m.icon}`} aria-hidden="true" />
                 </div>
 
                 <h3 className="text-xl font-semibold mb-3 flex items-center gap-2">
-                  <i className="fas fa-circle-check text-neonGreen" />
+                  <i className="fas fa-circle-check text-neonGreen" aria-hidden="true" />
                   {m.title}
                 </h3>
 
@@ -138,7 +138,7 @@ export const Modules: React.FC = () => {
                 {m.href && (
                   <div className="mt-4">
                     <Link href={m.href} className="inline-flex items-center gap-2 text-electricBlue hover:underline">
-                      Open <i className="fas fa-arrow-right" aria-hidden />
+                      Open <i className="fas fa-arrow-right" aria-hidden="true" />
                     </Link>
                   </div>
                 )}

--- a/components/sections/Specialties.tsx
+++ b/components/sections/Specialties.tsx
@@ -58,7 +58,7 @@ export const Specialties: React.FC = () => {
             <Card key={s.title} className="p-6 rounded-ds-2xl border border-purpleVibe/20 hover:border-purpleVibe/40 transition">
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
-                  <i className={`fas ${s.icon}`} aria-hidden />
+                  <i className={`fas ${s.icon}`} aria-hidden="true" />
                 </div>
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
@@ -68,7 +68,7 @@ export const Specialties: React.FC = () => {
                   <p className="text-muted-foreground mt-1">{s.desc}</p>
                   <div className="mt-3">
                     <Link href={s.href} className="text-electricBlue hover:underline inline-flex items-center gap-2">
-                      Explore <i className="fas fa-arrow-right" aria-hidden />
+                      Explore <i className="fas fa-arrow-right" aria-hidden="true" />
                     </Link>
                   </div>
                 </div>

--- a/components/sections/Testimonials.tsx
+++ b/components/sections/Testimonials.tsx
@@ -71,11 +71,11 @@ export const Testimonials: React.FC = () => {
             </blockquote>
 
             <div className="mt-5 flex items-center gap-1 text-warning/90" aria-hidden="true">
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star" />
-              <i className="fas fa-star-half-alt" />
+              <i className="fas fa-star" aria-hidden="true" />
+              <i className="fas fa-star" aria-hidden="true" />
+              <i className="fas fa-star" aria-hidden="true" />
+              <i className="fas fa-star" aria-hidden="true" />
+              <i className="fas fa-star-half-alt" aria-hidden="true" />
             </div>
           </Card>
         ))}
@@ -86,7 +86,7 @@ export const Testimonials: React.FC = () => {
           href="/reviews"
           className="inline-flex items-center gap-2 px-4 py-2 rounded-ds border border-border hover:bg-electricBlue/5 transition"
         >
-          Read more reviews <i className="fas fa-arrow-right" aria-hidden />
+          Read more reviews <i className="fas fa-arrow-right" aria-hidden="true" />
         </a>
       </div>
     </Container>

--- a/components/sections/Waitlist.tsx
+++ b/components/sections/Waitlist.tsx
@@ -197,10 +197,10 @@ export default function WaitlistSection() {
 
             <div className="md:col-span-2 pt-1">
               <Button type="submit" variant="primary" disabled={!canSubmit} className="w-full rounded-full py-5 text-h3 font-semibold">
-                <i className="fas fa-lock mr-2" aria-hidden /> {loading ? 'Securing…' : 'Secure Your Early Access'}
+                <i className="fas fa-lock mr-2" aria-hidden="true" /> {loading ? 'Securing…' : 'Secure Your Early Access'}
               </Button>
               <div className="text-center text-small mt-3 text-electricBlue">
-                <i className="fas fa-gift mr-2" aria-hidden /> First 500 get 30% off for 3 months
+                <i className="fas fa-gift mr-2" aria-hidden="true" /> First 500 get 30% off for 3 months
               </div>
             </div>
           </form>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -697,5 +697,5 @@ function StatusDot({ state }: { state: ProviderStatus['state'] }) {
       : state === 'degraded'
       ? 'bg-amber-500'
       : 'bg-red-500';
-  return <span className={`inline-block w-2.5 h-2.5 rounded-full ${cls}`} aria-hidden />;
+  return <span className={`inline-block w-2.5 h-2.5 rounded-full ${cls}`} aria-hidden="true" />;
 }

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -120,7 +120,7 @@ export default function BlogIndex() {
                 placeholder="Try “t/f/ng”, “cue card”, “study plan”…"
                 value={q}
                 onChange={e => { setQ(e.currentTarget.value); setPage(1); }}
-                iconLeft={<i className="fas fa-search" aria-hidden />}
+                iconLeft={<i className="fas fa-search" aria-hidden="true" />}
               />
               <label className="block">
                 <span className="mb-1.5 inline-block text-small text-grayish">Category</span>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -67,7 +67,7 @@ export default function FAQPage() {
                 placeholder="Try “reset password”, “AI scoring”, “mic recording”…"
                 value={term}
                 onChange={e => setTerm(e.currentTarget.value)}
-                iconLeft={<i className="fas fa-search" aria-hidden />}
+                iconLeft={<i className="fas fa-search" aria-hidden="true" />}
               />
               <label className="block">
                 <span className="mb-1.5 inline-block text-small text-grayish">Category</span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -67,7 +67,7 @@ export default function HomePage() {
                 "
               >
                 <span>{x.label}</span>
-                <i className={`fas ${x.icon} text-grayish`} aria-hidden />
+                <i className={`fas ${x.icon} text-grayish`} aria-hidden="true" />
               </Link>
             ))}
           </div>
@@ -99,7 +99,7 @@ export default function HomePage() {
               <Link key={c.href} href={c.href} className="rounded-ds-2xl border border-purpleVibe/20 p-6 hover:border-purpleVibe/40 hover:-translate-y-1 transition block">
                 <div className="flex items-start gap-4">
                   <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
-                    <i className={`fas ${c.icon}`} />
+                    <i className={`fas ${c.icon}`} aria-hidden="true" />
                   </div>
                   <div>
                     <h3 className="text-h3 mb-1">{c.h}</h3>

--- a/pages/listening/[slug].tsx
+++ b/pages/listening/[slug].tsx
@@ -414,9 +414,11 @@ export default function ListeningTestPage() {
                             className={`w-full text-left p-3.5 rounded-ds border ${cls}`}
                           >
                             <span className="mr-2">{opt}</span>
-                            {checked && correct && <i className="fas fa-check-circle text-success" aria-hidden />}
+                            {checked && correct && (
+                              <i className="fas fa-check-circle text-success" aria-label="Correct" />
+                            )}
                             {checked && !correct && chosen && (
-                              <i className="fas fa-times-circle text-sunsetOrange" aria-hidden />
+                              <i className="fas fa-times-circle text-sunsetOrange" aria-label="Incorrect" />
                             )}
                           </button>
                         </li>

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -94,25 +94,25 @@ export default function LoginOptions() {
   const features = [
     (
       <>
-        <i className="fas fa-shield-alt text-success" aria-hidden />
+        <i className="fas fa-shield-alt text-success" aria-hidden="true" />
         Secure OAuth (Apple, Google, Facebook)
       </>
     ),
     (
       <>
-        <i className="fas fa-mobile-alt" aria-hidden />
+        <i className="fas fa-mobile-alt" aria-hidden="true" />
         Phone OTP sign-in
       </>
     ),
     (
       <>
-        <i className="fas fa-envelope" aria-hidden />
+        <i className="fas fa-envelope" aria-hidden="true" />
         Email &amp; Password
       </>
     ),
     (
       <>
-        <i className="fas fa-chart-line text-electricBlue" aria-hidden />
+        <i className="fas fa-chart-line text-electricBlue" aria-hidden="true" />
         Personalized study plan &amp; analytics
       </>
     ),

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -48,19 +48,19 @@ export default function SignupOptions() {
   const features = [
     (
       <>
-        <i className="fas fa-user-check" aria-hidden />
+        <i className="fas fa-user-check" aria-hidden="true" />
         Apple / Google / Facebook
       </>
     ),
     (
       <>
-        <i className="fas fa-envelope" aria-hidden />
+        <i className="fas fa-envelope" aria-hidden="true" />
         Email &amp; password
       </>
     ),
     (
       <>
-        <i className="fas fa-mobile-alt" aria-hidden />
+        <i className="fas fa-mobile-alt" aria-hidden="true" />
         Phone (OTP)
       </>
     ),


### PR DESCRIPTION
## Summary
- add `aria-hidden` to decorative icons in hero, modules, and retention strip
- audit components and pages to ensure icons are hidden or labeled

## Testing
- `npm test` *(fails: admin.from is not a function)*
- `npm run lint` *(fails: EmptyState is not defined; Parsing error: Unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f7099b9483218b3af893ca79ddc4