### PR TITLE
feat: add grid layout primitives

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/design-system/icons';
 import { resources, quickLinks, contactInfo } from '@/data/footerLinks';
 import { useLocale } from '@/lib/locale';
+import { FooterGrid } from '@/components/design-system/FooterGrid';
 
 export const Footer: React.FC = () => {
   const { t } = useLocale();
@@ -22,7 +23,7 @@ export const Footer: React.FC = () => {
     <footer className="py-24 border-t border-border">
       <Container>
         {/* 1 col on mobile -> 2 on small -> 4 on md */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-10 mb-10">
+        <FooterGrid className="gap-10 mb-10">
           {/* Brand + Socials */}
           <div>
             <h3 className="text-xl font-semibold mb-4">GramorX</h3>
@@ -92,7 +93,7 @@ export const Footer: React.FC = () => {
               </li>
             </ul>
           </div>
-        </div>
+        </FooterGrid>
 
         <div className="text-center pt-8 border-t border-border text-sm text-muted-foreground">
           &copy; {new Date().getFullYear()} GramorX. All rights reserved.

--- a/components/design-system/FooterGrid.tsx
+++ b/components/design-system/FooterGrid.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export type FooterGridProps = React.HTMLAttributes<HTMLDivElement> & {
+  children?: React.ReactNode;
+};
+
+export const FooterGrid: React.FC<FooterGridProps> = ({
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = ['grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4', className]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+export default FooterGrid;

--- a/components/design-system/TileGrid.tsx
+++ b/components/design-system/TileGrid.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export type TileGridProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** Tailwind gap utility, e.g., "gap-4" */
+  gap?: string;
+  /** Tailwind grid column utilities, e.g., "sm:grid-cols-2 lg:grid-cols-5" */
+  cols?: string;
+  children?: React.ReactNode;
+};
+
+export const TileGrid: React.FC<TileGridProps> = ({
+  gap = 'gap-4',
+  cols = '',
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = ['grid', gap, cols, className].filter(Boolean).join(' ');
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+export default TileGrid;

--- a/components/design-system/index.ts
+++ b/components/design-system/index.ts
@@ -3,3 +3,5 @@ export { Select } from './Select';
 export { Textarea } from './Textarea';
 export { SeasonToggle } from './SeasonToggle';
 export * from './icons';
+export { TileGrid } from './TileGrid';
+export { FooterGrid } from './FooterGrid';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ import { CertificationBadges } from '@/components/sections/CertificationBadges';
 import { Testimonials } from '@/components/sections/Testimonials';
 import { Pricing } from '@/components/sections/Pricing';
 import Waitlist from '@/components/sections/Waitlist';
+import { TileGrid } from '@/components/design-system/TileGrid';
 
 export default function HomePage() {
   const { t } = useLocale();
@@ -47,7 +48,7 @@ export default function HomePage() {
 
       {/* Phase-3: Quick Command Center (go anywhere, from anywhere) */}
       <Section id="command-center" Container className="py-12">
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <TileGrid gap="gap-3" cols="sm:grid-cols-2 lg:grid-cols-5">
           {[
             { label: t('home.commandCenter.listening'), href: '/listening', icon: 'fa-headphones' },
             { label: t('home.commandCenter.reading'), href: '/reading', icon: 'fa-book-open' },
@@ -67,7 +68,7 @@ export default function HomePage() {
               <i className={`fas ${x.icon} text-grayish`} aria-hidden="true" />
             </Link>
           ))}
-        </div>
+        </TileGrid>
       </Section>
 
       {/* Partners */}
@@ -81,7 +82,7 @@ export default function HomePage() {
 
       {/* Phase-3 retention strip */}
       <Section id="scale-retention" Container className="py-16">
-        <div className="grid gap-4 md:grid-cols-3">
+        <TileGrid cols="md:grid-cols-3">
           {[
             {
               h: t('home.retentionStrip.challenge.heading'),
@@ -111,14 +112,14 @@ export default function HomePage() {
                 <div className="w-12 h-12 rounded-full grid place-items-center text-white bg-gradient-to-br from-purpleVibe to-electricBlue">
                   <i className={`fas ${c.icon}`} aria-hidden="true" />
                 </div>
-                <div>
+              <div>
                   <h3 className="text-h3 mb-1">{c.h}</h3>
                   <p className="text-grayish">{c.p}</p>
                 </div>
               </div>
             </Link>
           ))}
-        </div>
+        </TileGrid>
       </Section>
 
       {/* Social proof */}


### PR DESCRIPTION
## Summary
- add TileGrid for configurable tile layouts
- add FooterGrid for standard footer columns
- refactor homepage and footer to use grid primitives

## Testing
- `npm test` *(fails: Expected values to be strictly equal: actual undefined expected true)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ccf5f1dc8321b2373e2dd5a3e581