### PR TITLE
Refactor footer links into data module with translations

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,25 +13,11 @@ import {
   MapPinIcon,
   ClockIcon,
 } from '@/components/design-system/icons';
-
-const RESOURCES = [
-  { href: '/predictor', label: 'Band Score Predictor' },
-  { href: '/listening', label: 'Listening Practice' },
-  { href: '/reading', label: 'Reading Practice' },
-  { href: '/writing', label: 'Writing Task Samples' },
-  { href: '/speaking', label: 'Speaking Questions' },
-] as const;
-
-const QUICK = [
-  { href: '/pricing', label: 'Pricing & Plans' },
-  { href: '/account/referrals', label: 'Referral Rewards' },
-  { href: '/partners', label: 'Partner Program' },
-  { href: '/support', label: 'Support' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/faq', label: 'FAQ' },
-] as const;
+import { resources, quickLinks, contactInfo } from '@/data/footerLinks';
+import { useLocale } from '@/lib/locale';
 
 export const Footer: React.FC = () => {
+  const { t } = useLocale();
   return (
     <footer className="py-24 border-t border-border">
       <Container>
@@ -58,9 +44,9 @@ export const Footer: React.FC = () => {
               IELTS Resources
             </h3>
             <ul className="space-y-2">
-              {RESOURCES.map((x) => (
+              {resources.map((x) => (
                 <li key={x.label} className="text-muted-foreground">
-                  <NavLink href={x.href} label={x.label} className="!px-0 !py-1" />
+                  <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
                 </li>
               ))}
             </ul>
@@ -72,9 +58,9 @@ export const Footer: React.FC = () => {
               Quick Links
             </h3>
             <ul className="space-y-2">
-              {QUICK.map((x) => (
+              {quickLinks.map((x) => (
                 <li key={x.label} className="text-muted-foreground">
-                  <NavLink href={x.href} label={x.label} className="!px-0 !py-1" />
+                  <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
                 </li>
               ))}
             </ul>
@@ -88,21 +74,21 @@ export const Footer: React.FC = () => {
             <ul className="space-y-3 text-muted-foreground">
               <li>
                 <MailIcon className="mr-2 inline h-4 w-4" />
-                <a href="mailto:info@solvioadvisors.com" className="hover:underline">
-                  info@solvioadvisors.com
+                <a href={`mailto:${t(contactInfo.email)}`} className="hover:underline">
+                  {t(contactInfo.email)}
                 </a>
               </li>
               <li>
                 <PhoneIcon className="mr-2 inline h-4 w-4" />
-                <a href="tel:+19722954571" className="hover:underline">
-                  +1 (972) 295-4571
+                <a href={`tel:${t(contactInfo.phone)}`} className="hover:underline">
+                  {t(contactInfo.phone)}
                 </a>
               </li>
               <li>
-                <MapPinIcon className="mr-2 inline h-4 w-4" /> Houston, USA
+                <MapPinIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.location)}
               </li>
               <li>
-                <ClockIcon className="mr-2 inline h-4 w-4" /> Support: 24/7
+                <ClockIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.support)}
               </li>
             </ul>
           </div>

--- a/data/footerLinks.ts
+++ b/data/footerLinks.ts
@@ -1,0 +1,29 @@
+export type FooterLink = {
+  href: string;
+  label: string; // translation key
+};
+
+export const resources: FooterLink[] = [
+  { href: '/predictor', label: 'footer.resources.bandScorePredictor' },
+  { href: '/listening', label: 'footer.resources.listeningPractice' },
+  { href: '/reading', label: 'footer.resources.readingPractice' },
+  { href: '/writing', label: 'footer.resources.writingTaskSamples' },
+  { href: '/speaking', label: 'footer.resources.speakingQuestions' },
+];
+
+export const quickLinks: FooterLink[] = [
+  { href: '/pricing', label: 'footer.quickLinks.pricingPlans' },
+  { href: '/account/referrals', label: 'footer.quickLinks.referralRewards' },
+  { href: '/partners', label: 'footer.quickLinks.partnerProgram' },
+  { href: '/support', label: 'footer.quickLinks.support' },
+  { href: '/blog', label: 'footer.quickLinks.blog' },
+  { href: '/faq', label: 'footer.quickLinks.faq' },
+];
+
+export const contactInfo = {
+  email: 'footer.contact.email',
+  phone: 'footer.contact.phone',
+  location: 'footer.contact.location',
+  support: 'footer.contact.supportHours',
+} as const;
+

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -7,5 +7,28 @@
   "Error": "Error",
   "Preview (English)": "Preview (English)",
   "Preview (Urdu)": "Preview (Urdu)",
-  "Current locale": "Current locale"
+  "Current locale": "Current locale",
+  "footer": {
+    "resources": {
+      "bandScorePredictor": "Band Score Predictor",
+      "listeningPractice": "Listening Practice",
+      "readingPractice": "Reading Practice",
+      "writingTaskSamples": "Writing Task Samples",
+      "speakingQuestions": "Speaking Questions"
+    },
+    "quickLinks": {
+      "pricingPlans": "Pricing & Plans",
+      "referralRewards": "Referral Rewards",
+      "partnerProgram": "Partner Program",
+      "support": "Support",
+      "blog": "Blog",
+      "faq": "FAQ"
+    },
+    "contact": {
+      "email": "info@solvioadvisors.com",
+      "phone": "+1 (972) 295-4571",
+      "location": "Houston, USA",
+      "supportHours": "Support: 24/7"
+    }
+  }
 }

--- a/locales/ur/common.json
+++ b/locales/ur/common.json
@@ -7,5 +7,28 @@
   "Error": "خرابی",
   "Preview (English)": "پیش منظر (انگریزی)",
   "Preview (Urdu)": "پیش منظر (اردو)",
-  "Current locale": "موجودہ زبان"
+  "Current locale": "موجودہ زبان",
+  "footer": {
+    "resources": {
+      "bandScorePredictor": "بینڈ اسکور پیش گو",
+      "listeningPractice": "سننے کی مشق",
+      "readingPractice": "پڑھنے کی مشق",
+      "writingTaskSamples": "لکھنے کے ٹاسک نمونے",
+      "speakingQuestions": "بولنے کے سوالات"
+    },
+    "quickLinks": {
+      "pricingPlans": "قیمتیں اور پلانز",
+      "referralRewards": "ریفریل انعامات",
+      "partnerProgram": "پارٹنر پروگرام",
+      "support": "مدد",
+      "blog": "بلاگ",
+      "faq": "عمومی سوالات"
+    },
+    "contact": {
+      "email": "info@solvioadvisors.com",
+      "phone": "+1 (972) 295-4571",
+      "location": "ہیوسٹن، امریکہ",
+      "supportHours": "سپورٹ: 24/7"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- centralize footer link and contact metadata in `data/footerLinks.ts`
- import footer data in `Footer` and wrap labels/contact in translations
- add English and Urdu locale entries for new footer links and contact info

## Testing
- `npm test` *(fails: TypeError: admin.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b76fea48321b645b80ab435757a