### PR TITLE
Refactor header navigation into modular components

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,64 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useTheme } from 'next-themes';
 import { Container } from '@/components/design-system/Container';
-import { NavLink } from '@/components/design-system/NavLink';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
-import { UserMenu } from '@/components/design-system/UserMenu';
-import { NotificationBell } from '@/components/design-system/NotificationBell';
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { DesktopNav } from '@/components/navigation/DesktopNav';
+import { MobileNav } from '@/components/navigation/MobileNav';
 
-type ModuleLink = { label: string; href: string; desc?: string };
-
-const MODULE_LINKS: ModuleLink[] = [
-  { label: 'Listening', href: '/listening', desc: 'Audio comprehension drills' },
-  { label: 'Reading', href: '/reading', desc: 'Short passages & skimming' },
-  { label: 'Writing', href: '/writing', desc: 'Prompts, structure & style' },
-  { label: 'Speaking', href: '/speaking', desc: 'Pronunciation & fluency' },
-];
-
-const NAV: ReadonlyArray<{ href: string; label: string }> = [
-  { href: '/predictor', label: 'Band Predictor' },
-  { href: '/pricing', label: 'Pricing' },
-];
-
-// 🔥 Fire streak pill (token colors)
-function FireStreak({ value }: { value: number }) {
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full bg-primary/15 text-primary px-2.5 py-1 text-sm font-semibold"
-      title="Daily streak"
-    >
-      <span aria-hidden="true">🔥</span>
-      <span className="tabular-nums">{value}</span>
-    </span>
-  );
-}
-
-// Icon-only theme toggle
-function IconOnlyThemeToggle() {
-  const { theme, setTheme, resolvedTheme } = useTheme();
-  const isDark = (theme ?? resolvedTheme) === 'dark';
-  return (
-    <button
-      type="button"
-      aria-label="Toggle theme"
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted"
-    >
-      {isDark ? (
-        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
-          <path d="M6.76 4.84 5.34 3.42 3.92 4.84 5.34 6.26 6.76 4.84zM1 13h3v-2H1v2zm10 10h2v-3h-2v3zm9-10v-2h-3v2h3zm-2.76 7.16 1.42 1.42 1.42-1.42-1.42-1.42-1.42 1.42zM12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm7-1.58 1.42-1.42L19 0.58l-1.42 1.42L19 3.42zM4.84 17.24 3.42 18.66l1.42 1.42 1.42-1.42-1.42-1.42z" />
-        </svg>
-      ) : (
-        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
-      )}
-    </button>
-  );
-}
 
 export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const router = useRouter();
@@ -235,308 +183,29 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
             </span>
           </Link>
 
-          {/* Desktop */}
-          <nav className="hidden md:block" aria-label="Primary">
-            <ul className="flex items-center gap-3 relative">
-              {user.id && <li><NavLink href="/dashboard" label="Dashboard" /></li>}
-
-              {/* Modules */}
-              <li className="relative" ref={modulesRef}>
-                <button
-                  onClick={() => setOpenDesktopModules(v => !v)}
-                  aria-expanded={openDesktopModules}
-                  aria-haspopup="menu"
-                  aria-controls="desktop-modules-menu"
-                  className="px-3 py-2 rounded hover:bg-muted flex items-center gap-2"
-                >
-                  <span>Modules</span>
-                  <svg className="w-3.5 h-3.5 opacity-80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                    <path d={openDesktopModules ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
-                  </svg>
-                </button>
-
-                {openDesktopModules && (
-                  <div
-                    id="desktop-modules-menu"
-                    role="menu"
-                    className="absolute left-1/2 -translate-x-1/2 top-full mt-3 w-96 max-w-[90vw] bg-background border border-border rounded-2xl shadow-lg overflow-hidden"
-                  >
-                    <div className="grid grid-cols-12">
-                      <div className="col-span-8 p-6 sm:p-7">
-                        <div className="mb-3">
-                          <h3 className="font-slab text-lg">Skill Modules</h3>
-                          <p className="text-muted-foreground text-sm">Build the core exam skills with focused practice.</p>
-                        </div>
-                        <div className="grid sm:grid-cols-2 gap-3">
-                          {MODULE_LINKS.map((m) => (
-                            <NavLink
-                              key={m.href}
-                              href={m.href}
-                              className="group rounded-lg border border-transparent hover:border-border p-4 flex items-start gap-3 hover:bg-muted"
-                              onClick={() => setOpenDesktopModules(false)}
-                              role="menuitem"
-                            >
-                              <div className="mt-1">
-                                <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                                  <path d="M5 12h14M13 5l7 7-7 7" />
-                                </svg>
-                              </div>
-                              <div>
-                                <div className="font-medium">{m.label}</div>
-                                {m.desc && <div className="text-sm text-muted-foreground">{m.desc}</div>}
-                              </div>
-                            </NavLink>
-                          ))}
-                        </div>
-                      </div>
-
-                      <div className="col-span-4 bg-muted p-6 sm:p-7 flex flex-col justify-between">
-                        <div>
-                          <div className="mb-2 font-slab text-lg">New here?</div>
-                          <p className="text-sm text-muted-foreground">Take a quick placement to get a personalized start.</p>
-                        </div>
-                        <Link
-                          href="/placement"
-                          className="mt-4 inline-flex items-center justify-center rounded-xl px-4 py-2 font-semibold text-primary-foreground bg-primary hover:opacity-90"
-                          onClick={() => setOpenDesktopModules(false)}
-                          role="menuitem"
-                        >
-                          Start placement
-                          <span className="ml-2 inline-flex">
-                            <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                              <path d="M5 12h14M13 5l7 7-7 7" />
-                            </svg>
-                          </span>
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </li>
-
-              <li><NavLink href="/learning" label="Learning" /></li>
-
-              {NAV.map((n) => (<li key={n.href}><NavLink href={n.href} label={n.label} /></li>))}
-
-              {/* Partners/Admin shortcuts based on role */}
-              {role === 'partner' || role === 'admin' ? (
-                <li><NavLink href="/partners" label="Partners" /></li>
-              ) : null}
-              {role === 'admin' ? <li><NavLink href="/admin/partners" label="Admin" /></li> : null}
-
-              {ready ? (
-                user.id ? (
-                  <li>
-                    <UserMenu
-                      userId={user.id}
-                      email={user.email}
-                      name={user.name}
-                      avatarUrl={user.avatarUrl}
-                      onSignOut={signOut}
-                      // helpful quick links inside user menu if your DS supports it:
-                      links={[
-                        { href: '/account/billing', label: 'Billing' },
-                        { href: '/account/referrals', label: 'Referrals' },
-                      ]}
-                    />
-                  </li>
-                ) : (
-                  <li>
-                    <Link
-                      href="/login"
-                      className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
-                    >
-                      Sign in
-                    </Link>
-                  </li>
-                )
-              ) : (
-                <li><div className="h-9 w-24 rounded-full bg-muted animate-pulse" /></li>
-              )}
-
-              {/* Streak + theme + notifications */}
-              <li><FireStreak value={streakState} /></li>
-              <li><NotificationBell /></li>
-              <li><IconOnlyThemeToggle /></li>
-            </ul>
-          </nav>
-
-          {/* Mobile controls */}
-          <div className="flex items-center gap-2 md:hidden">
-            <NotificationBell />
-            <IconOnlyThemeToggle />
-            <button
-              aria-label="Toggle menu"
-              aria-expanded={mobileOpen}
-              onClick={() => setMobileOpen(v => !v)}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted"
-            >
-              {mobileOpen ? (
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                  <path d="M6 6l12 12M6 18L18 6" />
-                </svg>
-              ) : (
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                  <path d="M3 6h18M3 12h18M3 18h18" />
-                </svg>
-              )}
-            </button>
-          </div>
+          <DesktopNav
+            user={user}
+            role={role}
+            ready={ready}
+            streak={streakState}
+            openModules={openDesktopModules}
+            setOpenModules={setOpenDesktopModules}
+            modulesRef={modulesRef}
+            signOut={signOut}
+          />
+          <MobileNav
+            user={user}
+            role={role}
+            ready={ready}
+            streak={streakState}
+            mobileOpen={mobileOpen}
+            setMobileOpen={setMobileOpen}
+            mobileModulesOpen={mobileModulesOpen}
+            setMobileModulesOpen={setMobileModulesOpen}
+            signOut={signOut}
+          />
         </div>
       </Container>
-
-      {/* Mobile menu overlay */}
-      <div
-        className={`fixed inset-0 z-40 bg-black/40 md:hidden transition-opacity ${mobileOpen ? '' : 'pointer-events-none opacity-0'}`}
-        onClick={() => setMobileOpen(false)}
-      />
-
-      {/* Mobile panel */}
-      {mobileOpen && (
-        <div className="relative z-50 md:hidden border-t border-border bg-background shadow-lg">
-          <Container>
-            <div className="py-3 flex items-center justify-between">
-              <FireStreak value={streakState} />
-              {ready && user.id ? (
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={signOut}
-                    className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
-                  >
-                    Sign out
-                  </button>
-                </div>
-              ) : ready ? (
-                <Link
-                  href="/login"
-                  className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
-                  onClick={() => setMobileOpen(false)}
-                >
-                  Sign in
-                </Link>
-              ) : (
-                <div className="h-9 w-24 rounded-full bg-muted animate-pulse" />
-              )}
-            </div>
-
-            <nav aria-label="Mobile Navigation" className="pb-4">
-              <ul className="flex flex-col gap-1">
-                {user.id && (
-                  <li>
-                    <NavLink
-                      href="/dashboard"
-                      className="block px-3 py-3 rounded-lg hover:bg-muted"
-                      onClick={() => setMobileOpen(false)}
-                    >
-                      Dashboard
-                    </NavLink>
-                  </li>
-                )}
-                <li>
-                  <NavLink
-                    href="/learning"
-                    className="block px-3 py-3 rounded-lg hover:bg-muted"
-                    onClick={() => setMobileOpen(false)}
-                  >
-                    Learning
-                  </NavLink>
-                </li>
-
-                {/* Modules accordion */}
-                <li>
-                  <button
-                    className="w-full flex items-center justify-between px-3 py-3 rounded-lg hover:bg-muted"
-                    onClick={() => setMobileModulesOpen(v => !v)}
-                    aria-expanded={mobileModulesOpen}
-                    aria-controls="mobile-modules-list"
-                  >
-                    <span className="font-medium">Modules</span>
-                    <svg className="w-3.5 h-3.5 opacity-80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                      <path d={mobileModulesOpen ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
-                    </svg>
-                  </button>
-                  {mobileModulesOpen && (
-                    <ul id="mobile-modules-list" className="mt-1 ml-2 rounded-lg border border-border overflow-hidden">
-                      {MODULE_LINKS.map((m) => (
-                        <li key={m.href}>
-                          <NavLink
-                            href={m.href}
-                            className="block px-4 py-3 hover:bg-muted"
-                            onClick={() => setMobileOpen(false)}
-                          >
-                            {m.label}
-                          </NavLink>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
-
-                {/* Key destinations */}
-                {NAV.map((n) => (
-                  <li key={n.href}>
-                    <NavLink
-                      href={n.href}
-                      className="block px-3 py-3 rounded-lg hover:bg-muted"
-                      onClick={() => setMobileOpen(false)}
-                    >
-                      {n.label}
-                    </NavLink>
-                  </li>
-                ))}
-
-                {/* Partner/Admin context links */}
-                {role === 'partner' || role === 'admin' ? (
-                  <li>
-                    <NavLink
-                      href="/partners"
-                      className="block px-3 py-3 rounded-lg hover:bg-muted"
-                      onClick={() => setMobileOpen(false)}
-                    >
-                      Partners
-                    </NavLink>
-                  </li>
-                ) : null}
-                {role === 'admin' ? (
-                  <li>
-                    <NavLink
-                      href="/admin/partners"
-                      className="block px-3 py-3 rounded-lg hover:bg-muted"
-                      onClick={() => setMobileOpen(false)}
-                    >
-                      Admin
-                    </NavLink>
-                  </li>
-                ) : null}
-
-                {/* Useful account links */}
-                {user.id ? (
-                  <>
-                    <li>
-                      <NavLink
-                        href="/account/billing"
-                        className="block px-3 py-3 rounded-lg hover:bg-muted"
-                        onClick={() => setMobileOpen(false)}
-                      >
-                        Billing
-                      </NavLink>
-                    </li>
-                    <li>
-                      <NavLink
-                        href="/account/referrals"
-                        className="block px-3 py-3 rounded-lg hover:bg-muted"
-                        onClick={() => setMobileOpen(false)}
-                      >
-                        Referrals
-                      </NavLink>
-                    </li>
-                  </>
-                ) : null}
-              </ul>
-            </nav>
-          </Container>
-        </div>
-      )}
     </header>
   );
 };

--- a/components/navigation/DesktopNav.tsx
+++ b/components/navigation/DesktopNav.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import Link from 'next/link';
+import { NavLink } from '@/components/design-system/NavLink';
+import { UserMenu } from '@/components/design-system/UserMenu';
+import { NotificationBell } from '@/components/design-system/NotificationBell';
+import { ModuleMenu } from './ModuleMenu';
+import { FireStreak } from './FireStreak';
+import { IconOnlyThemeToggle } from './IconOnlyThemeToggle';
+import { NAV } from './constants';
+import React from 'react';
+
+interface UserInfo {
+  id: string | null;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+interface DesktopNavProps {
+  user: UserInfo;
+  role: string | null;
+  ready: boolean;
+  streak: number;
+  openModules: boolean;
+  setOpenModules: (open: boolean) => void;
+  modulesRef: React.RefObject<HTMLLIElement>;
+  signOut: () => Promise<void>;
+}
+
+export function DesktopNav({ user, role, ready, streak, openModules, setOpenModules, modulesRef, signOut }: DesktopNavProps) {
+  return (
+    <nav className="hidden md:block" aria-label="Primary">
+      <ul className="flex items-center gap-3 relative">
+        {user.id && <li><NavLink href="/dashboard" label="Dashboard" /></li>}
+        <ModuleMenu open={openModules} setOpen={setOpenModules} modulesRef={modulesRef} />
+        <li><NavLink href="/learning" label="Learning" /></li>
+        {NAV.map((n) => (
+          <li key={n.href}><NavLink href={n.href} label={n.label} /></li>
+        ))}
+        {role === 'partner' || role === 'admin' ? (
+          <li><NavLink href="/partners" label="Partners" /></li>
+        ) : null}
+        {role === 'admin' ? <li><NavLink href="/admin/partners" label="Admin" /></li> : null}
+        {ready ? (
+          user.id ? (
+            <li>
+              <UserMenu
+                userId={user.id}
+                email={user.email}
+                name={user.name}
+                avatarUrl={user.avatarUrl}
+                onSignOut={signOut}
+                links={[
+                  { href: '/account/billing', label: 'Billing' },
+                  { href: '/account/referrals', label: 'Referrals' },
+                ]}
+              />
+            </li>
+          ) : (
+            <li>
+              <Link
+                href="/login"
+                className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
+              >
+                Sign in
+              </Link>
+            </li>
+          )
+        ) : (
+          <li><div className="h-9 w-24 rounded-full bg-muted animate-pulse" /></li>
+        )}
+        <li><FireStreak value={streak} /></li>
+        <li><NotificationBell /></li>
+        <li><IconOnlyThemeToggle /></li>
+      </ul>
+    </nav>
+  );
+}

--- a/components/navigation/FireStreak.tsx
+++ b/components/navigation/FireStreak.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export function FireStreak({ value }: { value: number }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full bg-primary/15 text-primary px-2.5 py-1 text-sm font-semibold"
+      title="Daily streak"
+    >
+      <span aria-hidden="true">🔥</span>
+      <span className="tabular-nums">{value}</span>
+    </span>
+  );
+}

--- a/components/navigation/IconOnlyThemeToggle.tsx
+++ b/components/navigation/IconOnlyThemeToggle.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+
+export function IconOnlyThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const isDark = (theme ?? resolvedTheme) === 'dark';
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted"
+    >
+      {isDark ? (
+        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
+          <path d="M6.76 4.84 5.34 3.42 3.92 4.84 5.34 6.26 6.76 4.84zM1 13h3v-2H1v2zm10 10h2v-3h-2v3zm9-10v-2h-3v2h3zm-2.76 7.16 1.42 1.42 1.42-1.42-1.42-1.42-1.42 1.42zM12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm7-1.58 1.42-1.42L19 0.58l-1.42 1.42L19 3.42zM4.84 17.24 3.42 18.66l1.42 1.42 1.42-1.42-1.42-1.42z" />
+        </svg>
+      ) : (
+        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/components/navigation/MobileNav.tsx
+++ b/components/navigation/MobileNav.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { createPortal } from 'react-dom';
+import { Container } from '@/components/design-system/Container';
+import { NavLink } from '@/components/design-system/NavLink';
+import { NotificationBell } from '@/components/design-system/NotificationBell';
+import { FireStreak } from './FireStreak';
+import { IconOnlyThemeToggle } from './IconOnlyThemeToggle';
+import { MODULE_LINKS, NAV } from './constants';
+
+interface UserInfo {
+  id: string | null;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+interface MobileNavProps {
+  user: UserInfo;
+  role: string | null;
+  ready: boolean;
+  streak: number;
+  mobileOpen: boolean;
+  setMobileOpen: (open: boolean) => void;
+  mobileModulesOpen: boolean;
+  setMobileModulesOpen: (open: boolean) => void;
+  signOut: () => Promise<void>;
+}
+
+export function MobileNav({ user, role, ready, streak, mobileOpen, setMobileOpen, mobileModulesOpen, setMobileModulesOpen, signOut }: MobileNavProps) {
+  const overlay = (
+    <div
+      className={`fixed inset-0 z-40 bg-black/40 md:hidden transition-opacity ${mobileOpen ? '' : 'pointer-events-none opacity-0'}`}
+      onClick={() => setMobileOpen(false)}
+    />
+  );
+
+  const panel = mobileOpen ? (
+    <div className="relative z-50 md:hidden border-t border-border bg-background shadow-lg">
+      <Container>
+        <div className="py-3 flex items-center justify-between">
+          <FireStreak value={streak} />
+          {ready && user.id ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={signOut}
+                className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
+              >
+                Sign out
+              </button>
+            </div>
+          ) : ready ? (
+            <Link
+              href="/login"
+              className="px-4 py-2 rounded-full bg-primary text-primary-foreground font-semibold hover:opacity-90 transition"
+              onClick={() => setMobileOpen(false)}
+            >
+              Sign in
+            </Link>
+          ) : (
+            <div className="h-9 w-24 rounded-full bg-muted animate-pulse" />
+          )}
+        </div>
+
+        <nav aria-label="Mobile Navigation" className="pb-4">
+          <ul className="flex flex-col gap-1">
+            {user.id && (
+              <li>
+                <NavLink
+                  href="/dashboard"
+                  className="block px-3 py-3 rounded-lg hover:bg-muted"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Dashboard
+                </NavLink>
+              </li>
+            )}
+            <li>
+              <NavLink
+                href="/learning"
+                className="block px-3 py-3 rounded-lg hover:bg-muted"
+                onClick={() => setMobileOpen(false)}
+              >
+                Learning
+              </NavLink>
+            </li>
+            <li>
+              <button
+                className="w-full flex items-center justify-between px-3 py-3 rounded-lg hover:bg-muted"
+                onClick={() => setMobileModulesOpen(!mobileModulesOpen)}
+                aria-expanded={mobileModulesOpen}
+                aria-controls="mobile-modules-list"
+              >
+                <span className="font-medium">Modules</span>
+                <svg className="w-3.5 h-3.5 opacity-80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <path d={mobileModulesOpen ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
+                </svg>
+              </button>
+              {mobileModulesOpen && (
+                <ul id="mobile-modules-list" className="mt-1 ml-2 rounded-lg border border-border overflow-hidden">
+                  {MODULE_LINKS.map((m) => (
+                    <li key={m.href}>
+                      <NavLink
+                        href={m.href}
+                        className="block px-4 py-3 hover:bg-muted"
+                        onClick={() => setMobileOpen(false)}
+                      >
+                        {m.label}
+                      </NavLink>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+            {NAV.map((n) => (
+              <li key={n.href}>
+                <NavLink
+                  href={n.href}
+                  className="block px-3 py-3 rounded-lg hover:bg-muted"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  {n.label}
+                </NavLink>
+              </li>
+            ))}
+            {role === 'partner' || role === 'admin' ? (
+              <li>
+                <NavLink
+                  href="/partners"
+                  className="block px-3 py-3 rounded-lg hover:bg-muted"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Partners
+                </NavLink>
+              </li>
+            ) : null}
+            {role === 'admin' ? (
+              <li>
+                <NavLink
+                  href="/admin/partners"
+                  className="block px-3 py-3 rounded-lg hover:bg-muted"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Admin
+                </NavLink>
+              </li>
+            ) : null}
+            {user.id ? (
+              <>
+                <li>
+                  <NavLink
+                    href="/account/billing"
+                    className="block px-3 py-3 rounded-lg hover:bg-muted"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    Billing
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink
+                    href="/account/referrals"
+                    className="block px-3 py-3 rounded-lg hover:bg-muted"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    Referrals
+                  </NavLink>
+                </li>
+              </>
+            ) : null}
+          </ul>
+        </nav>
+      </Container>
+    </div>
+  ) : null;
+
+  return (
+    <>
+      <div className="flex items-center gap-2 md:hidden">
+        <NotificationBell />
+        <IconOnlyThemeToggle />
+        <button
+          aria-label="Toggle menu"
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen(!mobileOpen)}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted"
+        >
+          {mobileOpen ? (
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M6 6l12 12M6 18L18 6" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M3 6h18M3 12h18M3 18h18" />
+            </svg>
+          )}
+        </button>
+      </div>
+      {typeof document !== 'undefined' ? createPortal(<>{overlay}{panel}</>, document.body) : null}
+    </>
+  );
+}

--- a/components/navigation/ModuleMenu.tsx
+++ b/components/navigation/ModuleMenu.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Link from 'next/link';
+import { NavLink } from '@/components/design-system/NavLink';
+import { MODULE_LINKS } from './constants';
+import React from 'react';
+
+interface ModuleMenuProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  modulesRef: React.RefObject<HTMLLIElement>;
+}
+
+export function ModuleMenu({ open, setOpen, modulesRef }: ModuleMenuProps) {
+  return (
+    <li className="relative" ref={modulesRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-controls="desktop-modules-menu"
+        className="px-3 py-2 rounded hover:bg-muted flex items-center gap-2"
+      >
+        <span>Modules</span>
+        <svg className="w-3.5 h-3.5 opacity-80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d={open ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          id="desktop-modules-menu"
+          role="menu"
+          className="absolute left-1/2 -translate-x-1/2 top-full mt-3 w-96 max-w-[90vw] bg-background border border-border rounded-2xl shadow-lg overflow-hidden"
+        >
+          <div className="grid grid-cols-12">
+            <div className="col-span-8 p-6 sm:p-7">
+              <div className="mb-3">
+                <h3 className="font-slab text-lg">Skill Modules</h3>
+                <p className="text-muted-foreground text-sm">Build the core exam skills with focused practice.</p>
+              </div>
+              <div className="grid sm:grid-cols-2 gap-3">
+                {MODULE_LINKS.map((m) => (
+                  <NavLink
+                    key={m.href}
+                    href={m.href}
+                    className="group rounded-lg border border-transparent hover:border-border p-4 flex items-start gap-3 hover:bg-muted"
+                    onClick={() => setOpen(false)}
+                    role="menuitem"
+                  >
+                    <div className="mt-1">
+                      <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                        <path d="M5 12h14M13 5l7 7-7 7" />
+                      </svg>
+                    </div>
+                    <div>
+                      <div className="font-medium">{m.label}</div>
+                      {m.desc && <div className="text-sm text-muted-foreground">{m.desc}</div>}
+                    </div>
+                  </NavLink>
+                ))}
+              </div>
+            </div>
+
+            <div className="col-span-4 bg-muted p-6 sm:p-7 flex flex-col justify-between">
+              <div>
+                <div className="mb-2 font-slab text-lg">New here?</div>
+                <p className="text-sm text-muted-foreground">Take a quick placement to get a personalized start.</p>
+              </div>
+              <Link
+                href="/placement"
+                className="mt-4 inline-flex items-center justify-center rounded-xl px-4 py-2 font-semibold text-primary-foreground bg-primary hover:opacity-90"
+                onClick={() => setOpen(false)}
+                role="menuitem"
+              >
+                Start placement
+                <span className="ml-2 inline-flex">
+                  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <path d="M5 12h14M13 5l7 7-7 7" />
+                  </svg>
+                </span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/components/navigation/constants.ts
+++ b/components/navigation/constants.ts
@@ -1,0 +1,13 @@
+export type ModuleLink = { label: string; href: string; desc?: string };
+
+export const MODULE_LINKS: ModuleLink[] = [
+  { label: 'Listening', href: '/listening', desc: 'Audio comprehension drills' },
+  { label: 'Reading', href: '/reading', desc: 'Short passages & skimming' },
+  { label: 'Writing', href: '/writing', desc: 'Prompts, structure & style' },
+  { label: 'Speaking', href: '/speaking', desc: 'Pronunciation & fluency' },
+];
+
+export const NAV: ReadonlyArray<{ href: string; label: string }> = [
+  { href: '/predictor', label: 'Band Predictor' },
+  { href: '/pricing', label: 'Pricing' },
+];


### PR DESCRIPTION
## Summary
- extract module and nav link constants
- implement DesktopNav, MobileNav, ModuleMenu, and supporting utilities
- refactor Header to orchestrate new navigation components

## Testing
- `npm test` *(fails: admin.from is not a function)*
- `npm run lint` *(fails: components/paywall/PaywallGate.tsx Parsing error: Unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b70a23c8321b4676373a1d45c61