### PR TITLE
Wrap layout content with Container

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from '@/components/Footer';
 import { useStreak } from '@/hooks/useStreak';
 import { Breadcrumbs, type Crumb } from '@/components/design-system/Breadcrumbs';
 import { BottomNav } from '@/components/navigation/BottomNav';
+import { Container } from '@/components/design-system/Container';
 
 export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { current } = useStreak();
@@ -21,12 +22,12 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
   return (
     <>
       <Header streak={current} />
-      <main>
+      <Container>
         {segments.length > 0 && (
-          <Breadcrumbs items={breadcrumbItems} className="p-4" />
+          <Breadcrumbs items={breadcrumbItems} className="py-4" />
         )}
-        {children}
-      </main>
+        <main>{children}</main>
+      </Container>
       <Footer />
       <BottomNav />
     </>

--- a/pages/checkout/cancel.tsx
+++ b/pages/checkout/cancel.tsx
@@ -23,7 +23,7 @@ const CancelPage: NextPage = () => {
       <Head><title>Checkout Canceled</title></Head>
       <main className="min-h-screen bg-background text-foreground">
         <Section>
-          <Container className="max-w-3xl px-4 text-center">
+          <Container className="max-w-3xl text-center">
             <h1 className="mb-2 text-3xl font-semibold">Checkout canceled</h1>
             <p className="text-muted-foreground">
               No worries — your card hasn’t been charged.

--- a/pages/checkout/success.tsx
+++ b/pages/checkout/success.tsx
@@ -23,7 +23,7 @@ const SuccessPage: NextPage = () => {
       <Head><title>Payment Successful</title></Head>
       <main className="min-h-screen bg-background text-foreground">
         <Section>
-          <Container className="max-w-3xl px-4 text-center">
+          <Container className="max-w-3xl text-center">
             <h1 className="mb-2 text-3xl font-semibold">You’re upgraded! 🎉</h1>
             <p className="text-muted-foreground">
               Your subscription is active. You can now access full IELTS modules, AI feedback, and analytics.


### PR DESCRIPTION
## Summary
- import Container into Layout and wrap main content and breadcrumbs for consistent width
- drop page-level horizontal padding in checkout success/cancel views

## Testing
- `npm run lint` *(fails: Parsing error: Unterminated string literal in components/paywall/PaywallGate.tsx)*
- `npm test` *(fails: TypeError: admin.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b6c10a0832186880a87867dbaec