### PR TITLE
refactor footer links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,18 +2,15 @@ import React from 'react';
 import { Container } from '@/components/design-system/Container';
 import { NavLink } from '@/components/design-system/NavLink';
 import { SocialIconLink } from '@/components/design-system/SocialIconLink';
+import { MailIcon, PhoneIcon, MapPinIcon, ClockIcon } from '@/components/design-system/icons';
 import {
-  FacebookIcon,
-  TwitterIcon,
-  InstagramIcon,
-  LinkedinIcon,
-  YoutubeIcon,
-  MailIcon,
-  PhoneIcon,
-  MapPinIcon,
-  ClockIcon,
-} from '@/components/design-system/icons';
-import { resources, quickLinks, contactInfo } from '@/data/footerLinks';
+  resources,
+  quickLinks,
+  contactInfo,
+  socialLinks,
+  brandInfo,
+} from '@/data/footerLinks';
+import { FooterSection } from './FooterSection';
 import { useLocale } from '@/lib/locale';
 
 export const Footer: React.FC = () => {
@@ -25,73 +22,54 @@ export const Footer: React.FC = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-10 mb-10">
           {/* Brand + Socials */}
           <div>
-            <h3 className="text-xl font-semibold mb-4">GramorX</h3>
-            <p className="text-muted-foreground">
-              The most advanced IELTS preparation platform powered by AI and expert teaching.
-            </p>
+            <h3 className="text-xl font-semibold mb-4">{brandInfo.name}</h3>
+            <p className="text-muted-foreground">{t(brandInfo.description)}</p>
             <div className="flex gap-3 mt-4">
-              <SocialIconLink href="https://facebook.com" icon={<FacebookIcon className="h-5 w-5" />} label="Facebook" />
-              <SocialIconLink href="https://twitter.com" icon={<TwitterIcon className="h-5 w-5" />} label="Twitter / X" />
-              <SocialIconLink href="https://instagram.com" icon={<InstagramIcon className="h-5 w-5" />} label="Instagram" />
-              <SocialIconLink href="https://linkedin.com" icon={<LinkedinIcon className="h-5 w-5" />} label="LinkedIn" />
-              <SocialIconLink href="https://youtube.com" icon={<YoutubeIcon className="h-5 w-5" />} label="YouTube" />
+              {socialLinks.map(({ href, label, icon: Icon }) => (
+                <SocialIconLink key={label} href={href} icon={<Icon className="h-5 w-5" />} label={label} />
+              ))}
             </div>
           </div>
 
           {/* Resources */}
-          <div>
-            <h3 className="text-xl font-semibold mb-4 relative after:absolute after:-bottom-2 after:left-0 after:w-12 after:h-[3px] after:bg-primary">
-              IELTS Resources
-            </h3>
-            <ul className="space-y-2">
-              {resources.map((x) => (
-                <li key={x.label} className="text-muted-foreground">
-                  <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
-                </li>
-              ))}
-            </ul>
-          </div>
+          <FooterSection title="IELTS Resources">
+            {resources.map((x) => (
+              <li key={x.label} className="text-muted-foreground">
+                <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
+              </li>
+            ))}
+          </FooterSection>
 
           {/* Quick links */}
-          <div>
-            <h3 className="text-xl font-semibold mb-4 relative after:absolute after:-bottom-2 after:left-0 after:w-12 after:h-[3px] after:bg-primary">
-              Quick Links
-            </h3>
-            <ul className="space-y-2">
-              {quickLinks.map((x) => (
-                <li key={x.label} className="text-muted-foreground">
-                  <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
-                </li>
-              ))}
-            </ul>
-          </div>
+          <FooterSection title="Quick Links">
+            {quickLinks.map((x) => (
+              <li key={x.label} className="text-muted-foreground">
+                <NavLink href={x.href} label={t(x.label)} className="!px-0 !py-1" />
+              </li>
+            ))}
+          </FooterSection>
 
           {/* Contact */}
-          <div>
-            <h3 className="text-xl font-semibold mb-4 relative after:absolute after:-bottom-2 after:left-0 after:w-12 after:h-[3px] after:bg-primary">
-              Contact Us
-            </h3>
-            <ul className="space-y-3 text-muted-foreground">
-              <li>
-                <MailIcon className="mr-2 inline h-4 w-4" />
-                <a href={`mailto:${t(contactInfo.email)}`} className="hover:underline">
-                  {t(contactInfo.email)}
-                </a>
-              </li>
-              <li>
-                <PhoneIcon className="mr-2 inline h-4 w-4" />
-                <a href={`tel:${t(contactInfo.phone)}`} className="hover:underline">
-                  {t(contactInfo.phone)}
-                </a>
-              </li>
-              <li>
-                <MapPinIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.location)}
-              </li>
-              <li>
-                <ClockIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.support)}
-              </li>
-            </ul>
-          </div>
+          <FooterSection title="Contact Us" listClassName="space-y-3 text-muted-foreground">
+            <li>
+              <MailIcon className="mr-2 inline h-4 w-4" />
+              <a href={`mailto:${t(contactInfo.email)}`} className="hover:underline">
+                {t(contactInfo.email)}
+              </a>
+            </li>
+            <li>
+              <PhoneIcon className="mr-2 inline h-4 w-4" />
+              <a href={`tel:${t(contactInfo.phone)}`} className="hover:underline">
+                {t(contactInfo.phone)}
+              </a>
+            </li>
+            <li>
+              <MapPinIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.location)}
+            </li>
+            <li>
+              <ClockIcon className="mr-2 inline h-4 w-4" /> {t(contactInfo.support)}
+            </li>
+          </FooterSection>
         </div>
 
         <div className="text-center pt-8 border-t border-border text-sm text-muted-foreground">

--- a/components/FooterSection.tsx
+++ b/components/FooterSection.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const FooterSection: React.FC<{ title: string; children: React.ReactNode; listClassName?: string }> = ({ title, children, listClassName = 'space-y-2' }) => (
+  <div>
+    <h3 className="text-xl font-semibold mb-4 relative after:absolute after:-bottom-2 after:left-0 after:w-12 after:h-[3px] after:bg-primary">
+      {title}
+    </h3>
+    <ul className={listClassName}>{children}</ul>
+  </div>
+);
+

--- a/data/footerLinks.ts
+++ b/data/footerLinks.ts
@@ -1,3 +1,13 @@
+import type { ComponentType } from 'react';
+import type { IconProps } from '@/components/design-system/icons';
+import {
+  FacebookIcon,
+  TwitterIcon,
+  InstagramIcon,
+  LinkedinIcon,
+  YoutubeIcon,
+} from '@/components/design-system/icons';
+
 export type FooterLink = {
   href: string;
   label: string; // translation key
@@ -26,4 +36,28 @@ export const contactInfo = {
   location: 'footer.contact.location',
   support: 'footer.contact.supportHours',
 } as const;
+
+export type SocialLink = {
+  href: string;
+  label: string;
+  icon: ComponentType<IconProps>;
+};
+
+export const socialLinks: SocialLink[] = [
+  { href: 'https://facebook.com', label: 'Facebook', icon: FacebookIcon },
+  { href: 'https://twitter.com', label: 'Twitter / X', icon: TwitterIcon },
+  { href: 'https://instagram.com', label: 'Instagram', icon: InstagramIcon },
+  { href: 'https://linkedin.com', label: 'LinkedIn', icon: LinkedinIcon },
+  { href: 'https://youtube.com', label: 'YouTube', icon: YoutubeIcon },
+];
+
+export type BrandInfo = {
+  name: string;
+  description: string; // translation key
+};
+
+export const brandInfo: BrandInfo = {
+  name: 'GramorX',
+  description: 'footer.brand.description',
+};
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -9,6 +9,9 @@
   "Preview (Urdu)": "Preview (Urdu)",
   "Current locale": "Current locale",
   "footer": {
+    "brand": {
+      "description": "The most advanced IELTS preparation platform powered by AI and expert teaching."
+    },
     "resources": {
       "bandScorePredictor": "Band Score Predictor",
       "listeningPractice": "Listening Practice",

--- a/locales/ur/common.json
+++ b/locales/ur/common.json
@@ -9,6 +9,9 @@
   "Preview (Urdu)": "پیش منظر (اردو)",
   "Current locale": "موجودہ زبان",
   "footer": {
+    "brand": {
+      "description": "AI اور ماہر تدریس سے چلنے والا جدید ترین IELTS تیاری پلیٹ فارم۔"
+    },
     "resources": {
       "bandScorePredictor": "بینڈ اسکور پیش گو",
       "listeningPractice": "سننے کی مشق",


### PR DESCRIPTION
## Summary
- centralize footer brand and social metadata in data/footerLinks
- render footer sections via reusable FooterSection component
- add translations for brand description

## Testing
- `npm run lint` *(fails: 'EmptyState' is not defined and other lint errors)*
- `npm test` *(fails: AssertionError in login-event.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ccf5cf208321b35b8c3237b21438