### PR TITLE
localize home labels

### DIFF
--- a/lib/locale.tsx
+++ b/lib/locale.tsx
@@ -17,13 +17,20 @@ const LocaleContext = createContext<LocaleContextValue>({
 });
 
 async function loadMessages(locale: string) {
-  try {
-    const res = await fetch(`/locales/${locale}/common.json`);
-    if (!res.ok) throw new Error('Failed to load');
-    return (await res.json()) as Record<string, any>;
-  } catch {
-    return {} as Record<string, any>;
-  }
+  const fetchJson = async (path: string) => {
+    try {
+      const res = await fetch(path);
+      if (!res.ok) throw new Error('Failed to load');
+      return (await res.json()) as Record<string, any>;
+    } catch {
+      return {} as Record<string, any>;
+    }
+  };
+  const [common, home] = await Promise.all([
+    fetchJson(`/locales/${locale}/common.json`),
+    fetchJson(`/locales/${locale}/home.json`),
+  ]);
+  return { ...common, home } as Record<string, any>;
 }
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/locales/en/home.json
+++ b/locales/en/home.json
@@ -1,0 +1,23 @@
+{
+  "commandCenter": {
+    "listening": "Listening",
+    "reading": "Reading",
+    "writing": "Writing",
+    "speaking": "Speaking",
+    "progress": "Progress"
+  },
+  "retentionStrip": {
+    "challenge": {
+      "heading": "14-Day Challenge",
+      "description": "Join cohorts, finish daily tasks, climb leaderboard."
+    },
+    "certificate": {
+      "heading": "Shareable Certificate",
+      "description": "Finish a challenge to generate a branded cert."
+    },
+    "teacherPilot": {
+      "heading": "Teacher Pilot",
+      "description": "Assign tasks and track students (beta)."
+    }
+  }
+}

--- a/locales/ur/home.json
+++ b/locales/ur/home.json
@@ -1,0 +1,23 @@
+{
+  "commandCenter": {
+    "listening": "سننا",
+    "reading": "پڑھنا",
+    "writing": "لکھنا",
+    "speaking": "بولنا",
+    "progress": "پیش رفت"
+  },
+  "retentionStrip": {
+    "challenge": {
+      "heading": "14 روزہ چیلنج",
+      "description": "ساتھیوں میں شامل ہوں، روزانہ کے کام مکمل کریں، اور لیڈر بورڈ پر اوپر جائیں۔"
+    },
+    "certificate": {
+      "heading": "قابلِ اشتراک سرٹیفیکیٹ",
+      "description": "چیلنج مکمل کریں اور برانڈڈ سرٹیفیکیٹ حاصل کریں۔"
+    },
+    "teacherPilot": {
+      "heading": "اساتذہ کے لیے پائلٹ",
+      "description": "کام تفویض کریں اور طلبہ کی نگرانی کریں (بیٹا)۔"
+    }
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,11 +49,11 @@ export default function HomePage() {
       <Section id="command-center" Container className="py-12">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
           {[
-            { label: 'Listening', href: '/listening', icon: 'fa-headphones' },
-            { label: 'Reading', href: '/reading', icon: 'fa-book-open' },
-            { label: 'Writing', href: '/writing', icon: 'fa-pen-nib' },
-            { label: 'Speaking', href: '/speaking', icon: 'fa-microphone' },
-            { label: 'Progress', href: '/progress', icon: 'fa-chart-line' },
+            { label: t('home.commandCenter.listening'), href: '/listening', icon: 'fa-headphones' },
+            { label: t('home.commandCenter.reading'), href: '/reading', icon: 'fa-book-open' },
+            { label: t('home.commandCenter.writing'), href: '/writing', icon: 'fa-pen-nib' },
+            { label: t('home.commandCenter.speaking'), href: '/speaking', icon: 'fa-microphone' },
+            { label: t('home.commandCenter.progress'), href: '/progress', icon: 'fa-chart-line' },
           ].map((x) => (
             <Link
               key={x.href}
@@ -83,9 +83,24 @@ export default function HomePage() {
       <Section id="scale-retention" Container className="py-16">
         <div className="grid gap-4 md:grid-cols-3">
           {[
-            { h: '14-Day Challenge', p: 'Join cohorts, finish daily tasks, climb leaderboard.', href: '/challenge', icon: 'fa-trophy' },
-            { h: 'Shareable Certificate', p: 'Finish a challenge to generate a branded cert.', href: '/cert/sample', icon: 'fa-certificate' },
-            { h: 'Teacher Pilot', p: 'Assign tasks and track students (beta).', href: '/teacher', icon: 'fa-chalkboard-teacher' },
+            {
+              h: t('home.retentionStrip.challenge.heading'),
+              p: t('home.retentionStrip.challenge.description'),
+              href: '/challenge',
+              icon: 'fa-trophy',
+            },
+            {
+              h: t('home.retentionStrip.certificate.heading'),
+              p: t('home.retentionStrip.certificate.description'),
+              href: '/cert/sample',
+              icon: 'fa-certificate',
+            },
+            {
+              h: t('home.retentionStrip.teacherPilot.heading'),
+              p: t('home.retentionStrip.teacherPilot.description'),
+              href: '/teacher',
+              icon: 'fa-chalkboard-teacher',
+            },
           ].map((c) => (
             <Link
               key={c.href}


### PR DESCRIPTION
## Summary
- internationalize command center links and retention strip copy on home page
- add English and Urdu translations for new home strings
- load page-specific `home.json` alongside `common.json`

## Testing
- ❌ `npm test` (TypeError: admin.from is not a function)
- ❌ `npm run lint` (Parsing error: Unterminated string literal in components/paywall/PaywallGate.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b84b686e50832192aa521c35db9902