### PR TITLE
Disable phone OTP login with Coming Soon badge

### DIFF
--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -5,6 +5,7 @@ import AuthLayout from '@/components/layouts/AuthLayout';
 import AuthSidePanel from '@/components/layouts/AuthSidePanel';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
+import { Badge } from '@/components/design-system/Badge';
 import {
   AppleIcon,
   GoogleIcon,
@@ -220,16 +221,20 @@ export default function LoginOptions() {
               </Link>
             </Button>
 
-            <Button asChild variant="secondary" className="rounded-ds-xl" fullWidth>
-              <Link
-                href={`/login/phone${selectedRole ? `?role=${selectedRole}` : ''}`}
-                aria-label="Sign in with Phone OTP"
-              >
-                <span className="inline-flex items-center gap-3">
-                  <SmsIcon className="h-5 w-5" />
-                  Phone (OTP)
-                </span>
-              </Link>
+            <Button
+              variant="secondary"
+              className="rounded-ds-xl"
+              fullWidth
+              disabled
+              aria-disabled="true"
+            >
+              <span className="inline-flex items-center gap-3">
+                <SmsIcon className="h-5 w-5" />
+                Phone (OTP)
+                <Badge variant="info" size="sm">
+                  Coming Soon
+                </Badge>
+              </span>
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary
- disable Phone OTP login button and mark feature as Coming Soon

## Testing
- `npm test` *(fails: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d62bf5208321b51a704f8f68178c