### PR TITLE
refactor: extract header state hook

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,50 +1,20 @@
 'use client';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { Container } from '@/components/design-system/Container';
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
-import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 import { DesktopNav } from '@/components/navigation/DesktopNav';
 import { MobileNav } from '@/components/navigation/MobileNav';
+import { useHeaderState } from '@/components/hooks/useHeaderState';
 
 
 export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
-  const router = useRouter();
-
   const [openDesktopModules, setOpenDesktopModules] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [mobileModulesOpen, setMobileModulesOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
 
-  const [ready, setReady] = useState(false);
-  const [role, setRole] = useState<string | null>(null);
-  const [user, setUser] = useState<{ id: string | null; email: string | null; name: string | null; avatarUrl: string | null }>({
-    id: null, email: null, name: null, avatarUrl: null,
-  });
-
-  // Streak (prop wins; otherwise fetch)
-  const [streakState, setStreakState] = useState<number>(streak ?? 0);
-  useEffect(() => { if (typeof streak === 'number') setStreakState(streak); }, [streak]);
-  const fetchStreak = useCallback(async () => {
-    if (typeof streak === 'number') return;
-    const { data: session } = await supabaseBrowser.auth.getSession();
-    const token = session?.session?.access_token;
-    if (!token) return;
-    const res = await fetch('/api/words/today', { headers: { Authorization: `Bearer ${token}` } });
-    if (res.ok) { const j = await res.json(); if (typeof j?.streakDays === 'number') setStreakState(j.streakDays); }
-  }, [streak]);
-  useEffect(() => { fetchStreak(); }, [fetchStreak]);
-  useEffect(() => {
-    const onChanged = (e: Event) => {
-      const ce = e as CustomEvent<{ value?: number }>;
-      if (typeof ce.detail?.value === 'number') setStreakState(ce.detail.value);
-      else fetchStreak();
-    };
-    window.addEventListener('streak:changed', onChanged as EventListener);
-    return () => window.removeEventListener('streak:changed', onChanged as EventListener);
-  }, [fetchStreak]);
+  const { user, role, streak: streakState, ready, signOut } = useHeaderState(streak);
 
   // Solid header when scrolled or any menu open
   useEffect(() => {
@@ -56,63 +26,6 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const solidHeader = scrolled || openDesktopModules || mobileOpen;
 
   const modulesRef = useRef<HTMLLIElement>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const computeRole = async (uid: string | null, appMeta?: any, userMeta?: any) => {
-      let r: any = appMeta?.role ?? userMeta?.role ?? null;
-      if (!r && uid) {
-        const { data: prof } = await supabaseBrowser.from('profiles').select('role').eq('id', uid).single();
-        r = prof?.role ?? null;
-      }
-      return r ? String(r).toLowerCase() : null;
-    };
-
-    const sync = async () => {
-      const { data } = await supabaseBrowser.auth.getSession();
-      const s = data.session?.user ?? null;
-      const userMeta = (s?.user_metadata ?? {}) as Record<string, unknown>;
-      if (!cancelled) {
-        setUser({
-          id: s?.id ?? null,
-          email: s?.email ?? null,
-          name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
-          avatarUrl: typeof userMeta['avatar_url'] === 'string' ? (userMeta['avatar_url'] as string) : null,
-        });
-        const r = await computeRole(s?.id ?? null, s?.app_metadata, userMeta);
-        if (!cancelled) setRole(r);
-        setReady(true);
-      }
-    };
-    sync();
-
-    const { data: sub } = supabaseBrowser.auth.onAuthStateChange(
-      async (_e: AuthChangeEvent, session: Session | null) => {
-        const s = session?.user ?? null;
-        const userMeta = (s?.user_metadata ?? {}) as Record<string, unknown>;
-        setUser({
-          id: s?.id ?? null,
-          email: s?.email ?? null,
-          name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
-          avatarUrl: typeof userMeta['avatar_url'] === 'string' ? (userMeta['avatar_url'] as string) : null,
-        });
-        const r = await computeRole(s?.id ?? null, s?.app_metadata, userMeta);
-        setRole(r);
-        if (!s) setStreakState(0);
-      }
-    );
-
-    return () => { cancelled = true; sub?.subscription?.unsubscribe(); };
-  }, []);
-
-  useEffect(() => {
-    const onAvatarChanged = (e: Event) => {
-      const ce = e as CustomEvent<{ url: string }>;
-      setUser((u) => ({ ...u, avatarUrl: ce.detail.url }));
-    };
-    window.addEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
-    return () => window.removeEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
-  }, []);
 
   useEffect(() => {
     const onClick = (e: MouseEvent) => {
@@ -148,13 +61,6 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
       document.removeEventListener('touchmove', preventTouch);
     };
   }, [mobileOpen]);
-
-  const signOut = async () => {
-    await supabaseBrowser.auth.signOut();
-    setStreakState(0);
-    router.replace('/login');
-  };
-
   return (
     <header
       className={[

--- a/components/hooks/useHeaderState.ts
+++ b/components/hooks/useHeaderState.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+
+interface UserInfo {
+  id: string | null;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+export function useHeaderState(initialStreak?: number) {
+  const router = useRouter();
+
+  const [ready, setReady] = useState(false);
+  const [role, setRole] = useState<string | null>(null);
+  const [user, setUser] = useState<UserInfo>({ id: null, email: null, name: null, avatarUrl: null });
+
+  // Streak (prop wins; otherwise fetch)
+  const [streak, setStreak] = useState<number>(initialStreak ?? 0);
+  useEffect(() => {
+    if (typeof initialStreak === 'number') setStreak(initialStreak);
+  }, [initialStreak]);
+  const fetchStreak = useCallback(async () => {
+    if (typeof initialStreak === 'number') return;
+    const { data: session } = await supabaseBrowser.auth.getSession();
+    const token = session?.session?.access_token;
+    if (!token) return;
+    const res = await fetch('/api/words/today', { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) {
+      const j = await res.json();
+      if (typeof j?.streakDays === 'number') setStreak(j.streakDays);
+    }
+  }, [initialStreak]);
+  useEffect(() => {
+    fetchStreak();
+  }, [fetchStreak]);
+  useEffect(() => {
+    const onChanged = (e: Event) => {
+      const ce = e as CustomEvent<{ value?: number }>;
+      if (typeof ce.detail?.value === 'number') setStreak(ce.detail.value);
+      else fetchStreak();
+    };
+    window.addEventListener('streak:changed', onChanged as EventListener);
+    return () => window.removeEventListener('streak:changed', onChanged as EventListener);
+  }, [fetchStreak]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const computeRole = async (uid: string | null, appMeta?: any, userMeta?: any) => {
+      let r: any = appMeta?.role ?? userMeta?.role ?? null;
+      if (!r && uid) {
+        const { data: prof } = await supabaseBrowser.from('profiles').select('role').eq('id', uid).single();
+        r = prof?.role ?? null;
+      }
+      return r ? String(r).toLowerCase() : null;
+    };
+
+    const sync = async () => {
+      const { data } = await supabaseBrowser.auth.getSession();
+      const s = data.session?.user ?? null;
+      const userMeta = (s?.user_metadata ?? {}) as Record<string, unknown>;
+      if (!cancelled) {
+        setUser({
+          id: s?.id ?? null,
+          email: s?.email ?? null,
+          name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
+          avatarUrl: typeof userMeta['avatar_url'] === 'string' ? (userMeta['avatar_url'] as string) : null,
+        });
+        const r = await computeRole(s?.id ?? null, s?.app_metadata, userMeta);
+        if (!cancelled) setRole(r);
+        setReady(true);
+      }
+    };
+    sync();
+
+    const { data: sub } = supabaseBrowser.auth.onAuthStateChange(
+      async (_e: AuthChangeEvent, session: Session | null) => {
+        const s = session?.user ?? null;
+        const userMeta = (s?.user_metadata ?? {}) as Record<string, unknown>;
+        setUser({
+          id: s?.id ?? null,
+          email: s?.email ?? null,
+          name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
+          avatarUrl: typeof userMeta['avatar_url'] === 'string' ? (userMeta['avatar_url'] as string) : null,
+        });
+        const r = await computeRole(s?.id ?? null, s?.app_metadata, userMeta);
+        setRole(r);
+        if (!s) setStreak(0);
+      }
+    );
+
+    return () => {
+      cancelled = true;
+      sub?.subscription?.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    const onAvatarChanged = (e: Event) => {
+      const ce = e as CustomEvent<{ url: string }>;
+      setUser((u) => ({ ...u, avatarUrl: ce.detail.url }));
+    };
+    window.addEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
+    return () => window.removeEventListener('profile:avatar-changed', onAvatarChanged as EventListener);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await supabaseBrowser.auth.signOut();
+    setStreak(0);
+    router.replace('/login');
+  }, [router]);
+
+  return { user, role, streak, ready, signOut };
+}
+


### PR DESCRIPTION
## Summary
- encapsulate header auth, role, and streak logic into `useHeaderState` hook
- simplify `Header` by consuming new hook and passing values to navigation components

## Testing
- `npm test` *(fails: AssertionError [ERR_ASSERTION])* 
- `npm run lint` *(fails: Parsing error: Unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c9430ef08321ab1d206834826efe