### PR TITLE
refactor: extract home page data and tiles

### DIFF
--- a/components/sections/CommandCenterTile.tsx
+++ b/components/sections/CommandCenterTile.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+export interface CommandCenterTileProps {
+  label: string;
+  href: string;
+  icon: string;
+  className?: string;
+}
+
+export const CommandCenterTile: React.FC<CommandCenterTileProps> = ({ label, href, icon, className }) => (
+  <Link
+    href={href}
+    className={cn(
+      'rounded-ds-xl border border-border px-4 py-3 text-sm font-medium hover:bg-electricBlue/5 transition flex items-center justify-between',
+      className,
+    )}
+  >
+    <span>{label}</span>
+    <i className={`fas ${icon} text-grayish`} aria-hidden="true" />
+  </Link>
+);
+
+export default CommandCenterTile;

--- a/components/sections/RetentionCard.tsx
+++ b/components/sections/RetentionCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+export interface RetentionCardProps {
+  heading: string;
+  description: string;
+  href: string;
+  icon: string;
+  className?: string;
+}
+
+export const RetentionCard: React.FC<RetentionCardProps> = ({
+  heading,
+  description,
+  href,
+  icon,
+  className,
+}) => (
+  <Link
+    href={href}
+    className={cn(
+      'rounded-ds-2xl border border-purpleVibe/20 p-6 hover:border-purpleVibe/40 hover:-translate-y-1 transition block',
+      className,
+    )}
+  >
+    <div className="flex items-start gap-4">
+      <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
+        <i className={`fas ${icon}`} aria-hidden="true" />
+      </div>
+      <div>
+        <h3 className="text-h3 mb-1">{heading}</h3>
+        <p className="text-grayish">{description}</p>
+      </div>
+    </div>
+  </Link>
+);
+
+export default RetentionCard;

--- a/data/home.ts
+++ b/data/home.ts
@@ -1,0 +1,28 @@
+export const commandCenter = [
+  { label: 'home.commandCenter.listening', href: '/listening', icon: 'fa-headphones' },
+  { label: 'home.commandCenter.reading', href: '/reading', icon: 'fa-book-open' },
+  { label: 'home.commandCenter.writing', href: '/writing', icon: 'fa-pen-nib' },
+  { label: 'home.commandCenter.speaking', href: '/speaking', icon: 'fa-microphone' },
+  { label: 'home.commandCenter.progress', href: '/progress', icon: 'fa-chart-line' },
+];
+
+export const scaleRetention = [
+  {
+    h: 'home.retentionStrip.challenge.heading',
+    p: 'home.retentionStrip.challenge.description',
+    href: '/challenge',
+    icon: 'fa-trophy',
+  },
+  {
+    h: 'home.retentionStrip.certificate.heading',
+    p: 'home.retentionStrip.certificate.description',
+    href: '/cert/sample',
+    icon: 'fa-certificate',
+  },
+  {
+    h: 'home.retentionStrip.teacherPilot.heading',
+    p: 'home.retentionStrip.teacherPilot.description',
+    href: '/teacher',
+    icon: 'fa-chalkboard-teacher',
+  },
+];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,9 +2,11 @@
 import React, { useEffect } from 'react';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
-import Link from 'next/link';
 import { useLocale } from '@/lib/locale';
 import { Section } from '@/components/design-system/Section';
+import { commandCenter, scaleRetention } from '@/data/home';
+import { CommandCenterTile } from '@/components/sections/CommandCenterTile';
+import { RetentionCard } from '@/components/sections/RetentionCard';
 
 // Hero is heavy → hydrate client only
 const Hero = dynamic(
@@ -48,24 +50,13 @@ export default function HomePage() {
       {/* Phase-3: Quick Command Center (go anywhere, from anywhere) */}
       <Section id="command-center" Container className="py-12">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          {[
-            { label: t('home.commandCenter.listening'), href: '/listening', icon: 'fa-headphones' },
-            { label: t('home.commandCenter.reading'), href: '/reading', icon: 'fa-book-open' },
-            { label: t('home.commandCenter.writing'), href: '/writing', icon: 'fa-pen-nib' },
-            { label: t('home.commandCenter.speaking'), href: '/speaking', icon: 'fa-microphone' },
-            { label: t('home.commandCenter.progress'), href: '/progress', icon: 'fa-chart-line' },
-          ].map((x) => (
-            <Link
+          {commandCenter.map((x) => (
+            <CommandCenterTile
               key={x.href}
+              label={t(x.label)}
               href={x.href}
-              className="
-                rounded-ds-xl border border-border px-4 py-3 text-sm font-medium
-                hover:bg-electricBlue/5 transition flex items-center justify-between
-              "
-            >
-              <span>{x.label}</span>
-              <i className={`fas ${x.icon} text-grayish`} aria-hidden="true" />
-            </Link>
+              icon={x.icon}
+            />
           ))}
         </div>
       </Section>
@@ -82,41 +73,14 @@ export default function HomePage() {
       {/* Phase-3 retention strip */}
       <Section id="scale-retention" Container className="py-16">
         <div className="grid gap-4 md:grid-cols-3">
-          {[
-            {
-              h: t('home.retentionStrip.challenge.heading'),
-              p: t('home.retentionStrip.challenge.description'),
-              href: '/challenge',
-              icon: 'fa-trophy',
-            },
-            {
-              h: t('home.retentionStrip.certificate.heading'),
-              p: t('home.retentionStrip.certificate.description'),
-              href: '/cert/sample',
-              icon: 'fa-certificate',
-            },
-            {
-              h: t('home.retentionStrip.teacherPilot.heading'),
-              p: t('home.retentionStrip.teacherPilot.description'),
-              href: '/teacher',
-              icon: 'fa-chalkboard-teacher',
-            },
-          ].map((c) => (
-            <Link
+          {scaleRetention.map((c) => (
+            <RetentionCard
               key={c.href}
+              heading={t(c.h)}
+              description={t(c.p)}
               href={c.href}
-              className="rounded-ds-2xl border border-purpleVibe/20 p-6 hover:border-purpleVibe/40 hover:-translate-y-1 transition block"
-            >
-              <div className="flex items-start gap-4">
-                <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
-                  <i className={`fas ${c.icon}`} aria-hidden="true" />
-                </div>
-                <div>
-                  <h3 className="text-h3 mb-1">{c.h}</h3>
-                  <p className="text-grayish">{c.p}</p>
-                </div>
-              </div>
-            </Link>
+              icon={c.icon}
+            />
           ))}
         </div>
       </Section>


### PR DESCRIPTION
## Summary
- move home page arrays to data/home
- add CommandCenterTile and RetentionCard components
- render home page tiles via imported data

## Testing
- `npm test` (fails: AssertionError in login-event.test)
- `npm run lint` (fails: various lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b8ccf78a4c8321936969625615dff2