### PR TITLE
refactor: use Section component on home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useLocale } from '@/lib/locale';
-import { Container } from '@/components/design-system/Container';
+import { Section } from '@/components/design-system/Section';
 
 // Hero is heavy → hydrate client only
 const Hero = dynamic(
@@ -48,31 +48,29 @@ export default function HomePage() {
       <Hero onStreakChange={onStreakChange} />
 
       {/* Phase-3: Quick Command Center (go anywhere, from anywhere) */}
-      <section id="command-center" className="py-12">
-        <Container>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-            {[
-              { label: 'Listening', href: '/listening', icon: 'fa-headphones' },
-              { label: 'Reading', href: '/reading', icon: 'fa-book-open' },
-              { label: 'Writing', href: '/writing', icon: 'fa-pen-nib' },
-              { label: 'Speaking', href: '/speaking', icon: 'fa-microphone' },
-              { label: 'Progress', href: '/progress', icon: 'fa-chart-line' },
-            ].map((x) => (
-              <Link
-                key={x.href}
-                href={x.href}
-                className="
-                  rounded-ds-xl border border-border px-4 py-3 text-sm font-medium
-                  hover:bg-electricBlue/5 transition flex items-center justify-between
-                "
-              >
-                <span>{x.label}</span>
-                <i className={`fas ${x.icon} text-grayish`} aria-hidden="true" />
-              </Link>
-            ))}
-          </div>
-        </Container>
-      </section>
+      <Section id="command-center" Container className="py-12">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          {[
+            { label: 'Listening', href: '/listening', icon: 'fa-headphones' },
+            { label: 'Reading', href: '/reading', icon: 'fa-book-open' },
+            { label: 'Writing', href: '/writing', icon: 'fa-pen-nib' },
+            { label: 'Speaking', href: '/speaking', icon: 'fa-microphone' },
+            { label: 'Progress', href: '/progress', icon: 'fa-chart-line' },
+          ].map((x) => (
+            <Link
+              key={x.href}
+              href={x.href}
+              className="
+                rounded-ds-xl border border-border px-4 py-3 text-sm font-medium
+                hover:bg-electricBlue/5 transition flex items-center justify-between
+              "
+            >
+              <span>{x.label}</span>
+              <i className={`fas ${x.icon} text-grayish`} aria-hidden="true" />
+            </Link>
+          ))}
+        </div>
+      </Section>
 
       {/* Partners */}
       <CertificationBadges />
@@ -84,29 +82,27 @@ export default function HomePage() {
       <Modules />
 
       {/* Phase-3 retention strip */}
-      <section id="scale-retention" className="py-16">
-        <Container>
-          <div className="grid gap-4 md:grid-cols-3">
-            {[
-              { h: '14-Day Challenge', p: 'Join cohorts, finish daily tasks, climb leaderboard.', href: '/challenge', icon: 'fa-trophy' },
-              { h: 'Shareable Certificate', p: 'Finish a challenge to generate a branded cert.', href: '/cert/sample', icon: 'fa-certificate' },
-              { h: 'Teacher Pilot', p: 'Assign tasks and track students (beta).', href: '/teacher', icon: 'fa-chalkboard-teacher' },
-            ].map((c) => (
-              <Link key={c.href} href={c.href} className="rounded-ds-2xl border border-purpleVibe/20 p-6 hover:border-purpleVibe/40 hover:-translate-y-1 transition block">
-                <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
-                    <i className={`fas ${c.icon}`} aria-hidden="true" />
-                  </div>
-                  <div>
-                    <h3 className="text-h3 mb-1">{c.h}</h3>
-                    <p className="text-grayish">{c.p}</p>
-                  </div>
+      <Section id="scale-retention" Container className="py-16">
+        <div className="grid gap-4 md:grid-cols-3">
+          {[
+            { h: '14-Day Challenge', p: 'Join cohorts, finish daily tasks, climb leaderboard.', href: '/challenge', icon: 'fa-trophy' },
+            { h: 'Shareable Certificate', p: 'Finish a challenge to generate a branded cert.', href: '/cert/sample', icon: 'fa-certificate' },
+            { h: 'Teacher Pilot', p: 'Assign tasks and track students (beta).', href: '/teacher', icon: 'fa-chalkboard-teacher' },
+          ].map((c) => (
+            <Link key={c.href} href={c.href} className="rounded-ds-2xl border border-purpleVibe/20 p-6 hover:border-purpleVibe/40 hover:-translate-y-1 transition block">
+              <div className="flex items-start gap-4">
+                <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
+                  <i className={`fas ${c.icon}`} aria-hidden="true" />
                 </div>
-              </Link>
-            ))}
-          </div>
-        </Container>
-      </section>
+                <div>
+                  <h3 className="text-h3 mb-1">{c.h}</h3>
+                  <p className="text-grayish">{c.p}</p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </Section>
 
       {/* Social proof */}
       <Testimonials />


### PR DESCRIPTION
## Summary
- wrap home page command center and scale retention sections in `Section`
- remove direct `Container` usage by leveraging `Section`'s `Container` prop
- adjust padding to preserve original spacing

## Testing
- `npx next lint --file pages/index.tsx`
- `npm run lint` *(fails: Parsing error: Unterminated string literal in `components/paywall/PaywallGate.tsx`)*
- `npm test` *(fails: TypeError: admin.from is not a function in `pages/api/auth/login-event.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8458bb7248321b8635152b00930bd